### PR TITLE
JKernel cleanup and DVD types

### DIFF
--- a/include/JSystem/JKernel/JKRAramBlock/JKRAramBlock.h
+++ b/include/JSystem/JKernel/JKRAramBlock/JKRAramBlock.h
@@ -24,13 +24,14 @@ public:
     void newGroupID(u8 groupId) { mGroupId = groupId; }
 
 public:
-    JSULink<JKRAramBlock> mBlockLink;
-    u32 mAddress;
-    u32 mSize;
-    u32 mFreeSize;
-    u8 mGroupId;
-    u8 mIsTempMemory;
-    u8 padding[2];
+    /* 0x00 */  // vtable
+    /* 0x04 */ JSULink<JKRAramBlock> mBlockLink;
+    /* 0x14 */ u32 mAddress;
+    /* 0x18 */ u32 mSize;
+    /* 0x1C */ u32 mFreeSize;
+    /* 0x20 */ u8 mGroupId;
+    /* 0x21 */ u8 mIsTempMemory;
+    /* 0x22 */ u8 padding[2];
 };
 
 #endif

--- a/include/JSystem/JKernel/JKRAramHeap/JKRAramHeap.h
+++ b/include/JSystem/JKernel/JKRAramHeap/JKRAramHeap.h
@@ -37,13 +37,15 @@ private:
     void unlock() { OSUnlockMutex(&mMutex); }
 
 public:
-    OSMutex mMutex;
-    JKRHeap* mHeap;
-    u32 mHeadAddress;
-    u32 mTailAddress;
-    u32 mSize;
-    u8 mGroupId;
-    u8 padding_0x41[3];
+    /* 0x00 */  // vtable
+    /* 0x04 */  // JKRDisposer
+    /* 0x18 */ OSMutex mMutex;
+    /* 0x30 */ JKRHeap* mHeap;
+    /* 0x34 */ u32 mHeadAddress;
+    /* 0x38 */ u32 mTailAddress;
+    /* 0x3C */ u32 mSize;
+    /* 0x40 */ u8 mGroupId;
+    /* 0x41 */ u8 padding_0x41[3];
 };
 
 #endif

--- a/include/JSystem/JKernel/JKRDisposer/JKRDisposer.h
+++ b/include/JSystem/JKernel/JKRDisposer/JKRDisposer.h
@@ -11,8 +11,9 @@ public:
     virtual ~JKRDisposer();
 
 public:
-    JKRHeap* mHeap;
-    JSULink<JKRDisposer> mLink;
+    /* 0x00 */  // vtable
+    /* 0x04 */ JKRHeap* mHeap;
+    /* 0x08 */ JSULink<JKRDisposer> mLink;
 };
 
 #endif

--- a/include/JSystem/JKernel/JKRDvdFile/JKRDvdFile.h
+++ b/include/JSystem/JKernel/JKRDvdFile/JKRDvdFile.h
@@ -18,11 +18,11 @@ public:
     void initiate(void);
     s32 sync(void);
 
-    int getFileID() const { return mFileID << 2; }
+    int getFileID() const { return mFileInfo.start_address << 2; }
 
-    const u8* getFileInfo() const { return mDvdCommandBlock; }
+    const DVDFileInfo& getFileInfo() const { return mFileInfo; }
 
-    int getStatus() { return DVDGetCommandBlockStatus(&mDvdCommandBlock[0]); }
+    int getStatus() { return DVDGetCommandBlockStatus(&mFileInfo.block); }
 
 public:
     /* vt[03] */ virtual bool open(const char*);                 /* override */
@@ -41,17 +41,14 @@ private:
     /* 0x50 */ u32 field_0x50;
     /* 0x54 */ u32 field_0x54;
     /* 0x58 */ u32 field_0x58;
-    /* 0x5C */ u8 mDvdCommandBlock[48];
-    /* 0x98 */ s32 mFileID;
-    /* 0x9C */ s32 mFileSize;
-    /* 0x00 */ u32 field_0x94;
+    /* 0x5C */ DVDFileInfo mFileInfo;
     /* 0x98 */ JKRDvdFile* mDvdFile;
     /* 0x9C */ OSMessageQueue mMessageQueue1;
-    /* 0x00 */ OSMessage mMessage1;
-    /* 0x00 */ OSMessageQueue mMessageQueue2;
-    /* 0x00 */ OSMessage mMessage2;
-    /* 0x00 */ JSULink<JKRDvdFile> mDvdLink;
-    /* 0x00 */ OSThread* mOSThread;
+    /* 0xBC */ OSMessage mMessage1;
+    /* 0xC0 */ OSMessageQueue mMessageQueue2;
+    /* 0xE0 */ OSMessage mMessage2;
+    /* 0xE4 */ JSULink<JKRDvdFile> mDvdLink;
+    /* 0xF4 */ OSThread* mOSThread;
 
 public:
     static void doneProcess(long, DVDFileInfo*);

