### PR TITLE
Makefile changes: Remove objcopy hack and allow building with WSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ ifneq ($(findstring MSYS,$(shell uname)),)
   WINDOWS := 1
 endif
 
+WSLENV ?= ok
+ifndef WSLENV
+	WINDOWS := 1
+endif
+
 #-------------------------------------------------------------------------------
 # Files
 #-------------------------------------------------------------------------------
@@ -37,7 +42,7 @@ O_FILES := $(INIT_O_FILES) $(EXTAB_O_FILES) $(EXTABINDEX_O_FILES) $(TEXT_O_FILES
 # Tools
 #-------------------------------------------------------------------------------
 
-MWCC_VERSION := 1.2.5
+MWCC_VERSION := 3.0
 
 # Programs
 ifeq ($(WINDOWS),1)
@@ -104,7 +109,7 @@ tools:
 $(ELF): $(O_FILES) $(LDSCRIPT)
 	$(LD) $(LDFLAGS) -o $@ -lcf $(LDSCRIPT) $(O_FILES)
 # The Metrowerks linker doesn't generate physical addresses in the ELF program headers. This fixes it somehow.
-	$(OBJCOPY) $@ $@
+#	$(OBJCOPY) $@ $@
 
 $(BUILD_DIR)/%.o: %.s
 	$(AS) $(ASFLAGS) -o $@ $<

--- a/tools/elf2dol.c
+++ b/tools/elf2dol.c
@@ -234,7 +234,7 @@ void read_elf_segments(DOL_map *map, const char *elf, uint32_t sdata_pdhr, uint3
 	for(i=0; i<phnum; i++) {
 		if(swap32(phdrs[i].p_type) == PT_LOAD) {
 			uint32_t offset = swap32(phdrs[i].p_offset);
-			uint32_t paddr = swap32(phdrs[i].p_paddr);
+			uint32_t paddr = swap32(phdrs[i].p_vaddr);
 			uint32_t filesz = swap32(phdrs[i].p_filesz);
 			uint32_t memsz = swap32(phdrs[i].p_memsz);
 			uint32_t flags = swap32(phdrs[i].p_flags);


### PR DESCRIPTION
 - Identifies WSL as windows since exe just works™️ on WSL
 - Removes the objcopy hack when building the elf after a change to elf2dol that makes it unnecessary
 - Changes the mwcc version to 3.0 to avoid the linker error occurring on linker versions below 2.7