### PR TITLE
diff.py: fix --lhs-name option

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -576,7 +576,7 @@ def dump_objfile() -> Tuple[str, ObjdumpCommand, ObjdumpCommand]:
     objdump_flags = ["-drz"]
     return (
         objfile,
-        (objdump_flags, refobjfile, args.start),
+        (objdump_flags, refobjfile, args.lhs_name or args.start),
         (objdump_flags + maybe_get_objdump_source_flags(), objfile, args.start),
     )
 


### PR DESCRIPTION
`--lhs-name SYMBOL` allows specifying a symbol in `expected/` to diff against, instead of using the same one on both sides of the diff. however, i didn't remember to patch one little thing during implementation for @notyourav , which made it useless. this fixes that!