### PR TITLE
JKRHeap functions

### DIFF
--- a/asm/JKernel/JKRHeap.s
+++ b/asm/JKernel/JKRHeap.s
@@ -1,7 +1,30 @@
 .include "macros.inc"
 
-.section .text, "ax" # 802ce138
+.section .text, "ax" # 802CED84
 
+.global JKRHeap_state_register
+JKRHeap_state_register:
+/* 802CED84 002CBCC4  4E 80 00 20 */	blr 
 
-.extern "C" becomeCurrentHeap__7JKRHeapFv
-.extern "C" __nw__FUl
+.global JKRHeap_state_compare
+JKRHeap_state_compare:
+/* 802CED88 002CBCC8  80 64 00 04 */	lwz r3, 4(r4)
+/* 802CED8C 002CBCCC  80 05 00 04 */	lwz r0, 4(r5)
+/* 802CED90 002CBCD0  7C 03 00 50 */	subf r0, r3, r0
+/* 802CED94 002CBCD4  7C 00 00 34 */	cntlzw r0, r0
+/* 802CED98 002CBCD8  54 03 D9 7E */	srwi r3, r0, 5
+/* 802CED9C 002CBCDC  4E 80 00 20 */	blr 
+
+.global JKRHeap_state_dump
+JKRHeap_state_dump:
+/* 802CEDA0 002CBCE0  4E 80 00 20 */	blr 
+
+.global JKRHeap_do_changeGroupID
+JKRHeap_do_changeGroupID:
+/* 802CEDA4 002CBCE4  38 60 00 00 */	li r3, 0
+/* 802CEDA8 002CBCE8  4E 80 00 20 */	blr 
+
+.global JKRHeap_do_getCurrentGroupId
+JKRHeap_do_getCurrentGroupId:
+/* 802CEDAC 002CBCEC  38 60 00 00 */	li r3, 0
+/* 802CEDB0 002CBCF0  4E 80 00 20 */	blr 

--- a/include/JSystem/JKernel/JKRDisposer/JKRDisposer.h
+++ b/include/JSystem/JKernel/JKRDisposer/JKRDisposer.h
@@ -3,6 +3,7 @@
 
 #include "dolphin/types.h"
 #include "JSystem/JSupport/JSUList/JSUList.h"