--- a/include/JSystem/JKernel/JKRDvdFile/JKRDvdFile.h
+++ b/include/JSystem/JKernel/JKRDvdFile/JKRDvdFile.h
@@ -11,45 +11,47 @@ class JSUFileInputStream;
 class JKRDvdFile : public JKRFile {
 public:
     JKRDvdFile();
-    JKRDvdFile(char const*);
+    JKRDvdFile(const char*);
     JKRDvdFile(long);
     virtual ~JKRDvdFile();
 
     void initiate(void);
     s32 sync(void);
 
-    int getFileID() const { return this->file_info.start_address << 2; }
+    int getFileID() const { return mFileID << 2; }
 
-    const DVDFileInfo* getFileInfo() const { return &this->file_info; }
+    const u8* getFileInfo() const { return mDvdCommandBlock; }
 
-    int getStatus() { return DVDGetCommandBlockStatus(&this->file_info); }
+    int getStatus() { return DVDGetCommandBlockStatus(&mDvdCommandBlock[0]); }
 
 public:
-    /* vt[03] */ virtual bool open(char const*);                 /* override */
+    /* vt[03] */ virtual bool open(const char*);                 /* override */
     /* vt[04] */ virtual void close(void);                       /* override */
     /* vt[05] */ virtual s32 readData(void*, long, long);        /* override */
-    /* vt[06] */ virtual s32 writeData(void const*, long, long); /* override */
+    /* vt[06] */ virtual s32 writeData(const void*, long, long); /* override */
     /* vt[07] */ virtual s32 getFileSize(void) const;            /* override */
     /* vt[08] */ virtual bool open(long);
 
 private:
-    OSMutex mMutex1;
-    OSMutex mMutex2;
-    JKRADCommand* field_0x4c;
-    OSThread* field_0x50;
-    JSUFileInputStream* field_0x54;
-    u32 field_0x58;
-    DVDFileInfo file_info;
-    // s32 mFileID;
-    // s32 mFileSize;
-    // u32 field_0x94;
-    JKRDvdFile* mDvdFile;
-    OSMessageQueue mQueue1;
-    OSMessage mMessages1[1];
-    OSMessageQueue mQueue2;
-    OSMessage mMessages2[1];
-    JSULink<JKRDvdFile> mDvdLink;
-    OSThread* mOSThread;
+    /* 0x00 */ // vtable
+    /* 0x04 */ // JKRFile
+    /* 0x1C */ OSMutex mMutex1;
+    /* 0x34 */ OSMutex mMutex2;
+    /* 0x4C */ u32 field_0x4c;
+    /* 0x50 */ u32 field_0x50;
+    /* 0x54 */ u32 field_0x54;
+    /* 0x58 */ u32 field_0x58;
+    /* 0x5C */ u8 mDvdCommandBlock[48];
+    /* 0x98 */ s32 mFileID;
+    /* 0x9C */ s32 mFileSize;
+    /* 0x00 */ u32 field_0x94;
+    /* 0x98 */ JKRDvdFile* mDvdFile;
+    /* 0x9C */ OSMessageQueue mMessageQueue1;
+    /* 0x00 */ OSMessage mMessage1;
+    /* 0x00 */ OSMessageQueue mMessageQueue2;
+    /* 0x00 */ OSMessage mMessage2;
+    /* 0x00 */ JSULink<JKRDvdFile> mDvdLink;
+    /* 0x00 */ OSThread* mOSThread;
 
 public:
     static void doneProcess(long, DVDFileInfo*);

--- a/include/JSystem/JKernel/JKRDvdFile/JKRDvdFile.h
+++ b/include/JSystem/JKernel/JKRDvdFile/JKRDvdFile.h
@@ -33,8 +33,8 @@ public:
     /* vt[08] */ virtual bool open(long);
 
 private:
-    /* 0x00 */ // vtable
-    /* 0x04 */ // JKRFile
+    /* 0x00 */  // vtable
+    /* 0x04 */  // JKRFile
     /* 0x1C */ OSMutex mMutex1;
     /* 0x34 */ OSMutex mMutex2;
     /* 0x4C */ u32 field_0x4c;

--- a/include/JSystem/JKernel/JKRFile/JKRFile.h
+++ b/include/JSystem/JKernel/JKRFile/JKRFile.h
@@ -11,18 +11,20 @@ public:
 
     s32 read(void*, long, long);
 
-    bool isAvailable() { return this->mIsAvailable; }
+    bool isAvailable() const { return this->mIsAvailable; }
 
 public:
     /* vt[03] */ virtual bool open(const char*) = 0;
     /* vt[04] */ virtual void close() = 0;
-    /* vt[05] */ virtual s32 readData(void*, long, long) = 0;
-    /* vt[06] */ virtual s32 writeData(const void*, long, long) = 0;
+    /* vt[05] */ virtual s32 readData(void*, s32, s32) = 0;
+    /* vt[06] */ virtual s32 writeData(const void*, s32, s32) = 0;
     /* vt[07] */ virtual s32 getFileSize() const = 0;
 
 protected:
-    bool mIsAvailable;
-    u8 field_0x19[3];
+    /* 0x00 */  // vtable
+    /* 0x04 */  // JKRDisposer
+    /* 0x18 */ bool mIsAvailable;
+    /* 0x19 */ u8 field_0x19[3];
 };
 
 #endif

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap.h
@@ -89,8 +89,8 @@ public:
     void unlock() { OSUnlockMutex(&mMutex); }
 
 protected:
-    /* 0x00 */ // vtable
-    /* 0x04 */ // JKRDisposer
+    /* 0x00 */  // vtable
+    /* 0x04 */  // JKRDisposer
     /* 0x18 */ OSMutex mMutex;
     /* 0x30 */ u32 mStart;
     /* 0x34 */ u32 mEnd;

--- a/include/JSystem/JKernel/JKRHeap/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap/JKRHeap.h
@@ -27,7 +27,7 @@ public:
     s32 getFreeSize();
     void* getMaxFreeBlock();
     s32 getTotalFreeSize();
-    u8 changeGroupID(u8 param_1);
+    u8 changeGroupID(u8 newGroupId);
     s32 getMaxAllocatableSize(int alignment);
 
     JKRHeap* find(void* ptr) const;
@@ -63,7 +63,7 @@ public:
     /* vt[22] */ virtual bool state_compare(JKRHeap::TState const&, JKRHeap::TState const&) const;
     /* vt[23] */ virtual void state_dump();
 
-    void setDebugFill(bool debugFill) { this->mDebugFill = debugFill; }
+    void setDebugFill(bool debugFill) { mDebugFill = debugFill; }
 
     void* getStartAddr() const { return (void*)mStart; }
 
@@ -71,37 +71,39 @@ public:
 
     u32 getSize() const { return mSize; }
 
-    bool getErrorFlag() { return mErrorFlag; }
+    bool getErrorFlag() const { return mErrorFlag; }
 