+#include "JSystem/JKernel/JKRDisposer/JKRDisposer_vtable.h"
 
 class JKRHeap;
 class JKRDisposer {
@@ -11,7 +12,7 @@ class JKRDisposer {
     ~JKRDisposer();
 
   public:
-    void** __vt;
+    _VTABLE_JKRDisposer* __vt;
     JKRHeap* heap;
     JSUPtrLink ptr_link;
 };

--- a/include/JSystem/JKernel/JKRDisposer/JKRDisposer_vtable.h
+++ b/include/JSystem/JKernel/JKRDisposer/JKRDisposer_vtable.h
@@ -1,0 +1,14 @@
+#ifndef __JKRDISPOSER_VTABLE_H__
+#define __JKRDISPOSER_VTABLE_H__
+
+#include "dolphin/types.h"
+
+class JKRDisposer;
+struct _VTABLE_JKRDisposer {
+    void (*func0)(JKRDisposer*);
+    void (*_ct)(JKRDisposer*);
+    void (*_dt)(JKRDisposer*, int);
+    void (*func4)(JKRDisposer*);
+};
+
+#endif

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap.h
@@ -3,14 +3,14 @@
 #include "JSystem/JKernel/JKRDisposer/JKRDisposer.h"
 
 typedef void (*JKRErrorHandler)(void*, unsigned long, int);
-class JKRHeap : JKRDisposer {
+class JKRHeap {
   public:
     JKRHeap(void*, u32, JKRHeap*, bool);
     ~JKRHeap();
 
     static bool initArena(char**, u32*, int);
-    void becomeSystemHeap();
-    void becomeCurrentHeap();
+    JKRHeap* becomeSystemHeap();
+    JKRHeap* becomeCurrentHeap();
     void destroy();
 
     static void* alloc(u32 size, int alignment, JKRHeap* heap);
@@ -53,6 +53,11 @@ class JKRHeap : JKRDisposer {
     bool isSubHeap(JKRHeap* heap) const;
 
   public:
+      union {
+        JKRDisposer __base;
+        void** __vt;
+    };
+
     u8 mutex[24];
     u32 begin;
     u32 end;
@@ -64,8 +69,9 @@ class JKRHeap : JKRDisposer {
     JSUPtrList child_list;
     JSUPtrLink heap_link;
     JSUPtrList disposable_list;
-    bool error_handler;
+    bool error_flag;
     u8 field_0x69;
+    //u8 field_0x70[4];
 };
 
 void* operator new(u32 size);

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap.h
@@ -2,6 +2,34 @@
 #include "dolphin/types.h"
 #include "JSystem/JKernel/JKRDisposer/JKRDisposer.h"
 
+
+struct _VTABLE_JKRHeap {
+    void (*func0)(JKRHeap*);
+    void (*_ct)(JKRHeap*);
+    void (*_dt)(JKRHeap*);
+    void (*callAllDisposer)(JKRHeap*);
+    void (*func4)(JKRHeap*);
+    void (*func5)(JKRHeap*);
+    void (*dump_sort)(JKRHeap*);
+    void (*func7)(JKRHeap*);
+    void (*do_destroy)(JKRHeap*);
+    void (*do_alloc)(JKRHeap*,u32 size, int alignment);
+    void (*do_free)(JKRHeap*,void*ptr);
+    void (*do_freeAll)(JKRHeap*);
+    void (*do_freeTail)(JKRHeap*);
+    void (*func13)(JKRHeap*);
+    void (*func14)(JKRHeap*);
+    void (*func15)(JKRHeap*);
+    void (*func16)(JKRHeap*);
+    void (*func17)(JKRHeap*);
+    void (*func18)(JKRHeap*);
+    void (*do_changeGroup)(JKRHeap*);
+    void (*do_getCurrent)(JKRHeap*);
+    void (*state_register)(JKRHeap*);
+    void (*state_compare)(JKRHeap*);
+    void (*state_dump)(JKRHeap*);
+};
+
 typedef void (*JKRErrorHandler)(void*, unsigned long, int);
 class JKRHeap {
   public:
@@ -55,7 +83,7 @@ class JKRHeap {
   public:
       union {
         JKRDisposer __base;
-        void** __vt;
+        _VTABLE_JKRHeap* __vt;
     };
 
     u8 mutex[24];
@@ -71,7 +99,7 @@ class JKRHeap {
     JSUPtrList disposable_list;
     bool error_flag;
     u8 field_0x69;
-    //u8 field_0x70[4];
+    u8 field_0x6a[4];
 };
 
 void* operator new(u32 size);

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap.h
@@ -1,34 +1,10 @@
+#ifndef __JKRHEAP_H__
+#define __JKRHEAP_H__
 
 #include "dolphin/types.h"
 #include "JSystem/JKernel/JKRDisposer/JKRDisposer.h"
 
-
-struct _VTABLE_JKRHeap {
-    void (*func0)(JKRHeap*);
-    void (*_ct)(JKRHeap*);
-    void (*_dt)(JKRHeap*);
-    void (*callAllDisposer)(JKRHeap*);
-    void (*func4)(JKRHeap*);
-    void (*func5)(JKRHeap*);
-    void (*dump_sort)(JKRHeap*);
-    void (*func7)(JKRHeap*);
-    void (*do_destroy)(JKRHeap*);
-    void (*do_alloc)(JKRHeap*,u32 size, int alignment);
-    void (*do_free)(JKRHeap*,void*ptr);
-    void (*do_freeAll)(JKRHeap*);
-    void (*do_freeTail)(JKRHeap*);
-    void (*func13)(JKRHeap*);
-    void (*func14)(JKRHeap*);
-    void (*func15)(JKRHeap*);
-    void (*func16)(JKRHeap*);
-    void (*func17)(JKRHeap*);
-    void (*func18)(JKRHeap*);
-    void (*do_changeGroup)(JKRHeap*);
-    void (*do_getCurrent)(JKRHeap*);
-    void (*state_register)(JKRHeap*);
-    void (*state_compare)(JKRHeap*);
-    void (*state_dump)(JKRHeap*);
-};
+#include "JSystem/JKernel/JKRHeap/JKRHeap_vtable.h"
 
 typedef void (*JKRErrorHandler)(void*, unsigned long, int);
 class JKRHeap {
@@ -58,17 +34,17 @@ class JKRHeap {
     s32 getSize(void* ptr);
 
     s32 getFreeSize();
-    u32 getMaxFreeBlock();
-    u32 getTotalFreeSize();
+    s32 getMaxFreeBlock();
+    s32 getTotalFreeSize();
     u8 changeGroupID(u8 param_1);
-    u32 getMaxAllocatableSize(int alignment);
+    s32 getMaxAllocatableSize(int alignment);
 
     static JKRHeap* findFromRoot(void* ptr);
     JKRHeap* find(void* ptr) const;
     JKRHeap* findAllHeap(void* ptr) const;
 
     void dispose_subroutine(u32 begin, u32 end);
-    void dispose(void* ptr, u32 size);
+    bool dispose(void* ptr, u32 size);
     void dispose(void* begin, void* end);
     void dispose();
 
@@ -112,3 +88,5 @@ void* operator new[](u32 size, JKRHeap* heap, int alignment);
 
 void operator delete(void* ptr);
 void operator delete[](void* ptr);
+
+#endif

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap_vtable.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap_vtable.h
@@ -21,9 +21,9 @@ struct _VTABLE_JKRHeap {
     void (*func13)(JKRHeap*);
     s32 (*do_resize)(JKRHeap*, void* ptr, u32 size);
     s32 (*do_getSize)(JKRHeap*, void* ptr);
-    s32 (*go_getFreeSize)(JKRHeap*);
-    s32 (*go_getMaxFreeBlock)(JKRHeap*);
-    s32 (*getTotalFreeSize)(JKRHeap*);
+    s32 (*do_getFreeSize)(JKRHeap*);
+    s32 (*do_getMaxFreeBlock)(JKRHeap*);
+    s32 (*do_getTotalFreeSize)(JKRHeap*);
     u8 (*do_changeGroupID)(JKRHeap*, u8 param_1);
     void (*do_getCurrent)(JKRHeap*);
     void (*state_register)(JKRHeap*);

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap_vtable.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap_vtable.h
@@ -1,0 +1,34 @@
+#ifndef __JKRHEAP_VTABLE_H__
+#define __JKRHEAP_VTABLE_H__
+
+#include "dolphin/types.h"
+
+class JKRHeap;
+struct _VTABLE_JKRHeap {
+    void (*func0)(JKRHeap*);
+    void (*_ct)(JKRHeap*);
+    void (*_dt)(JKRHeap*);
+    void (*callAllDisposer)(JKRHeap*);
+    void (*func4)(JKRHeap*);
+    void (*func5)(JKRHeap*);
+    void (*dump_sort)(JKRHeap*);
+    void (*func7)(JKRHeap*);
+    void (*do_destroy)(JKRHeap*);
+    void* (*do_alloc)(JKRHeap*,u32 size, int alignment);
+    void (*do_free)(JKRHeap*,void*ptr);
+    void (*do_freeAll)(JKRHeap*);
+    void (*do_freeTail)(JKRHeap*);
+    void (*func13)(JKRHeap*);
+    s32 (*do_resize)(JKRHeap*, void* ptr, u32 size);
+    s32 (*do_getSize)(JKRHeap*, void* ptr);
+    s32 (*go_getFreeSize)(JKRHeap*);
+    s32 (*go_getMaxFreeBlock)(JKRHeap*);
+    s32 (*getTotalFreeSize)(JKRHeap*);
+    u8 (*do_changeGroupID)(JKRHeap*, u8 param_1);
+    void (*do_getCurrent)(JKRHeap*);
+    void (*state_register)(JKRHeap*);
+    void (*state_compare)(JKRHeap*);
+    void (*state_dump)(JKRHeap*);
+};
+
+#endif

--- a/include/functions.h
+++ b/include/functions.h
@@ -156,12 +156,7 @@ extern "C" {
 
 // OS
 extern "C" {
-    void OSInitMutex(void);
-    void OSGetArenaLo(void);
-    void OSGetArenaHi(void);
-    void OSInitAlloc(void);
-    void OSSetArenaLo(void);
-    void OSSetArenaHi(void);
+    void OSInitMutex(u8[24]);
     void OSEnableScheduler(void);
     void OSDisableScheduler(void);
     void OSCheckActiveThreads(void);
@@ -178,6 +173,12 @@ extern "C" {
     void OSReportInit(void);
     void OSGetCurrentThread(void);
     void OSTicksToCalendarTime(void);
+
+    u32 OSGetArenaLo();
+    u32 OSGetArenaHi();
+    u32 OSInitAlloc(u32 low, u32 high, int param_3);
+    void OSSetArenaLo(u32 param_1);
+    void OSSetArenaHi(u32 param_1);
 }
 
 // DVD

--- a/include/variables.h
+++ b/include/variables.h
@@ -1,3 +1,7 @@
+#include "JSystem/JKernel/JKRDisposer/JKRDisposer_vtable.h"
+#include "JSystem/JKernel/JKRHeap/JKRHeap_vtable.h"
+
+
 extern float lbl_80451D5C;
 extern u8 lbl_80379234[0x64];
 extern int lbl_804061C0;
@@ -84,7 +88,7 @@ extern u8 lbl_803BB498;
 extern _VTABLE_JKRHeap lbl_803CBF70; // JKRHeap::__vt
 
 extern JKRHeap* lbl_80451370; // JKRHeap::sSystemHeap
-extern void* lbl_80451378; // JKRHeap::sRootHeap
+extern JKRHeap* lbl_80451378; // JKRHeap::sRootHeap
 extern JKRHeap* lbl_80451374; // JKRHeap::sCurrentHeap
 extern void* lbl_8045137C; // JKRHeap::mErrorHandler
 
@@ -108,4 +112,4 @@ extern u32 lbl_80000028;
 extern char lbl_8039CAD8[12]; // "JKRHeap.cpp"
 
 // func_802D147C
-extern void* lbl_803CC0F0[4]; // JKRDisposer::__vt
+extern _VTABLE_JKRDisposer lbl_803CC0F0; // JKRDisposer::__vt

--- a/include/variables.h
+++ b/include/variables.h
@@ -81,7 +81,7 @@ extern u8 lbl_803BB498;
 #define _SDA2_BASE_(dummy) 0
 
 // func_802CE138
-extern void* lbl_803CBF70[24]; // JKRHeap::__vt
+extern _VTABLE_JKRHeap lbl_803CBF70; // JKRHeap::__vt
 
 extern JKRHeap* lbl_80451370; // JKRHeap::sSystemHeap
 extern void* lbl_80451378; // JKRHeap::sRootHeap

--- a/include/variables.h
+++ b/include/variables.h
@@ -81,11 +81,11 @@ extern u8 lbl_803BB498;
 #define _SDA2_BASE_(dummy) 0
 
 // func_802CE138
-extern u32 lbl_803CBF70[24];
+extern void* lbl_803CBF70[24]; // JKRHeap::__vt
 
-extern void* lbl_80451370; // JKRHeap::sSystemHeap
+extern JKRHeap* lbl_80451370; // JKRHeap::sSystemHeap
 extern void* lbl_80451378; // JKRHeap::sRootHeap
-extern void* lbl_80451374; // JKRHeap::sCurrentHeap
+extern JKRHeap* lbl_80451374; // JKRHeap::sCurrentHeap
 extern void* lbl_8045137C; // JKRHeap::mErrorHandler
 
 extern u8 lbl_804508B0[8]; // ::*fill*
@@ -98,6 +98,11 @@ extern void* lbl_8045138C; // JKRHeap::mUserRamStart
 extern void* lbl_80451390; // JKRHeap::mUserRamEnd
 extern u32 lbl_80451394;   // JKRHeap::mMemorySize
 
+extern u8 lbl_80000000;
+extern u32 lbl_80000028;
+
+#define OS_GLOBAL(T, ADDR) *((T*)((void*)ADDR))
+#define OS_GLOBAL_ADDR(T, ADDR) ((T*)((void*)ADDR))
 
 // func_802CEB40
 extern char lbl_8039CAD8[12]; // "JKRHeap.cpp"

--- a/libs/JSystem/JKernel/JKRDisposer.cpp
+++ b/libs/JSystem/JKernel/JKRDisposer.cpp
@@ -3,7 +3,7 @@
 #include "JSystem/JKernel/JKRHeap/JKRHeap.h"
 
 // #include "JSystem/JKernel/asm/func_802D147C.s"
-JKRDisposer::JKRDisposer() : __vt(lbl_803CC0F0), ptr_link(this) {
+JKRDisposer::JKRDisposer() : __vt(&lbl_803CC0F0), ptr_link(this) {
     this->heap     = JKRHeap::findFromRoot(this);
     if (this->heap != 0) {
         this->heap->disposable_list.append(&this->ptr_link);

--- a/libs/JSystem/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/JKernel/JKRHeap.cpp
@@ -226,7 +226,7 @@ asm s32 JKRHeap::getSize(void* ptr) {
 // Same problem as with all other virtual calls.
 #ifdef NONMATCHING
 s32 JKRHeap::getFreeSize() {
-    return (*this->__vt->go_getFreeSize)(this);
+    return (*this->__vt->do_getFreeSize)(this);
 }
 #else
 asm s32 JKRHeap::getFreeSize() {
@@ -238,7 +238,7 @@ asm s32 JKRHeap::getFreeSize() {
 // Same problem as with all other virtual calls.
 #ifdef NONMATCHING
 s32 JKRHeap::getMaxFreeBlock() {
-    return (*this->__vt->go_getMaxFreeBlock)(this);
+    return (*this->__vt->do_getMaxFreeBlock)(this);
 }
 #else
 asm s32 JKRHeap::getMaxFreeBlock() {
@@ -250,7 +250,7 @@ asm s32 JKRHeap::getMaxFreeBlock() {
 // Same problem as with all other virtual calls.
 #ifdef NONMATCHING
 s32 JKRHeap::getTotalFreeSize() {
-    return (*this->__vt->go_getTotalFreeSize)(this);
+    return (*this->__vt->do_getTotalFreeSize)(this);
 }
 #else
 asm s32 JKRHeap::getTotalFreeSize() {

--- a/libs/JSystem/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/JKernel/JKRHeap.cpp
@@ -4,44 +4,39 @@
 // Initializing the members seems to be weird because of
 // the way we're using vtables.
 #ifdef NONMATCHING
-JKRHeap::JKRHeap(void *data,u32 size,JKRHeap *parent,bool error_flag) : 
-    __base(), 
-    __vt(lbl_803CBF70), 
-    child_list(true), 
-    heap_link(this), 
-    disposable_list(true)
-{
-  OSInitMutex(this->mutex);
-  this->size = size;
-  this->begin = (u32)data;
-  this->end = (u32)data + size;
+JKRHeap::JKRHeap(void* data, u32 size, JKRHeap* parent, bool error_flag)
+    : __base(), __vt(lbl_803CBF70), child_list(true), heap_link(this), disposable_list(true) {
+    OSInitMutex(this->mutex);
+    this->size  = size;
+    this->begin = (u32)data;
+    this->end   = (u32)data + size;
 
-  if (parent == NULL) {
-    this->becomeSystemHeap();
-    this->becomeCurrentHeap();
-  } else {
-    JSUPtrLink* ptr = (JSUPtrLink*)&this->child_list;
-    if (ptr != NULL) {
-      ptr = &this->heap_link;
+    if (parent == NULL) {
+        this->becomeSystemHeap();
+        this->becomeCurrentHeap();
+    } else {
+        JSUPtrLink* ptr = (JSUPtrLink*)&this->child_list;
+        if (ptr != NULL) {
+            ptr = &this->heap_link;
+        }
+
+        parent->child_list.append(ptr);
+        if (lbl_80451370 == lbl_80451378) {
+            this->becomeSystemHeap();
+        }
+        if (lbl_80451374 == lbl_80451378) {
+            this->becomeCurrentHeap();
+        }
     }
 
-    parent->child_list.append(ptr);
-    if (lbl_80451370 == lbl_80451378) {
-      this->becomeSystemHeap();
+    this->error_flag = error_flag;
+    if ((this->error_flag == true) && (lbl_8045137C == NULL)) {
+        lbl_8045137C = JKRHeap::JKRDefaultMemoryErrorRoutine;
     }
-    if (lbl_80451374 == lbl_80451378) {
-      this->becomeCurrentHeap();
-    }
-  }
 
-  this->error_flag = error_flag;
-  if ((this->error_flag == true) && (lbl_8045137C == NULL)) {
-    lbl_8045137C = JKRHeap::JKRDefaultMemoryErrorRoutine;
-  }
-
-  this->field_0x3c = lbl_804508B0[0];
-  this->field_0x3d = lbl_80451380[0];
-  this->field_0x69 = 0;
+    this->field_0x3c = lbl_804508B0[0];
+    this->field_0x3d = lbl_80451380[0];
+    this->field_0x69 = 0;
 }
 #else
 asm JKRHeap::JKRHeap(void* data, u32 size, JKRHeap* parent, bool error_flag) {
@@ -61,13 +56,13 @@ bool JKRHeap::initArena(char** memory, u32* size, int param_3) {
     u32 ram_end;
     u32 ram;
 
-    u32 low = OSGetArenaLo();
+    u32 low  = OSGetArenaLo();
     u32 high = OSGetArenaHi();
     if (low == high) return false;
 
-    ram = OSInitAlloc(low, high, param_3);
-    ram_start = (ram + 0x1fU & 0xffffffe0);
-    ram_end = (high & 0xffffffe0);
+    ram          = OSInitAlloc(low, high, param_3);
+    ram_start    = (ram + 0x1fU & 0xffffffe0);
+    ram_end      = (high & 0xffffffe0);
     lbl_80451384 = OS_GLOBAL_ADDR(void, 0x80000000);
     lbl_80451388 = (void*)ram_start;
     lbl_8045138C = (void*)ram_start;
@@ -76,27 +71,27 @@ bool JKRHeap::initArena(char** memory, u32* size, int param_3) {
     OSSetArenaLo(ram_end);
     OSSetArenaHi(ram_end);
     *memory = (char*)ram_start;
-    *size = ram_end - ram_start;
+    *size   = ram_end - ram_start;
     return true;
 }
 
 // #include "JSystem/JKernel/JKRHeap/asm/func_802CE428.s"
-JKRHeap * JKRHeap::becomeSystemHeap() {
+JKRHeap* JKRHeap::becomeSystemHeap() {
     JKRHeap* prev = lbl_80451370;
-    lbl_80451370 = this;
+    lbl_80451370  = this;
     return prev;
 }
 
 // #include "JSystem/JKernel/JKRHeap/asm/func_802CE438.s"
-JKRHeap * JKRHeap::becomeCurrentHeap() {
+JKRHeap* JKRHeap::becomeCurrentHeap() {
     JKRHeap* prev = lbl_80451374;
-    lbl_80451374 = this;
+    lbl_80451374  = this;
     return prev;
 }
 
 // All virtual calls seems to only use r12
-// but emulating the call with use another 
-// register (r4 in this case).  
+// but emulating the call with use another
+// register (r4 in this case).
 #ifdef NONMATCHING
 void JKRHeap::destroy() {
     (*this->__vt->do_destroy)(this);
@@ -124,7 +119,7 @@ void* JKRHeap::alloc(u32 size, int alignment, JKRHeap* heap) {
 // Same problem as with all other virtual calls.
 #ifdef NONMATCHING
 void* JKRHeap::alloc(u32 size, int alignment) {
-    (*this->__vt->do_alloc)(this, size, alignment);
+    return (*this->__vt->do_alloc)(this, size, alignment);
 }
 #else
 asm void* JKRHeap::alloc(u32 size, int alignment) {
@@ -135,11 +130,11 @@ asm void* JKRHeap::alloc(u32 size, int alignment) {
 
 // #include "JSystem/JKernel/JKRHeap/asm/func_802CE500.s"
 void JKRHeap::free(void* ptr, JKRHeap* heap) {
-    if(!heap) {
+    if (!heap) {
         heap = findFromRoot(ptr);
-        if(!heap) return;
+        if (!heap) return;
     }
-    
+
     heap->free(ptr);
 }
 
@@ -194,49 +189,103 @@ s32 JKRHeap::resize(void* ptr, u32 size, JKRHeap* heap) {
     return heap->resize(ptr, size);
 }
 
+// Same problem as with all other virtual calls.
+#ifdef NONMATCHING
+s32 JKRHeap::resize(void* ptr, u32 size) {
+    return (*this->__vt->do_resize)(this, ptr, size);
+}
+#else
 asm s32 JKRHeap::resize(void* ptr, u32 size) {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE684.s"
 }
+#endif
 
-asm s32 JKRHeap::getSize(void* ptr, JKRHeap* heap) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CE6B0.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CE6B0.s"
+s32 JKRHeap::getSize(void* ptr, JKRHeap* heap) {
+    if (!heap) {
+        heap = findFromRoot(ptr);
+        if (!heap) return -1;
+    }
+
+    return heap->getSize(ptr);
 }
 
+// Same problem as with all other virtual calls.
+#ifdef NONMATCHING
+s32 JKRHeap::getSize(void* ptr) {
+    return (*this->__vt->do_getSize)(this, ptr);
+}
+#else
 asm s32 JKRHeap::getSize(void* ptr) {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE700.s"
 }
+#endif
 
+// Same problem as with all other virtual calls.
+#ifdef NONMATCHING
+s32 JKRHeap::getFreeSize() {
+    return (*this->__vt->go_getFreeSize)(this);
+}
+#else
 asm s32 JKRHeap::getFreeSize() {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE72C.s"
 }
+#endif
 
-asm u32 JKRHeap::getMaxFreeBlock() {
+// Same problem as with all other virtual calls.
+#ifdef NONMATCHING
+s32 JKRHeap::getMaxFreeBlock() {
+    return (*this->__vt->go_getMaxFreeBlock)(this);
+}
+#else
+asm s32 JKRHeap::getMaxFreeBlock() {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE758.s"
 }
+#endif
 
-asm u32 JKRHeap::getTotalFreeSize() {
+// Same problem as with all other virtual calls.
+#ifdef NONMATCHING
+s32 JKRHeap::getTotalFreeSize() {
+    return (*this->__vt->go_getTotalFreeSize)(this);
+}
+#else
+asm s32 JKRHeap::getTotalFreeSize() {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE784.s"
 }
+#endif
 
+// Same problem as with all other virtual calls.
+#ifdef NONMATCHING
+u8 JKRHeap::changeGroupID(u8 param_1) {
+    return (*this->__vt->go_changeGroupID)(this, param_1);
+}
+#else
 asm u8 JKRHeap::changeGroupID(u8 param_1) {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE7B0.s"
 }
+#endif
 
-asm u32 JKRHeap::getMaxAllocatableSize(int alignment) {
-    nofralloc
+asm s32 JKRHeap::getMaxAllocatableSize(int alignment){nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE7DC.s"
 }
 
-asm JKRHeap* JKRHeap::findFromRoot(void* ptr) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CE83C.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CE83C.s"
+JKRHeap* JKRHeap::findFromRoot(void* ptr) {
+    if (lbl_80451378 == NULL) {
+        return (JKRHeap*)NULL;
+    }
+
+    if (((void*)lbl_80451378->begin <= ptr) && (ptr < (void*)lbl_80451378->end)) {
+        return lbl_80451378->find(ptr);
+    }
+
+    return lbl_80451378->findAllHeap(ptr);
 }
 
 asm JKRHeap* JKRHeap::find(void* ptr) const {
@@ -254,14 +303,17 @@ asm void JKRHeap::dispose_subroutine(u32 begin, u32 end) {
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE9E4.s"
 }
 
-asm void JKRHeap::dispose(void* ptr, u32 size) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CEA78.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CEA78.s"
+bool JKRHeap::dispose(void* ptr, u32 size) {
+    u32 begin = (u32)ptr;
+    u32 end   = (u32)ptr + size;
+    this->dispose_subroutine(begin, end);
+    return false;
 }
 
-asm void JKRHeap::dispose(void* begin, void* end) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CEAA0.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CEAA0.s"
+void JKRHeap::dispose(void* begin, void* end) {
+    this->dispose_subroutine((u32)begin, (u32)end);
 }
 
 asm void JKRHeap::dispose() {
@@ -269,9 +321,18 @@ asm void JKRHeap::dispose() {
 #include "JSystem/JKernel/JKRHeap/asm/func_802CEAC0.s"
 }
 
-asm void JKRHeap::copyMemory(void* dst, void* src, u32 size) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CEB18.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CEB18.s"
+void JKRHeap::copyMemory(void* dst, void* src, u32 size) {
+    u32 count = (size + 3) / 4;
+
+    u32* dst_32 = (u32*)dst;
+    u32* src_32 = (u32*)src;
+    while (count > 0) {
+        *dst_32 = *src_32;
+        dst_32++;
+        src_32++;
+        count--;
+    }
 }
 
 asm void JKRHeap::JKRDefaultMemoryErrorRoutine(JKRHeap* heap, u32 size, int alignment) {
@@ -294,42 +355,44 @@ asm bool JKRHeap::isSubHeap(JKRHeap* heap) const {
 #include "JSystem/JKernel/JKRHeap/asm/func_802CEBA8.s"
 }
 
-asm void* operator new(u32 size) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CEC4C.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CEC4C.s"
+void* operator new(u32 size) {
+    return JKRHeap::alloc(size, 4, (JKRHeap*)NULL);
 }
 
-asm void* operator new(u32 size, int alignment) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CEC74.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CEC74.s"
+void* operator new(u32 size, int alignment) {
+    return JKRHeap::alloc(size, alignment, (JKRHeap*)NULL);
 }
 
-asm void* operator new(u32 size, JKRHeap* heap, int alignment) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CEC98.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CEC98.s"
+void* operator new(u32 size, JKRHeap* heap, int alignment) {
+    return JKRHeap::alloc(size, alignment, heap);
 }
 
-asm void* operator new[](u32 size) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CECC4.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CECC4.s"
+void* operator new[](u32 size) {
+    return JKRHeap::alloc(size, 4, (JKRHeap*)NULL);
 }
 
-asm void* operator new[](u32 size, int alignment) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CECEC.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CECEC.s"
+void* operator new[](u32 size, int alignment) {
+    return JKRHeap::alloc(size, alignment, (JKRHeap*)NULL);
 }
 
-asm void* operator new[](u32 size, JKRHeap* heap, int alignment) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CED10.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CED10.s"
+void* operator new[](u32 size, JKRHeap* heap, int alignment) {
+    return JKRHeap::alloc(size, alignment, heap);
 }
 
-asm void operator delete(void* ptr) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CED3C.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CED3C.s"
+void operator delete(void* ptr) {
+    JKRHeap::free(ptr, (JKRHeap*)NULL);
 }
 
-asm void operator delete[](void* ptr) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CED60.s"
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CED60.s"
+void operator delete[](void* ptr) {
+    JKRHeap::free(ptr, (JKRHeap*)NULL);
 }
+
+

--- a/libs/JSystem/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/JKernel/JKRHeap.cpp
@@ -55,16 +55,19 @@ asm JKRHeap::~JKRHeap() {
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE264.s"
 }
 
-// All instruction are correct but the register order is wrong.
-#ifdef NONMATCHING
+// #include "JSystem/JKernel/JKRHeap/asm/func_802CE378.s"
 bool JKRHeap::initArena(char** memory, u32* size, int param_3) {
+    u32 ram_start;
+    u32 ram_end;
+    u32 ram;
+
     u32 low = OSGetArenaLo();
     u32 high = OSGetArenaHi();
     if (low == high) return false;
 
-    u32 ram = OSInitAlloc(low, high, param_3);
-    u32 ram_start = (ram + 0x1fU & 0xffffffe0);
-    u32 ram_end = (high & 0xffffffe0);
+    ram = OSInitAlloc(low, high, param_3);
+    ram_start = (ram + 0x1fU & 0xffffffe0);
+    ram_end = (high & 0xffffffe0);
     lbl_80451384 = OS_GLOBAL_ADDR(void, 0x80000000);
     lbl_80451388 = (void*)ram_start;
     lbl_8045138C = (void*)ram_start;
@@ -76,12 +79,6 @@ bool JKRHeap::initArena(char** memory, u32* size, int param_3) {
     *size = ram_end - ram_start;
     return true;
 }
-#else
-asm bool JKRHeap::initArena(char**, u32*, int) {
-    nofralloc
-#include "JSystem/JKernel/JKRHeap/asm/func_802CE378.s"
-}
-#endif
 
 // #include "JSystem/JKernel/JKRHeap/asm/func_802CE428.s"
 JKRHeap * JKRHeap::becomeSystemHeap() {
@@ -97,10 +94,14 @@ JKRHeap * JKRHeap::becomeCurrentHeap() {
     return prev;
 }
 
+#ifdef NONMATCHING
+
+#else
 asm void JKRHeap::destroy() {
     nofralloc
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE448.s"
 }
+#endif
 
 asm void* JKRHeap::alloc(u32 size, int alignment, JKRHeap* heap) {
     nofralloc

--- a/obj_files.mk
+++ b/obj_files.mk
@@ -159,7 +159,6 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/d/file/d_file_select.o    \
             $(BUILD_DIR)/asm/d/file/sel/d_file_sel_warning.o    \
             $(BUILD_DIR)/src/d/d_file/d_file_sel_info.o    \
-            $(BUILD_DIR)/asm/d/file/sel/d_file_sel_info.o    \
             $(BUILD_DIR)/asm/d/bright/d_bright_check.o    \
             $(BUILD_DIR)/asm/d/d_scope.o    \
             $(BUILD_DIR)/asm/d/select/d_select_cursor.o    \


### PR DESCRIPTION
Decompiled most of JKRHeap, added vtables for JKRHeap and JKRDisposer, and added labels to virtual functions (in JKRHeap).

There is a big issue with virtual calls. The code below will generate the correct instruction but not use register **r12**.
```c++
void JKRHeap::free(void* ptr) {
    (*this->__vt->do_free)(this, ptr);
}
```

![image](https://user-images.githubusercontent.com/3693193/100555830-68d5dd80-329e-11eb-996a-7fe7e19d36c3.png)