-    JKRHeap* getParent() {
-        JSUTree<JKRHeap>* parent = this->mChildTree.getParent();
+    JKRHeap* getParent() const {
+        JSUTree<JKRHeap>* parent = mChildTree.getParent();
         return parent->getObject();
     }
 
-    JSUTree<JKRHeap>& getHeapTree() { return this->mChildTree; }
+    JSUTree<JKRHeap>& getHeapTree() { return mChildTree; }
 
     void appendDisposer(JKRDisposer* disposer) { mDisposerList.append(&disposer->mLink); }
 
     void removeDisposer(JKRDisposer* disposer) { mDisposerList.remove(&disposer->mLink); }
 
-    void lock() { OSLockMutex(&this->mMutex); }
+    void lock() { OSLockMutex(&mMutex); }
 
-    void unlock() { OSUnlockMutex(&this->mMutex); }
+    void unlock() { OSUnlockMutex(&mMutex); }
 
 protected:
-    OSMutex mMutex;
-    u32 mStart;
-    u32 mEnd;
-    u32 mSize;
-    bool mDebugFill;
-    bool mCheckMemoryFilled;
-    u8 mAllocationMode;  // EAllocMode?
-    u8 mGroupId;
-    JSUTree<JKRHeap> mChildTree;
-    JSUList<JKRDisposer> mDisposerList;
-    bool mErrorFlag;
-    bool mInitFlag;
-    u8 padding_0x6a[2];
+    /* 0x00 */ // vtable
+    /* 0x04 */ // JKRDisposer
+    /* 0x18 */ OSMutex mMutex;
+    /* 0x30 */ u32 mStart;
+    /* 0x34 */ u32 mEnd;
+    /* 0x38 */ u32 mSize;
+    /* 0x3C */ bool mDebugFill;
+    /* 0x3D */ bool mCheckMemoryFilled;
+    /* 0x3E */ u8 mAllocationMode;  // EAllocMode?
+    /* 0x3F */ u8 mGroupId;
+    /* 0x40 */ JSUTree<JKRHeap> mChildTree;
+    /* 0x5C */ JSUList<JKRDisposer> mDisposerList;
+    /* 0x68 */ bool mErrorFlag;
+    /* 0x69 */ bool mInitFlag;
+    /* 0x6A */ u8 padding_0x6a[2];
 
 public:
     static bool initArena(char**, u32*, int);

--- a/include/dvd/dvd.h
+++ b/include/dvd/dvd.h
@@ -32,7 +32,7 @@ struct DVDDiskID {
 
 struct DVDFileInfo;
 struct DVDCommandBlock;
-typedef void (*DVDCBcallback)(s32 result, DVDCommandBlock* block);
+typedef void (*DVDCBCallback)(s32 result, DVDCommandBlock* block);
 typedef void (*DVDCallback)(s32 result, DVDFileInfo* info);
 
 struct DVDCommandBlock {
@@ -64,7 +64,7 @@ void DVDReadPrio(DVDFileInfo*, void*, s32, s32, s32);
 void DVDGetCurrentDiskID(void);
 s32 DVDFastOpen(long, DVDFileInfo*);
 int DVDGetCommandBlockStatus(DVDCommandBlock*);
-s32 DVDReadAsyncPrio(DVDFileInfo*, void*, long, long, void (*)(long, DVDFileInfo*), long);
+s32 DVDReadAsyncPrio(DVDFileInfo*, void*, long, long, DVDCallback, long);
 void DVDConvertPathToEntrynum(void);
 DVDState DVDGetDriveStatus(void);
 s32 DVDCheckDisk(void);

--- a/include/dvd/dvd.h
+++ b/include/dvd/dvd.h
@@ -20,7 +20,7 @@ typedef enum DVDState {
 } DVDState;
 }
 
-class DVDDiskID {
+struct DVDDiskID {
     char game_name[4];
     char company[2];
     u8 disk_number;
@@ -30,10 +30,9 @@ class DVDDiskID {
     u8 padding[22];
 };
 
-class DVDCommandBlock {
-public:
+struct DVDCommandBlock {
     DVDCommandBlock* next;
-    DVDCommandBlock* previous;
+    DVDCommandBlock* prev;
     u32 command;
     s32 state;
     u32 offset;
@@ -42,18 +41,15 @@ public:
     u32 current_transfer_size;
     u32 transferred_size;
     DVDDiskID* disk_id;
-    u8 callback[4];
+    DVDCBCallback callback;
     void* user_data;
 };
 
-// typedef void (*DVDCallback)(u32 result, DVDFileInfo *info);
-
-class DVDFileInfo {
-public:
+struct DVDFileInfo {
     DVDCommandBlock block;
     u32 start_address;
     u32 length;
-    u8 callback[4];
+    DVDCallback callback;
 };
 
 extern "C" {

--- a/include/dvd/dvd.h
+++ b/include/dvd/dvd.h
@@ -30,6 +30,11 @@ struct DVDDiskID {
     u8 padding[22];
 };
 
+struct DVDFileInfo;
+struct DVDCommandBlock;
+typedef void (*DVDCBcallback)(s32 result, DVDCommandBlock* block);
+typedef void (*DVDCallback)(s32 result, DVDFileInfo* info);
+
 struct DVDCommandBlock {
     DVDCommandBlock* next;
     DVDCommandBlock* prev;
@@ -58,7 +63,7 @@ s32 DVDClose(DVDFileInfo*);
 void DVDReadPrio(DVDFileInfo*, void*, s32, s32, s32);
 void DVDGetCurrentDiskID(void);
 s32 DVDFastOpen(long, DVDFileInfo*);
-int DVDGetCommandBlockStatus(DVDFileInfo*);
+int DVDGetCommandBlockStatus(DVDCommandBlock*);
 s32 DVDReadAsyncPrio(DVDFileInfo*, void*, long, long, void (*)(long, DVDFileInfo*), long);
 void DVDConvertPathToEntrynum(void);
 DVDState DVDGetDriveStatus(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -441,24 +441,6 @@ void initiate__6JUTXfbFUsUsP7JKRHeapl(void);
 void common_init__6JUTXfbFl(void);
 }
 
-// DVD
-// class DVDFileInfo;
-// extern "C" {
-// s32 DVDOpen(const char*, DVDFileInfo*);
-// s32 DVDClose(DVDFileInfo*);
-// void DVDReadPrio(DVDFileInfo*, void*, s32, s32, s32);
-// void DVDGetCurrentDiskID(void);
-// s32 DVDFastOpen(long, u8[48]);
-// int DVDGetCommandBlockStatus(u8[48]);
-// s32 DVDReadAsyncPrio(u8[48], void*, long, long, void (*)(long, DVDFileInfo*), long);
-// void DVDConvertPathToEntrynum(void);
-
-// void DVDChangeDir(void);
-// void DVDCloseDir(void);
-// void DVDOpenDir(void);
-// void DVDReadDir(void);
-// }
-
 class mDoCPd_c;
 extern "C" {
 void mDoCPd_c_NS_recalibrate(void);

--- a/include/global.h
+++ b/include/global.h
@@ -12,6 +12,8 @@ struct Vec {
     float x, y, z;
 };
 
+#define JUT_ASSERT(...)
+
 #include "dolphin/types.h"
 
 #include "ar/ARQ.h"

--- a/libs/JSystem/JKernel/JKRDisposer.cpp
+++ b/libs/JSystem/JKernel/JKRDisposer.cpp
@@ -2,17 +2,15 @@
 #include "JSystem/JKernel/JKRHeap/JKRHeap.h"
 #include "global.h"
 
-// #include "JSystem/JKernel/asm/func_802D147C.s"
 JKRDisposer::JKRDisposer() : mLink(this) {
-    this->mHeap = JKRHeap::findFromRoot(this);
-    if (this->mHeap) {
-        this->mHeap->appendDisposer(this);
+    mHeap = JKRHeap::findFromRoot(this);
+    if (mHeap) {
+        mHeap->appendDisposer(this);
     }
 }
 
-// #include "JSystem/JKernel/JKRDisposer/asm/func_802D14E4.s"
 JKRDisposer::~JKRDisposer() {
-    JKRHeap* heap = this->mHeap;
+    JKRHeap* heap = mHeap;
     if (heap) {
         heap->removeDisposer(this);
     }

--- a/libs/JSystem/JKernel/JKRDvdFile.cpp
+++ b/libs/JSystem/JKernel/JKRDvdFile.cpp
@@ -85,8 +85,7 @@ void JKRDvdFile::close() {
 }
 
 s32 JKRDvdFile::readData(void* param_1, long length, long param_3) {
-    // debug version have this:
-    // ASSERT((length & 0x1f) == 0);
+    JUT_ASSERT((length & 0x1f) == 0);
 
     OSLockMutex(&mMutex1);
     if (mOSThread) {

--- a/libs/JSystem/JKernel/JKRDvdFile.cpp
+++ b/libs/JSystem/JKernel/JKRDvdFile.cpp
@@ -32,16 +32,9 @@ asm JKRDvdFile::JKRDvdFile(long) {
 }
 #endif
 
-#ifndef NONMATCHING
 JKRDvdFile::~JKRDvdFile() {
     close();
 }
-#else
-asm JKRDvdFile::~JKRDvdFile() {
-    nofralloc
-#include "JSystem/JKernel/JKRDvdFile/asm/func_802D9748.s"
-}
-#endif
 
 void JKRDvdFile::initiate(void) {
     mDvdFile = this;

--- a/libs/JSystem/JKernel/JKRDvdFile.cpp
+++ b/libs/JSystem/JKernel/JKRDvdFile.cpp
@@ -104,8 +104,8 @@ s32 JKRDvdFile::readData(void* param_1, long length, long param_3) {
     mOSThread = OSGetCurrentThread();
 
     s32 result = -1;
-    s32 readAsyncResult = DVDReadAsyncPrio(&mFileInfo, param_1, length, param_3,
-                                           JKRDvdFile::doneProcess, 2);
+    s32 readAsyncResult =
+        DVDReadAsyncPrio(&mFileInfo, param_1, length, param_3, JKRDvdFile::doneProcess, 2);
     if (readAsyncResult) {
         result = sync();
     }

--- a/libs/JSystem/JKernel/JKRDvdFile.cpp
+++ b/libs/JSystem/JKernel/JKRDvdFile.cpp
@@ -56,7 +56,7 @@ void JKRDvdFile::initiate(void) {
 
 bool JKRDvdFile::open(const char* param_1) {
     if (!mIsAvailable) {
-        mIsAvailable = DVDOpen(param_1, mDvdCommandBlock);
+        mIsAvailable = DVDOpen(param_1, &mFileInfo);
         if (mIsAvailable) {
             lbl_8043436C.append(&mDvdLink);
             getStatus();
@@ -67,7 +67,7 @@ bool JKRDvdFile::open(const char* param_1) {
 
 bool JKRDvdFile::open(long param_1) {
     if (!mIsAvailable) {
-        mIsAvailable = DVDFastOpen(param_1, mDvdCommandBlock);
+        mIsAvailable = DVDFastOpen(param_1, &mFileInfo);
         if (mIsAvailable) {
             lbl_8043436C.append(&mDvdLink);
             getStatus();
@@ -78,7 +78,7 @@ bool JKRDvdFile::open(long param_1) {
 
 void JKRDvdFile::close() {
     if (mIsAvailable) {
-        s32 result = DVDClose(mDvdCommandBlock);
+        s32 result = DVDClose(&mFileInfo);
         if (result != 0) {
             mIsAvailable = false;
             lbl_8043436C.remove(&mDvdLink);
@@ -104,7 +104,7 @@ s32 JKRDvdFile::readData(void* param_1, long length, long param_3) {
     mOSThread = OSGetCurrentThread();
 
     s32 result = -1;
-    s32 readAsyncResult = DVDReadAsyncPrio(mDvdCommandBlock, param_1, length, param_3,
+    s32 readAsyncResult = DVDReadAsyncPrio(&mFileInfo, param_1, length, param_3,
                                            JKRDvdFile::doneProcess, 2);
     if (readAsyncResult) {
         result = sync();
@@ -136,5 +136,5 @@ void JKRDvdFile::doneProcess(long id, DVDFileInfo* fileInfo) {
 }
 
 s32 JKRDvdFile::getFileSize(void) const {
-    return mFileSize;
+    return mFileInfo.length;
 }

--- a/libs/JSystem/JKernel/JKRDvdFile.cpp
+++ b/libs/JSystem/JKernel/JKRDvdFile.cpp
@@ -2,14 +2,15 @@
 #include "global.h"
 
 JKRDvdFile::JKRDvdFile() : JKRFile(), mDvdLink(this) {
-    this->initiate();
+    initiate();
 }
 
+// end of fuctions is weird. instructions which should have been optimized out.
 #ifdef NONMATCHING
-JKRDvdFile::JKRDvdFile(char const* param_1) : JKRFile(), mDvdLink(this) {
-    this->initiate();
-    bool result = this->open(param_1);
-    this->mIsAvailable = result;
+JKRDvdFile::JKRDvdFile(const char* name) : JKRFile(), mDvdLink(this) {
+    initiate();
+    bool result = open(name);
+    mIsAvailable = result;
 }
 #else
 asm JKRDvdFile::JKRDvdFile(char const*) {
@@ -20,9 +21,9 @@ asm JKRDvdFile::JKRDvdFile(char const*) {
 
 #ifdef NONMATHCING
 JKRDvdFile::JKRDvdFile(long param_1) : JKRFile(), mDvdLink(this) {
-    this->initiate();
-    bool result = this->open(param_1);
-    this->mIsAvailable = result;
+    initiate();
+    bool result = open(param_1);
+    mIsAvailable = result;
 }
 #else
 asm JKRDvdFile::JKRDvdFile(long) {
@@ -33,7 +34,7 @@ asm JKRDvdFile::JKRDvdFile(long) {
 
 #ifndef NONMATCHING
 JKRDvdFile::~JKRDvdFile() {
-    this->close();
+    close();
 }
 #else
 asm JKRDvdFile::~JKRDvdFile() {
@@ -42,49 +43,45 @@ asm JKRDvdFile::~JKRDvdFile() {
 }
 #endif
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D97E4.s"
 void JKRDvdFile::initiate(void) {
-    this->mDvdFile = this;
-    OSInitMutex(&this->mMutex1);
-    OSInitMutex(&this->mMutex2);
-    OSInitMessageQueue(&this->mQueue2, this->mMessages2, 1);
-    OSInitMessageQueue(&this->mQueue1, this->mMessages1, 1);
-    this->mOSThread = NULL;
-    this->field_0x50 = 0;
-    this->field_0x58 = 0;
+    mDvdFile = this;
+    OSInitMutex(&mMutex1);
+    OSInitMutex(&mMutex2);
+    OSInitMessageQueue(&mMessageQueue2, &mMessage2, 1);
+    OSInitMessageQueue(&mMessageQueue1, &mMessage1, 1);
+    mOSThread = NULL;
+    field_0x50 = 0;
+    field_0x58 = 0;
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D9850.s"
-bool JKRDvdFile::open(char const* param_1) {
-    if (!this->mIsAvailable) {
-        this->mIsAvailable = DVDOpen(param_1, &this->file_info);
-        if (this->mIsAvailable) {
-            lbl_8043436C.append(&this->mDvdLink);
-            this->getStatus();
+bool JKRDvdFile::open(const char* param_1) {
+    if (!mIsAvailable) {
+        mIsAvailable = DVDOpen(param_1, mDvdCommandBlock);
+        if (mIsAvailable) {
+            lbl_8043436C.append(&mDvdLink);
+            getStatus();
         }
     }
-    return this->mIsAvailable;
+    return mIsAvailable;
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D98C4.s"
 bool JKRDvdFile::open(long param_1) {
-    if (!this->mIsAvailable) {
-        this->mIsAvailable = DVDFastOpen(param_1, &this->file_info);
-        if (this->mIsAvailable) {
-            lbl_8043436C.append(&this->mDvdLink);
-            this->getStatus();
+    if (!mIsAvailable) {
+        mIsAvailable = DVDFastOpen(param_1, mDvdCommandBlock);
+        if (mIsAvailable) {
+            lbl_8043436C.append(&mDvdLink);
+            getStatus();
         }
     }
-    return this->mIsAvailable;
+    return mIsAvailable;
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D9938.s"
 void JKRDvdFile::close() {
-    if (this->mIsAvailable) {
-        s32 result = DVDClose(&this->file_info);
+    if (mIsAvailable) {
+        s32 result = DVDClose(mDvdCommandBlock);
         if (result != 0) {
-            this->mIsAvailable = false;
-            lbl_8043436C.remove(&this->mDvdLink);
+            mIsAvailable = false;
+            lbl_8043436C.remove(&mDvdLink);
         } else {
             const char* filename = lbl_8039D260;       // "JKRDvdFile.cpp"
             const char* format = lbl_8039D260 + 0x0F;  // "%s"
@@ -94,56 +91,50 @@ void JKRDvdFile::close() {
     }
 }
 
-#define JUT_ASSERT(CONDITION)
-
-//#include "JSystem/JKernel/JKRDvdFile/asm/func_802D99B4.s"
 s32 JKRDvdFile::readData(void* param_1, long length, long param_3) {
-    JUT_ASSERT((length & 0x1f) == 0);
+    // debug version have this:
+    // ASSERT((length & 0x1f) == 0);
 
-    OSLockMutex(&this->mMutex1);
-    if (this->mOSThread) {
-        OSUnlockMutex(&this->mMutex1);
+    OSLockMutex(&mMutex1);
+    if (mOSThread) {
+        OSUnlockMutex(&mMutex1);
         return -1;
     }
 
-    this->mOSThread = OSGetCurrentThread();
+    mOSThread = OSGetCurrentThread();
 
     s32 result = -1;
-    s32 readAsyncResult =
-        DVDReadAsyncPrio(&this->file_info, param_1, length, param_3, JKRDvdFile::doneProcess, 2);
+    s32 readAsyncResult = DVDReadAsyncPrio(mDvdCommandBlock, param_1, length, param_3,
+                                           JKRDvdFile::doneProcess, 2);
     if (readAsyncResult) {
-        result = this->sync();
+        result = sync();
     }
 
-    this->mOSThread = NULL;
-    OSUnlockMutex(&this->mMutex1);
+    mOSThread = NULL;
+    OSUnlockMutex(&mMutex1);
 
     return result;
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D9A68.s"
-s32 JKRDvdFile::writeData(void const*, long, long) {
+s32 JKRDvdFile::writeData(const void*, long, long) {
     return -1;
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D9A70.s"
 s32 JKRDvdFile::sync(void) {
     OSMessage message;
-    OSLockMutex(&this->mMutex1);
-    OSReceiveMessage(&this->mQueue2, &message, 1);
-    this->mOSThread = NULL;
-    OSUnlockMutex(&this->mMutex1);
+    OSLockMutex(&mMutex1);
+    OSReceiveMessage(&mMessageQueue2, &message, 1);
+    mOSThread = NULL;
+    OSUnlockMutex(&mMutex1);
     return (int)message;
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D9AC4.s"
 void JKRDvdFile::doneProcess(long id, DVDFileInfo* fileInfo) {
     // fileInfo->field_0x3c looks like some kind of user pointer?
     JKRDvdFile* dvdFile = *(JKRDvdFile**)((u8*)fileInfo + 0x3c);
-    OSSendMessage(&dvdFile->mQueue2, (OSMessage)id, 0);
+    OSSendMessage(&dvdFile->mMessageQueue2, (OSMessage)id, OS_MESSAGE_NON_BLOCKING);
 }
 
-// #include "JSystem/JKernel/JKRDvdFile/asm/func_802D9AF8.s"
 s32 JKRDvdFile::getFileSize(void) const {
-    return this->file_info.length;
+    return mFileSize;
 }

--- a/libs/JSystem/JKernel/JKRFile.cpp
+++ b/libs/JSystem/JKernel/JKRFile.cpp
@@ -1,10 +1,9 @@
 #include "JSystem/JKernel/JKRFile/JKRFile.h"
 #include "global.h"
 
-// #include "JSystem/JKernel/JKRFile/asm/func_802D9518.s"
-s32 JKRFile::read(void* data, s32 size, long param_3) {
+s32 JKRFile::read(void* data, s32 size, long offset) {
     while (true) {
-        s32 result = this->readData(data, size, param_3);
+        s32 result = readData(data, size, offset);
         if (size != result)
             VIWaitForRetrace();
         else

--- a/libs/JSystem/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/JKernel/JKRHeap.cpp
@@ -1,44 +1,43 @@
 #include "JSystem/JKernel/JKRHeap/JKRHeap.h"
 #include "global.h"
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE138.s"
-JKRHeap::JKRHeap(void* data, u32 size, JKRHeap* parent, bool error_flag)
+JKRHeap::JKRHeap(void* data, u32 size, JKRHeap* parent, bool errorFlag)
     : JKRDisposer(), mChildTree(this), mDisposerList() {
-    OSInitMutex(&this->mMutex);
-    this->mSize = size;
-    this->mStart = (u32)data;
-    this->mEnd = (u32)data + size;
+    OSInitMutex(&mMutex);
+    mSize = size;
+    mStart = (u32)data;
+    mEnd = (u32)data + size;
 
     if (parent == NULL) {
-        this->becomeSystemHeap();
-        this->becomeCurrentHeap();
+        becomeSystemHeap();
+        becomeCurrentHeap();
     } else {
-        parent->mChildTree.appendChild(&this->mChildTree);
+        parent->mChildTree.appendChild(&mChildTree);
 
         if (lbl_80451370 == lbl_80451378) {
-            this->becomeSystemHeap();
+            becomeSystemHeap();
         }
         if (lbl_80451374 == lbl_80451378) {
-            this->becomeCurrentHeap();
+            becomeCurrentHeap();
         }
     }
 
-    this->mErrorFlag = error_flag;
-    if ((this->mErrorFlag == true) && (lbl_8045137C == NULL)) {
+    mErrorFlag = errorFlag;
+    if ((mErrorFlag == true) && (lbl_8045137C == NULL)) {
         lbl_8045137C = JKRHeap::JKRDefaultMemoryErrorRoutine;
     }
 
-    this->mDebugFill = lbl_804508B0;
-    this->mCheckMemoryFilled = lbl_80451380;
-    this->mInitFlag = false;
+    mDebugFill = lbl_804508B0;
+    mCheckMemoryFilled = lbl_80451380;
+    mInitFlag = false;
 }
 
 // using the wrong register for storing the results
 // lbl_80451370 = systemHeap;
 #ifdef NONMATCHING
 JKRHeap::~JKRHeap() {
-    JSUTree<JKRHeap>* parent = this->mChildTree.getParent();
-    parent->removeChild(&this->mChildTree);
+    JSUTree<JKRHeap>* parent = mChildTree.getParent();
+    parent->removeChild(&mChildTree);
 
     JSUTree<JKRHeap>* nextRootHeap = lbl_80451378->mChildTree.getFirstChild();
 
@@ -69,8 +68,6 @@ asm JKRHeap::~JKRHeap() {
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE264.s"
 }
 #endif
-
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE378.s"
 bool JKRHeap::initArena(char** memory, u32* size, int param_3) {
     u32 ram_start;
     u32 ram_end;
@@ -96,26 +93,22 @@ bool JKRHeap::initArena(char** memory, u32* size, int param_3) {
     return true;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE428.s"
 JKRHeap* JKRHeap::becomeSystemHeap() {
     JKRHeap* prev = lbl_80451370;
     lbl_80451370 = this;
     return prev;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE438.s"
 JKRHeap* JKRHeap::becomeCurrentHeap() {
     JKRHeap* prev = lbl_80451374;
     lbl_80451374 = this;
     return prev;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE448.s"
 void JKRHeap::destroy() {
-    this->do_destroy();
+    do_destroy();
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE474.s"
 void* JKRHeap::alloc(u32 size, int alignment, JKRHeap* heap) {
     if (heap != NULL) {
         return heap->alloc(size, alignment);
@@ -128,12 +121,10 @@ void* JKRHeap::alloc(u32 size, int alignment, JKRHeap* heap) {
     return NULL;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE4D4.s"
 void* JKRHeap::alloc(u32 size, int alignment) {
-    return this->do_alloc(size, alignment);
+    return do_alloc(size, alignment);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE500.s"
 void JKRHeap::free(void* ptr, JKRHeap* heap) {
     if (!heap) {
         heap = findFromRoot(ptr);
@@ -144,9 +135,8 @@ void JKRHeap::free(void* ptr, JKRHeap* heap) {
     heap->free(ptr);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE548.s"
 void JKRHeap::free(void* ptr) {
-    this->do_free(ptr);
+    do_free(ptr);
 }
 
 asm void JKRHeap::callAllDisposer() {
@@ -154,17 +144,14 @@ asm void JKRHeap::callAllDisposer() {
 #include "JSystem/JKernel/JKRHeap/asm/func_802CE574.s"
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE5CC.s"
 void JKRHeap::freeAll() {
-    this->do_freeAll();
+    do_freeAll();
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE5F8.s"
 void JKRHeap::freeTail() {
-    this->do_freeTail();
+    do_freeTail();
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE624.s"
 s32 JKRHeap::resize(void* ptr, u32 size, JKRHeap* heap) {
     if (!heap) {
         heap = findFromRoot(ptr);
@@ -175,12 +162,10 @@ s32 JKRHeap::resize(void* ptr, u32 size, JKRHeap* heap) {
     return heap->resize(ptr, size);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE684.s"
 s32 JKRHeap::resize(void* ptr, u32 size) {
-    return this->do_resize(ptr, size);
+    return do_resize(ptr, size);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE6B0.s"
 s32 JKRHeap::getSize(void* ptr, JKRHeap* heap) {
     if (!heap) {
         heap = findFromRoot(ptr);
@@ -191,36 +176,31 @@ s32 JKRHeap::getSize(void* ptr, JKRHeap* heap) {
     return heap->getSize(ptr);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE700.s"
 s32 JKRHeap::getSize(void* ptr) {
-    return this->do_getSize(ptr);
+    return do_getSize(ptr);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE72C.s"
 s32 JKRHeap::getFreeSize() {
-    return this->do_getFreeSize();
+    return do_getFreeSize();
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE758.s"
 void* JKRHeap::getMaxFreeBlock() {
-    return this->do_getMaxFreeBlock();
+    return do_getMaxFreeBlock();
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE784.s"
 s32 JKRHeap::getTotalFreeSize() {
-    return this->do_getTotalFreeSize();
+    return do_getTotalFreeSize();
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE7B0.s"
 u8 JKRHeap::changeGroupID(u8 param_1) {
-    return this->do_changeGroupID(param_1);
+    return do_changeGroupID(param_1);
 }
 
 // "not/nor" instruction in the wrong place
 #ifdef NONMATCHING
 s32 JKRHeap::getMaxAllocatableSize(int alignment) {
-    u32 maxFreeBlock = (u32)this->getMaxFreeBlock();
-    s32 freeSize = this->getFreeSize();
+    u32 maxFreeBlock = (u32)getMaxFreeBlock();
+    s32 freeSize = getFreeSize();
 
     u32 mask = alignment - 1U;
     s32 ptrOffset = mask & (alignment - (maxFreeBlock & 0xf));
@@ -234,7 +214,6 @@ asm s32 JKRHeap::getMaxAllocatableSize(int alignment) {
 }
 #endif
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE83C.s"
 JKRHeap* JKRHeap::findFromRoot(void* ptr) {
     if (lbl_80451378 == NULL) {
         return NULL;
@@ -247,10 +226,9 @@ JKRHeap* JKRHeap::findFromRoot(void* ptr) {
     return lbl_80451378->findAllHeap(ptr);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE894.s"
 JKRHeap* JKRHeap::find(void* ptr) const {
-    if (this->getStartAddr() <= ptr && ptr < this->getEndAddr()) {
-        const JSUTree<JKRHeap>& tree = this->mChildTree;
+    if (getStartAddr() <= ptr && ptr < getEndAddr()) {
+        const JSUTree<JKRHeap>& tree = mChildTree;
         if (tree.getNumChildren() != 0) {
             JSUTreeIterator<JKRHeap> iterator;
             for (iterator = tree.getFirstChild(); iterator != tree.getEndChild(); iterator++) {
@@ -268,9 +246,8 @@ JKRHeap* JKRHeap::find(void* ptr) const {
     return NULL;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE93C.s"
 JKRHeap* JKRHeap::findAllHeap(void* ptr) const {
-    const JSUTree<JKRHeap>& tree = this->mChildTree;
+    const JSUTree<JKRHeap>& tree = mChildTree;
     if (tree.getNumChildren() != 0) {
         JSUTreeIterator<JKRHeap> iterator;
         for (iterator = tree.getFirstChild(); iterator != tree.getEndChild(); iterator++) {
@@ -282,7 +259,7 @@ JKRHeap* JKRHeap::findAllHeap(void* ptr) const {
         }
     }
 
-    if (this->getStartAddr() <= ptr && ptr < this->getEndAddr()) {
+    if (getStartAddr() <= ptr && ptr < getEndAddr()) {
         // not sure about this... casting away const for now.
         return (JKRHeap*)this;
     }
@@ -290,19 +267,18 @@ JKRHeap* JKRHeap::findAllHeap(void* ptr) const {
     return NULL;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CE9E4.s"
 void JKRHeap::dispose_subroutine(u32 begin, u32 end) {
     JSUListIterator<JKRDisposer> last_iterator;
     JSUListIterator<JKRDisposer> next_iterator;
     JSUListIterator<JKRDisposer> iterator;
-    for (iterator = this->mDisposerList.getFirst(); iterator != this->mDisposerList.getEnd();
+    for (iterator = mDisposerList.getFirst(); iterator != mDisposerList.getEnd();
          iterator = next_iterator) {
         JKRDisposer* disposer = iterator.getObject();
 
         if ((void*)begin <= disposer && disposer < (void*)end) {
             disposer->~JKRDisposer();
             if (last_iterator == NULL) {
-                next_iterator = this->mDisposerList.getFirst();
+                next_iterator = mDisposerList.getFirst();
             } else {
                 next_iterator = last_iterator;
                 next_iterator++;
@@ -315,17 +291,15 @@ void JKRHeap::dispose_subroutine(u32 begin, u32 end) {
     }
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEA78.s"
 bool JKRHeap::dispose(void* ptr, u32 size) {
     u32 begin = (u32)ptr;
     u32 end = (u32)ptr + size;
-    this->dispose_subroutine(begin, end);
+    dispose_subroutine(begin, end);
     return false;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEAA0.s"
 void JKRHeap::dispose(void* begin, void* end) {
-    this->dispose_subroutine((u32)begin, (u32)end);
+    dispose_subroutine((u32)begin, (u32)end);
 }
 
 // missing stack variable?
@@ -334,7 +308,7 @@ void JKRHeap::dispose() {
     JKRDisposer* disposer;
     JSUListIterator<JKRDisposer> iterator;
 
-    JSUList<JKRDisposer>* list = &this->mDisposerList;
+    JSUList<JKRDisposer>* list = &mDisposerList;
     while (iterator = list->getFirst(), iterator != list->getEnd()) {
         disposer = iterator.getObject();
         disposer->~JKRDisposer();
@@ -347,7 +321,6 @@ asm void JKRHeap::dispose() {
 }
 #endif
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEB18.s"
 void JKRHeap::copyMemory(void* dst, void* src, u32 size) {
     u32 count = (size + 3) / 4;
 
@@ -361,7 +334,6 @@ void JKRHeap::copyMemory(void* dst, void* src, u32 size) {
     }
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEB40.s"
 void JKRHeap::JKRDefaultMemoryErrorRoutine(JKRHeap* heap, u32 size, int alignment) {
     const char* filename = lbl_8039CAD8;     // "JKRHeap.cpp"
     const char* format = lbl_8039CAD8 + 12;  // "%s"
@@ -369,31 +341,28 @@ void JKRHeap::JKRDefaultMemoryErrorRoutine(JKRHeap* heap, u32 size, int alignmen
     JUTException_NS_panic_f(filename, 0x33f, format, arg1);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEB78.s"
-bool JKRHeap::setErrorFlag(bool error_flag) {
-    bool prev = this->mErrorFlag;
-    this->mErrorFlag = error_flag;
+bool JKRHeap::setErrorFlag(bool errorFlag) {
+    bool prev = mErrorFlag;
+    mErrorFlag = errorFlag;
     return prev;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEB88.s"
-JKRErrorHandler JKRHeap::setErrorHandler(JKRErrorHandler error_handler) {
+JKRErrorHandler JKRHeap::setErrorHandler(JKRErrorHandler errorHandler) {
     JKRErrorHandler prev = (JKRErrorHandler)lbl_8045137C;
 
-    if (!error_handler) {
-        error_handler = (JKRErrorHandler)JKRHeap::JKRDefaultMemoryErrorRoutine;
+    if (!errorHandler) {
+        errorHandler = (JKRErrorHandler)JKRHeap::JKRDefaultMemoryErrorRoutine;
     }
 
-    lbl_8045137C = error_handler;
+    lbl_8045137C = errorHandler;
     return prev;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEBA8.s"
 bool JKRHeap::isSubHeap(JKRHeap* heap) const {
     if (!heap)
         return false;
 
-    const JSUTree<JKRHeap>& tree = this->mChildTree;
+    const JSUTree<JKRHeap>& tree = mChildTree;
     if (tree.getNumChildren() != 0) {
         JSUTreeIterator<JKRHeap> iterator;
         for (iterator = tree.getFirstChild(); iterator != tree.getEndChild(); ++iterator) {
@@ -412,42 +381,34 @@ bool JKRHeap::isSubHeap(JKRHeap* heap) const {
     return false;
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEC4C.s"
 void* operator new(u32 size) {
     return JKRHeap::alloc(size, 4, NULL);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEC74.s"
 void* operator new(u32 size, int alignment) {
     return JKRHeap::alloc(size, alignment, NULL);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CEC98.s"
 void* operator new(u32 size, JKRHeap* heap, int alignment) {
     return JKRHeap::alloc(size, alignment, heap);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CECC4.s"
 void* operator new[](u32 size) {
     return JKRHeap::alloc(size, 4, NULL);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CECEC.s"
 void* operator new[](u32 size, int alignment) {
     return JKRHeap::alloc(size, alignment, NULL);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CED10.s"
 void* operator new[](u32 size, JKRHeap* heap, int alignment) {
     return JKRHeap::alloc(size, alignment, heap);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CED3C.s"
 void operator delete(void* ptr) {
     JKRHeap::free(ptr, NULL);
 }
 
-// #include "JSystem/JKernel/JKRHeap/asm/func_802CED60.s"
 void operator delete[](void* ptr) {
     JKRHeap::free(ptr, NULL);
 }

--- a/libs/JSystem/JKernel/JKRThread.cpp
+++ b/libs/JSystem/JKernel/JKRThread.cpp
@@ -107,7 +107,7 @@ asm JKRThreadSwitch* JKRThreadSwitch::createManager(JKRHeap* heap) {
 asm JKRThread* JKRThreadSwitch::enter(JKRThread* param_1, int param_2) {
     nofralloc
 #include "JSystem/JKernel/JKRThread/asm/func_802D1A70.s"
-}
+}''
 
 asm void JKRThreadSwitch::callback(OSThread* param_1, OSThread* param_2) {
     nofralloc

--- a/libs/JSystem/JKernel/JKRThread.cpp
+++ b/libs/JSystem/JKernel/JKRThread.cpp
@@ -107,7 +107,7 @@ asm JKRThreadSwitch* JKRThreadSwitch::createManager(JKRHeap* heap) {
 asm JKRThread* JKRThreadSwitch::enter(JKRThread* param_1, int param_2) {
     nofralloc
 #include "JSystem/JKernel/JKRThread/asm/func_802D1A70.s"
-}''
+}
 
 asm void JKRThreadSwitch::callback(OSThread* param_1, OSThread* param_2) {
     nofralloc


### PR DESCRIPTION
Updated old JKernel code to follow the code style:
* removed this->
* added const
* added field offsets
* fixed naming
* removed // #include "XXX.s" for matched functions
* DVDFileInfo and DVDCommandBlock