### PR TITLE
Strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ ASFLAGS := -mgekko -I include
 LDFLAGS := -map $(MAP) -fp hard -nodefaults -w off
 
 # Compiler flags
-CFLAGS  += -Cpp_exceptions off -proc gekko -fp hard -O3 -nodefaults -msgstyle gcc -maxerrors 5 -enum int $(INCLUDES)
+CFLAGS  += -Cpp_exceptions off -proc gekko -fp hard -O3 -nodefaults -msgstyle gcc -str pool,readonly,reuse -RTTI off -maxerrors 5 -enum int $(INCLUDES)
 
 # elf2dol needs to know these in order to calculate sbss correctly.
 SDATA_PDHR := 9

--- a/asm/rodata/rodata_DynamicLink.s
+++ b/asm/rodata/rodata_DynamicLink.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a4a0 - 0x8039a7e8
+
+.global lbl_8039A4A0
+lbl_8039A4A0:
+.incbin "baserom.dol", 0x3974A0, 0x348
+

--- a/asm/rodata/rodata_GCN_mem_alloc.s
+++ b/asm/rodata/rodata_GCN_mem_alloc.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a21a8 - 0x803a2220
+
+.global lbl_803A21A8
+lbl_803A21A8:
+.incbin "baserom.dol", 0x39F1A8, 0x38
+
+.global lbl_803A21E0
+lbl_803A21E0:
+.incbin "baserom.dol", 0x39F1E0, 0x40
+

--- a/asm/rodata/rodata_J2DMatBlock.s
+++ b/asm/rodata/rodata_J2DMatBlock.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1c00 - 0x803a1c10
+
+.global lbl_803A1C00
+lbl_803A1C00:
+.incbin "baserom.dol", 0x39EC00, 0x10
+

--- a/asm/rodata/rodata_J2DPictureEx.s
+++ b/asm/rodata/rodata_J2DPictureEx.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1d50 - 0x803a1db8
+
+.global lbl_803A1D50
+lbl_803A1D50:
+.incbin "baserom.dol", 0x39ED50, 0x20
+
+.global lbl_803A1D70
+lbl_803A1D70:
+.incbin "baserom.dol", 0x39ED70, 0x20
+
+.global lbl_803A1D90
+lbl_803A1D90:
+.incbin "baserom.dol", 0x39ED90, 0x28
+

--- a/asm/rodata/rodata_J2DTevs.s
+++ b/asm/rodata/rodata_J2DTevs.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1b80 - 0x803a1c00
+
+.global lbl_803A1B80
+lbl_803A1B80:
+.incbin "baserom.dol", 0x39EB80, 0x20
+
+.global lbl_803A1BA0
+lbl_803A1BA0:
+.incbin "baserom.dol", 0x39EBA0, 0x24
+
+.global lbl_803A1BC4
+lbl_803A1BC4:
+.incbin "baserom.dol", 0x39EBC4, 0x1C
+
+.global lbl_803A1BE0
+lbl_803A1BE0:
+.incbin "baserom.dol", 0x39EBE0, 0x14
+
+.global lbl_803A1BF4
+lbl_803A1BF4:
+.incbin "baserom.dol", 0x39EBF4, 0xC
+

--- a/asm/rodata/rodata_J2DTextBox.s
+++ b/asm/rodata/rodata_J2DTextBox.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1c58 - 0x803a1c60
+
+.global lbl_803A1C58
+lbl_803A1C58:
+.incbin "baserom.dol", 0x39EC58, 0x8
+

--- a/asm/rodata/rodata_J2DTextBoxEx.s
+++ b/asm/rodata/rodata_J2DTextBoxEx.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1db8 - 0x803a1df8
+
+.global lbl_803A1DB8
+lbl_803A1DB8:
+.incbin "baserom.dol", 0x39EDB8, 0xC
+
+.global lbl_803A1DC4
+lbl_803A1DC4:
+.incbin "baserom.dol", 0x39EDC4, 0xC
+
+.global lbl_803A1DD0
+lbl_803A1DD0:
+.incbin "baserom.dol", 0x39EDD0, 0x10
+
+.global lbl_803A1DE0
+lbl_803A1DE0:
+.incbin "baserom.dol", 0x39EDE0, 0x10
+
+.global lbl_803A1DF0
+lbl_803A1DF0:
+.incbin "baserom.dol", 0x39EDF0, 0x8
+

--- a/asm/rodata/rodata_J2DWindow.s
+++ b/asm/rodata/rodata_J2DWindow.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1c10 - 0x803a1c58
+
+.global lbl_803A1C10
+lbl_803A1C10:
+.incbin "baserom.dol", 0x39EC10, 0x10
+
+.global lbl_803A1C20
+lbl_803A1C20:
+.incbin "baserom.dol", 0x39EC20, 0x10
+
+.global lbl_803A1C30
+lbl_803A1C30:
+.incbin "baserom.dol", 0x39EC30, 0x10
+
+.global lbl_803A1C40
+lbl_803A1C40:
+.incbin "baserom.dol", 0x39EC40, 0x18
+

--- a/asm/rodata/rodata_J2DWindowEx.s
+++ b/asm/rodata/rodata_J2DWindowEx.s
@@ -1,0 +1,55 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1c60 - 0x803a1d50
+
+.global lbl_803A1C60
+lbl_803A1C60:
+.incbin "baserom.dol", 0x39EC60, 0x10
+
+.global lbl_803A1C70
+lbl_803A1C70:
+.incbin "baserom.dol", 0x39EC70, 0x10
+
+.global lbl_803A1C80
+lbl_803A1C80:
+.incbin "baserom.dol", 0x39EC80, 0x10
+
+.global lbl_803A1C90
+lbl_803A1C90:
+.incbin "baserom.dol", 0x39EC90, 0x10
+
+.global lbl_803A1CA0
+lbl_803A1CA0:
+.incbin "baserom.dol", 0x39ECA0, 0x10
+
+.global lbl_803A1CB0
+lbl_803A1CB0:
+.incbin "baserom.dol", 0x39ECB0, 0x10
+
+.global lbl_803A1CC0
+lbl_803A1CC0:
+.incbin "baserom.dol", 0x39ECC0, 0x10
+
+.global lbl_803A1CD0
+lbl_803A1CD0:
+.incbin "baserom.dol", 0x39ECD0, 0x10
+
+.global lbl_803A1CE0
+lbl_803A1CE0:
+.incbin "baserom.dol", 0x39ECE0, 0x10
+
+.global lbl_803A1CF0
+lbl_803A1CF0:
+.incbin "baserom.dol", 0x39ECF0, 0x18
+
+.global lbl_803A1D08
+lbl_803A1D08:
+.incbin "baserom.dol", 0x39ED08, 0x18
+
+.global lbl_803A1D20
+lbl_803A1D20:
+.incbin "baserom.dol", 0x39ED20, 0x20
+
+.global lbl_803A1D40
+lbl_803A1D40:
+.incbin "baserom.dol", 0x39ED40, 0x10
+

--- a/asm/rodata/rodata_J3DAnmLoader.s
+++ b/asm/rodata/rodata_J3DAnmLoader.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2130 - 0x803a2170
+
+.global lbl_803A2130
+lbl_803A2130:
+.incbin "baserom.dol", 0x39F130, 0x40
+

--- a/asm/rodata/rodata_J3DClusterLoader.s
+++ b/asm/rodata/rodata_J3DClusterLoader.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2098 - 0x803a20b0
+
+.global lbl_803A2098
+lbl_803A2098:
+.incbin "baserom.dol", 0x39F098, 0x18
+

--- a/asm/rodata/rodata_J3DJoint.s
+++ b/asm/rodata/rodata_J3DJoint.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2068 - 0x803a2098
+
+.global lbl_803A2068
+lbl_803A2068:
+.incbin "baserom.dol", 0x39F068, 0xC
+
+.global lbl_803A2074
+lbl_803A2074:
+.incbin "baserom.dol", 0x39F074, 0xC
+
+.global lbl_803A2080
+lbl_803A2080:
+.incbin "baserom.dol", 0x39F080, 0xC
+
+.global lbl_803A208C
+lbl_803A208C:
+.incbin "baserom.dol", 0x39F08C, 0xC
+

--- a/asm/rodata/rodata_J3DMatBlock.s
+++ b/asm/rodata/rodata_J3DMatBlock.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1ea8 - 0x803a1ec8
+
+.global lbl_803A1EA8
+lbl_803A1EA8:
+.incbin "baserom.dol", 0x39EEA8, 0x20
+

--- a/asm/rodata/rodata_J3DModelLoader.s
+++ b/asm/rodata/rodata_J3DModelLoader.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a20b0 - 0x803a20e8
+
+.global lbl_803A20B0
+lbl_803A20B0:
+.incbin "baserom.dol", 0x39F0B0, 0x38
+

--- a/asm/rodata/rodata_J3DModelLoaderCalcSize.s
+++ b/asm/rodata/rodata_J3DModelLoaderCalcSize.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a20e8 - 0x803a2100
+
+.global lbl_803A20E8
+lbl_803A20E8:
+.incbin "baserom.dol", 0x39F0E8, 0x18
+

--- a/asm/rodata/rodata_J3DShape.s
+++ b/asm/rodata/rodata_J3DShape.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1e98 - 0x803a1ea8
+
+.global lbl_803A1E98
+lbl_803A1E98:
+.incbin "baserom.dol", 0x39EE98, 0x10
+

--- a/asm/rodata/rodata_J3DShapeFactory.s
+++ b/asm/rodata/rodata_J3DShapeFactory.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2100 - 0x803a2130
+
+.global lbl_803A2100
+lbl_803A2100:
+.incbin "baserom.dol", 0x39F100, 0x30
+

--- a/asm/rodata/rodata_J3DSkinDeform.s
+++ b/asm/rodata/rodata_J3DSkinDeform.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2008 - 0x803a2068
+
+.global lbl_803A2008
+lbl_803A2008:
+.incbin "baserom.dol", 0x39F008, 0x10
+
+.global lbl_803A2018
+lbl_803A2018:
+.incbin "baserom.dol", 0x39F018, 0x10
+
+.global lbl_803A2028
+lbl_803A2028:
+.incbin "baserom.dol", 0x39F028, 0x40
+

--- a/asm/rodata/rodata_J3DSys.s
+++ b/asm/rodata/rodata_J3DSys.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1df8 - 0x803a1e30
+
+.global lbl_803A1DF8
+lbl_803A1DF8:
+.incbin "baserom.dol", 0x39EDF8, 0x10
+
+.global lbl_803A1E08
+lbl_803A1E08:
+.incbin "baserom.dol", 0x39EE08, 0x10
+
+.global lbl_803A1E18
+lbl_803A1E18:
+.incbin "baserom.dol", 0x39EE18, 0x18
+

--- a/asm/rodata/rodata_J3DTevs.s
+++ b/asm/rodata/rodata_J3DTevs.s
@@ -1,0 +1,39 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1ec8 - 0x803a2008
+
+.global lbl_803A1EC8
+lbl_803A1EC8:
+.incbin "baserom.dol", 0x39EEC8, 0x34
+
+.global lbl_803A1EFC
+lbl_803A1EFC:
+.incbin "baserom.dol", 0x39EEFC, 0x20
+
+.global lbl_803A1F1C
+lbl_803A1F1C:
+.incbin "baserom.dol", 0x39EF1C, 0x64
+
+.global lbl_803A1F80
+lbl_803A1F80:
+.incbin "baserom.dol", 0x39EF80, 0x1C
+
+.global lbl_803A1F9C
+lbl_803A1F9C:
+.incbin "baserom.dol", 0x39EF9C, 0x14
+
+.global lbl_803A1FB0
+lbl_803A1FB0:
+.incbin "baserom.dol", 0x39EFB0, 0xC
+
+.global lbl_803A1FBC
+lbl_803A1FBC:
+.incbin "baserom.dol", 0x39EFBC, 0x2C
+
+.global lbl_803A1FE8
+lbl_803A1FE8:
+.incbin "baserom.dol", 0x39EFE8, 0x10
+
+.global lbl_803A1FF8
+lbl_803A1FF8:
+.incbin "baserom.dol", 0x39EFF8, 0x10
+

--- a/asm/rodata/rodata_J3DTransform.s
+++ b/asm/rodata/rodata_J3DTransform.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a1e30 - 0x803a1e98
+
+.global lbl_803A1E30
+lbl_803A1E30:
+.incbin "baserom.dol", 0x39EE30, 0x20
+
+.global lbl_803A1E50
+lbl_803A1E50:
+.incbin "baserom.dol", 0x39EE50, 0xC
+
+.global lbl_803A1E5C
+lbl_803A1E5C:
+.incbin "baserom.dol", 0x39EE5C, 0x30
+
+.global lbl_803A1E8C
+lbl_803A1E8C:
+.incbin "baserom.dol", 0x39EE8C, 0xC
+

--- a/asm/rodata/rodata_J3DUClipper.s
+++ b/asm/rodata/rodata_J3DUClipper.s
@@ -1,0 +1,27 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a948 - 0x8039a9f0
+
+.global lbl_8039A948
+lbl_8039A948:
+.incbin "baserom.dol", 0x397948, 0xC
+
+.global lbl_8039A954
+lbl_8039A954:
+.incbin "baserom.dol", 0x397954, 0xC
+
+.global lbl_8039A960
+lbl_8039A960:
+.incbin "baserom.dol", 0x397960, 0xC
+
+.global lbl_8039A96C
+lbl_8039A96C:
+.incbin "baserom.dol", 0x39796C, 0xC
+
+.global lbl_8039A978
+lbl_8039A978:
+.incbin "baserom.dol", 0x397978, 0xC
+
+.global lbl_8039A984
+lbl_8039A984:
+.incbin "baserom.dol", 0x397984, 0x6C
+

--- a/asm/rodata/rodata_JAISeMgr.s
+++ b/asm/rodata/rodata_JAISeMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b8f8 - 0x8039b910
+
+.global lbl_8039B8F8
+lbl_8039B8F8:
+.incbin "baserom.dol", 0x3988F8, 0x18
+

--- a/asm/rodata/rodata_JAISound.s
+++ b/asm/rodata/rodata_JAISound.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b910 - 0x8039b950
+
+.global lbl_8039B910
+lbl_8039B910:
+.incbin "baserom.dol", 0x398910, 0x40
+

--- a/asm/rodata/rodata_JASAiCtrl.s
+++ b/asm/rodata/rodata_JASAiCtrl.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b2e0 - 0x8039b338
+
+.global lbl_8039B2E0
+lbl_8039B2E0:
+.incbin "baserom.dol", 0x3982E0, 0x10
+
+.global lbl_8039B2F0
+lbl_8039B2F0:
+.incbin "baserom.dol", 0x3982F0, 0x48
+

--- a/asm/rodata/rodata_JASAramStream.s
+++ b/asm/rodata/rodata_JASAramStream.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b168 - 0x8039b190
+
+.global lbl_8039B168
+lbl_8039B168:
+.incbin "baserom.dol", 0x398168, 0xC
+
+.global lbl_8039B174
+lbl_8039B174:
+.incbin "baserom.dol", 0x398174, 0x1C
+

--- a/asm/rodata/rodata_JASAudioThread.s
+++ b/asm/rodata/rodata_JASAudioThread.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b338 - 0x8039b360
+
+.global lbl_8039B338
+lbl_8039B338:
+.incbin "baserom.dol", 0x398338, 0x28
+

--- a/asm/rodata/rodata_JASBank.s
+++ b/asm/rodata/rodata_JASBank.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b190 - 0x8039b1b8
+
+.global lbl_8039B190
+lbl_8039B190:
+.incbin "baserom.dol", 0x398190, 0xC
+
+.global lbl_8039B19C
+lbl_8039B19C:
+.incbin "baserom.dol", 0x39819C, 0x1C
+

--- a/asm/rodata/rodata_JASCalc.s
+++ b/asm/rodata/rodata_JASCalc.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039abb8 - 0x8039afd0
+
+.global lbl_8039ABB8
+lbl_8039ABB8:
+.incbin "baserom.dol", 0x397BB8, 0x400
+
+.global lbl_8039AFB8
+lbl_8039AFB8:
+.incbin "baserom.dol", 0x397FB8, 0x18
+

--- a/asm/rodata/rodata_JASDSPInterface.s
+++ b/asm/rodata/rodata_JASDSPInterface.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b360 - 0x8039b8b8
+
+.global lbl_8039B360
+lbl_8039B360:
+.incbin "baserom.dol", 0x398360, 0x40
+
+.global lbl_8039B3A0
+lbl_8039B3A0:
+.incbin "baserom.dol", 0x3983A0, 0x500
+
+.global lbl_8039B8A0
+lbl_8039B8A0:
+.incbin "baserom.dol", 0x3988A0, 0x18
+

--- a/asm/rodata/rodata_JASOscillator.s
+++ b/asm/rodata/rodata_JASOscillator.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b1d0 - 0x8039b2e0
+
+.global lbl_8039B1D0
+lbl_8039B1D0:
+.incbin "baserom.dol", 0x3981D0, 0x44
+
+.global lbl_8039B214
+lbl_8039B214:
+.incbin "baserom.dol", 0x398214, 0x44
+
+.global lbl_8039B258
+lbl_8039B258:
+.incbin "baserom.dol", 0x398258, 0x44
+
+.global lbl_8039B29C
+lbl_8039B29C:
+.incbin "baserom.dol", 0x39829C, 0x44
+

--- a/asm/rodata/rodata_JASSeqParser.s
+++ b/asm/rodata/rodata_JASSeqParser.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b018 - 0x8039b168
+
+.global lbl_8039B018
+lbl_8039B018:
+.incbin "baserom.dol", 0x398018, 0x150
+

--- a/asm/rodata/rodata_JASTrack.s
+++ b/asm/rodata/rodata_JASTrack.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039afd0 - 0x8039b018
+
+.global lbl_8039AFD0
+lbl_8039AFD0:
+.incbin "baserom.dol", 0x397FD0, 0x18
+
+.global lbl_8039AFE8
+lbl_8039AFE8:
+.incbin "baserom.dol", 0x397FE8, 0x18
+
+.global lbl_8039B000
+lbl_8039B000:
+.incbin "baserom.dol", 0x398000, 0x18
+

--- a/asm/rodata/rodata_JASVoiceBank.s
+++ b/asm/rodata/rodata_JASVoiceBank.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b1b8 - 0x8039b1d0
+
+.global lbl_8039B1B8
+lbl_8039B1B8:
+.incbin "baserom.dol", 0x3981B8, 0x18
+

--- a/asm/rodata/rodata_JAUSectionHeap.s
+++ b/asm/rodata/rodata_JAUSectionHeap.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b950 - 0x8039b9c0
+
+.global lbl_8039B950
+lbl_8039B950:
+.incbin "baserom.dol", 0x398950, 0x70
+

--- a/asm/rodata/rodata_JFWDisplay.s
+++ b/asm/rodata/rodata_JFWDisplay.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a878 - 0x8039a948
+
+.global lbl_8039A878
+lbl_8039A878:
+.incbin "baserom.dol", 0x397878, 0xD0
+

--- a/asm/rodata/rodata_JKRAram.s
+++ b/asm/rodata/rodata_JKRAram.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d078 - 0x8039d0b8
+
+.global lbl_8039D078
+lbl_8039D078:
+.incbin "baserom.dol", 0x39A078, 0x40
+

--- a/asm/rodata/rodata_JKRAramArchive.s
+++ b/asm/rodata/rodata_JKRAramArchive.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d188 - 0x8039d1b0
+
+.global lbl_8039D188
+lbl_8039D188:
+.incbin "baserom.dol", 0x39A188, 0x28
+

--- a/asm/rodata/rodata_JKRAramPiece.s
+++ b/asm/rodata/rodata_JKRAramPiece.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d0b8 - 0x8039d120
+
+.global lbl_8039D0B8
+lbl_8039D0B8:
+.incbin "baserom.dol", 0x39A0B8, 0x68
+

--- a/asm/rodata/rodata_JKRAramStream.s
+++ b/asm/rodata/rodata_JKRAramStream.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d120 - 0x8039d150
+
+.global lbl_8039D120
+lbl_8039D120:
+.incbin "baserom.dol", 0x39A120, 0x30
+

--- a/asm/rodata/rodata_JKRCompArchive.s
+++ b/asm/rodata/rodata_JKRCompArchive.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d220 - 0x8039d260
+
+.global lbl_8039D220
+lbl_8039D220:
+.incbin "baserom.dol", 0x39A220, 0x40
+

--- a/asm/rodata/rodata_JKRDvdArchive.s
+++ b/asm/rodata/rodata_JKRDvdArchive.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d1b0 - 0x8039d220
+
+.global lbl_8039D1B0
+lbl_8039D1B0:
+.incbin "baserom.dol", 0x39A1B0, 0x70
+

--- a/asm/rodata/rodata_JKRDvdFile.s
+++ b/asm/rodata/rodata_JKRDvdFile.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d260 - 0x8039d290
+
+.global lbl_8039D260
+lbl_8039D260:
+.incbin "baserom.dol", 0x39A260, 0x30
+

--- a/asm/rodata/rodata_JKRDvdRipper.s
+++ b/asm/rodata/rodata_JKRDvdRipper.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d290 - 0x8039d2f0
+
+.global lbl_8039D290
+lbl_8039D290:
+.incbin "baserom.dol", 0x39A290, 0x60
+

--- a/asm/rodata/rodata_JKRExpHeap.s
+++ b/asm/rodata/rodata_JKRExpHeap.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039caf0 - 0x8039ce50
+
+.global lbl_8039CAF0
+lbl_8039CAF0:
+.incbin "baserom.dol", 0x399AF0, 0x360
+

--- a/asm/rodata/rodata_JKRFileCache.s
+++ b/asm/rodata/rodata_JKRFileCache.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d158 - 0x8039d160
+
+.global lbl_8039D158
+lbl_8039D158:
+.incbin "baserom.dol", 0x39A158, 0x8
+

--- a/asm/rodata/rodata_JKRFileLoader.s
+++ b/asm/rodata/rodata_JKRFileLoader.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d150 - 0x8039d158
+
+.global lbl_8039D150
+lbl_8039D150:
+.incbin "baserom.dol", 0x39A150, 0x8
+

--- a/asm/rodata/rodata_JKRHeap.s
+++ b/asm/rodata/rodata_JKRHeap.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039cad8 - 0x8039caf0
+
+.global lbl_8039CAD8
+lbl_8039CAD8:
+.incbin "baserom.dol", 0x399AD8, 0x18
+

--- a/asm/rodata/rodata_JKRMemArchive.s
+++ b/asm/rodata/rodata_JKRMemArchive.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d160 - 0x8039d188
+
+.global lbl_8039D160
+lbl_8039D160:
+.incbin "baserom.dol", 0x39A160, 0x28
+

--- a/asm/rodata/rodata_JKRSolidHeap.s
+++ b/asm/rodata/rodata_JKRSolidHeap.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039ce50 - 0x8039cfa8
+
+.global lbl_8039CE50
+lbl_8039CE50:
+.incbin "baserom.dol", 0x399E50, 0x158
+

--- a/asm/rodata/rodata_JKRSolidHeap_padding.s
+++ b/asm/rodata/rodata_JKRSolidHeap_padding.s
@@ -1,0 +1,5 @@
+.include "macros.inc"
+.section .rodata, "a" 
+
+.byte 0x0
+

--- a/asm/rodata/rodata_JKRThread.s
+++ b/asm/rodata/rodata_JKRThread.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039cfa8 - 0x8039d078
+
+.global lbl_8039CFA8
+lbl_8039CFA8:
+.incbin "baserom.dol", 0x399FA8, 0xD0
+

--- a/asm/rodata/rodata_JUTCacheFont.s
+++ b/asm/rodata/rodata_JUTCacheFont.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d2f0 - 0x8039d360
+
+.global lbl_8039D2F0
+lbl_8039D2F0:
+.incbin "baserom.dol", 0x39A2F0, 0x70
+

--- a/asm/rodata/rodata_JUTConsole.s
+++ b/asm/rodata/rodata_JUTConsole.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d9a8 - 0x803a1b80
+
+.global lbl_8039D9A8
+lbl_8039D9A8:
+.incbin "baserom.dol", 0x39A9A8, 0x265C
+
+.global lbl_803A0004
+lbl_803A0004:
+.incbin "baserom.dol", 0x39D004, 0x1B7C
+

--- a/asm/rodata/rodata_JUTDirectPrint.s
+++ b/asm/rodata/rodata_JUTDirectPrint.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d9a0 - 0x8039d9a8
+
+.global lbl_8039D9A0
+lbl_8039D9A0:
+.incbin "baserom.dol", 0x39A9A0, 0x8
+

--- a/asm/rodata/rodata_JUTException.s
+++ b/asm/rodata/rodata_JUTException.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d490 - 0x8039d9a0
+
+.global lbl_8039D490
+lbl_8039D490:
+.incbin "baserom.dol", 0x39A490, 0x510
+

--- a/asm/rodata/rodata_JUTFontData_Ascfont_fix12.s
+++ b/asm/rodata/rodata_JUTFontData_Ascfont_fix12.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039da20 - 0x803a1b80
+
+.global lbl_8039DA20
+lbl_8039DA20:
+.incbin "baserom.dol", 0x39DA20, 0x25E4
+
+.global lbl_803A0004
+lbl_803A0004:
+.incbin "baserom.dol", 0x3A0004, 0x1B7C
+

--- a/asm/rodata/rodata_JUTPalette.s
+++ b/asm/rodata/rodata_JUTPalette.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d360 - 0x8039d390
+
+.global lbl_8039D360
+lbl_8039D360:
+.incbin "baserom.dol", 0x39A360, 0x30
+

--- a/asm/rodata/rodata_JUTResFont.s
+++ b/asm/rodata/rodata_JUTResFont.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039d390 - 0x8039d490
+
+.global lbl_8039D390
+lbl_8039D390:
+.incbin "baserom.dol", 0x39A390, 0xC
+
+.global lbl_8039D39C
+lbl_8039D39C:
+.incbin "baserom.dol", 0x39A39C, 0xC0
+
+.global lbl_8039D45C
+lbl_8039D45C:
+.incbin "baserom.dol", 0x39A45C, 0x34
+

--- a/asm/rodata/rodata_Padclamp.s
+++ b/asm/rodata/rodata_Padclamp.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2170 - 0x803a2180
+
+.global lbl_803A2170
+lbl_803A2170:
+.incbin "baserom.dol", 0x39F170, 0x10
+

--- a/asm/rodata/rodata_Z2Audience.s
+++ b/asm/rodata/rodata_Z2Audience.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039c220 - 0x8039c230
+
+.global lbl_8039C220
+lbl_8039C220:
+.incbin "baserom.dol", 0x399220, 0x10
+

--- a/asm/rodata/rodata_Z2AudioMgr.s
+++ b/asm/rodata/rodata_Z2AudioMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039ca58 - 0x8039cad8
+
+.global lbl_8039CA58
+lbl_8039CA58:
+.incbin "baserom.dol", 0x399A58, 0x80
+

--- a/asm/rodata/rodata_Z2EnvSeMgr.s
+++ b/asm/rodata/rodata_Z2EnvSeMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039c250 - 0x8039c260
+
+.global lbl_8039C250
+lbl_8039C250:
+.incbin "baserom.dol", 0x399250, 0x10
+

--- a/asm/rodata/rodata_Z2SceneMgr.s
+++ b/asm/rodata/rodata_Z2SceneMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039bfa8 - 0x8039c220
+
+.global lbl_8039BFA8
+lbl_8039BFA8:
+.incbin "baserom.dol", 0x398FA8, 0x278
+

--- a/asm/rodata/rodata_Z2SeMgr.s
+++ b/asm/rodata/rodata_Z2SeMgr.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b9f0 - 0x8039ba08
+
+.global lbl_8039B9F0
+lbl_8039B9F0:
+.incbin "baserom.dol", 0x3989F0, 0xC
+
+.global lbl_8039B9FC
+lbl_8039B9FC:
+.incbin "baserom.dol", 0x3989FC, 0xC
+

--- a/asm/rodata/rodata_Z2SeqMgr.s
+++ b/asm/rodata/rodata_Z2SeqMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039ba08 - 0x8039bc88
+
+.global lbl_8039BA08
+lbl_8039BA08:
+.incbin "baserom.dol", 0x398A08, 0x280
+

--- a/asm/rodata/rodata_Z2SoundMgr.s
+++ b/asm/rodata/rodata_Z2SoundMgr.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b9c0 - 0x8039b9f0
+
+.global lbl_8039B9C0
+lbl_8039B9C0:
+.incbin "baserom.dol", 0x3989C0, 0x10
+
+.global lbl_8039B9D0
+lbl_8039B9D0:
+.incbin "baserom.dol", 0x3989D0, 0x20
+

--- a/asm/rodata/rodata_Z2SoundObjMgr.s
+++ b/asm/rodata/rodata_Z2SoundObjMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039c240 - 0x8039c250
+
+.global lbl_8039C240
+lbl_8039C240:
+.incbin "baserom.dol", 0x399240, 0x10
+

--- a/asm/rodata/rodata_Z2SoundObject.s
+++ b/asm/rodata/rodata_Z2SoundObject.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039c230 - 0x8039c240
+
+.global lbl_8039C230
+lbl_8039C230:
+.incbin "baserom.dol", 0x399230, 0x10
+

--- a/asm/rodata/rodata_Z2SpeechMgr2.s
+++ b/asm/rodata/rodata_Z2SpeechMgr2.s
@@ -1,0 +1,103 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039c260 - 0x8039ca58
+
+.global lbl_8039C260
+lbl_8039C260:
+.incbin "baserom.dol", 0x399260, 0x64
+
+.global lbl_8039C2C4
+lbl_8039C2C4:
+.incbin "baserom.dol", 0x3992C4, 0xC
+
+.global lbl_8039C2D0
+lbl_8039C2D0:
+.incbin "baserom.dol", 0x3992D0, 0x64
+
+.global lbl_8039C334
+lbl_8039C334:
+.incbin "baserom.dol", 0x399334, 0xC
+
+.global lbl_8039C340
+lbl_8039C340:
+.incbin "baserom.dol", 0x399340, 0x64
+
+.global lbl_8039C3A4
+lbl_8039C3A4:
+.incbin "baserom.dol", 0x3993A4, 0xC
+
+.global lbl_8039C3B0
+lbl_8039C3B0:
+.incbin "baserom.dol", 0x3993B0, 0x64
+
+.global lbl_8039C414
+lbl_8039C414:
+.incbin "baserom.dol", 0x399414, 0xC
+
+.global lbl_8039C420
+lbl_8039C420:
+.incbin "baserom.dol", 0x399420, 0x6C
+
+.global lbl_8039C48C
+lbl_8039C48C:
+.incbin "baserom.dol", 0x39948C, 0x60
+
+.global lbl_8039C4EC
+lbl_8039C4EC:
+.incbin "baserom.dol", 0x3994EC, 0xC
+
+.global lbl_8039C4F8
+lbl_8039C4F8:
+.incbin "baserom.dol", 0x3994F8, 0x74
+
+.global lbl_8039C56C
+lbl_8039C56C:
+.incbin "baserom.dol", 0x39956C, 0x6C
+
+.global lbl_8039C5D8
+lbl_8039C5D8:
+.incbin "baserom.dol", 0x3995D8, 0x6C
+
+.global lbl_8039C644
+lbl_8039C644:
+.incbin "baserom.dol", 0x399644, 0x6C
+
+.global lbl_8039C6B0
+lbl_8039C6B0:
+.incbin "baserom.dol", 0x3996B0, 0x68
+
+.global lbl_8039C718
+lbl_8039C718:
+.incbin "baserom.dol", 0x399718, 0x6C
+
+.global lbl_8039C784
+lbl_8039C784:
+.incbin "baserom.dol", 0x399784, 0x6C
+
+.global lbl_8039C7F0
+lbl_8039C7F0:
+.incbin "baserom.dol", 0x3997F0, 0x54
+
+.global lbl_8039C844
+lbl_8039C844:
+.incbin "baserom.dol", 0x399844, 0x64
+
+.global lbl_8039C8A8
+lbl_8039C8A8:
+.incbin "baserom.dol", 0x3998A8, 0xC
+
+.global lbl_8039C8B4
+lbl_8039C8B4:
+.incbin "baserom.dol", 0x3998B4, 0x64
+
+.global lbl_8039C918
+lbl_8039C918:
+.incbin "baserom.dol", 0x399918, 0x68
+
+.global lbl_8039C980
+lbl_8039C980:
+.incbin "baserom.dol", 0x399980, 0xC
+
+.global lbl_8039C98C
+lbl_8039C98C:
+.incbin "baserom.dol", 0x39998C, 0xCC
+

--- a/asm/rodata/rodata_Z2StatusMgr.s
+++ b/asm/rodata/rodata_Z2StatusMgr.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039bc88 - 0x8039bfa8
+
+.global lbl_8039BC88
+lbl_8039BC88:
+.incbin "baserom.dol", 0x398C88, 0x320
+

--- a/asm/rodata/rodata_alloc.s
+++ b/asm/rodata/rodata_alloc.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2220 - 0x803a2238
+
+.global lbl_803A2220
+lbl_803A2220:
+.incbin "baserom.dol", 0x39F220, 0x18
+

--- a/asm/rodata/rodata_ansi_fp.s
+++ b/asm/rodata/rodata_ansi_fp.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2238 - 0x803a2318
+
+.global lbl_803A2238
+lbl_803A2238:
+.incbin "baserom.dol", 0x39F238, 0xE0
+

--- a/asm/rodata/rodata_c_cc_d.s
+++ b/asm/rodata/rodata_c_cc_d.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a7e8 - 0x8039a868
+
+.global lbl_8039A7E8
+lbl_8039A7E8:
+.incbin "baserom.dol", 0x3977E8, 0x80
+

--- a/asm/rodata/rodata_c_dylink.s
+++ b/asm/rodata/rodata_c_dylink.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80374640 - 0x80378878
+
+.global lbl_80374640
+lbl_80374640:
+.incbin "baserom.dol", 0x371640, 0x17A8
+
+.global lbl_80375DE8
+lbl_80375DE8:
+.incbin "baserom.dol", 0x372DE8, 0x2A90
+

--- a/asm/rodata/rodata_c_xyz.s
+++ b/asm/rodata/rodata_c_xyz.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a868 - 0x8039a878
+
+.global lbl_8039A868
+lbl_8039A868:
+.incbin "baserom.dol", 0x397868, 0x10
+

--- a/asm/rodata/rodata_control.s
+++ b/asm/rodata/rodata_control.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039aba8 - 0x8039abb8
+
+.global lbl_8039ABA8
+lbl_8039ABA8:
+.incbin "baserom.dol", 0x397BA8, 0x10
+

--- a/asm/rodata/rodata_d_a_alink.s
+++ b/asm/rodata/rodata_d_a_alink.s
@@ -1,0 +1,1115 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8038d658 - 0x80392640
+
+.global lbl_8038D658
+lbl_8038D658:
+.incbin "baserom.dol", 0x38A658, 0xC
+
+.global lbl_8038D664
+lbl_8038D664:
+.incbin "baserom.dol", 0x38A664, 0x58
+
+.global lbl_8038D6BC
+lbl_8038D6BC:
+.incbin "baserom.dol", 0x38A6BC, 0x58
+
+.global lbl_8038D714
+lbl_8038D714:
+.incbin "baserom.dol", 0x38A714, 0x54
+
+.global lbl_8038D768
+lbl_8038D768:
+.incbin "baserom.dol", 0x38A768, 0x54
+
+.global lbl_8038D7BC
+lbl_8038D7BC:
+.incbin "baserom.dol", 0x38A7BC, 0x70
+
+.global lbl_8038D82C
+lbl_8038D82C:
+.incbin "baserom.dol", 0x38A82C, 0x38
+
+.global lbl_8038D864
+lbl_8038D864:
+.incbin "baserom.dol", 0x38A864, 0x68
+
+.global lbl_8038D8CC
+lbl_8038D8CC:
+.incbin "baserom.dol", 0x38A8CC, 0x78
+
+.global lbl_8038D944
+lbl_8038D944:
+.incbin "baserom.dol", 0x38A944, 0x20
+
+.global lbl_8038D964
+lbl_8038D964:
+.incbin "baserom.dol", 0x38A964, 0x20
+
+.global lbl_8038D984
+lbl_8038D984:
+.incbin "baserom.dol", 0x38A984, 0x20
+
+.global lbl_8038D9A4
+lbl_8038D9A4:
+.incbin "baserom.dol", 0x38A9A4, 0x20
+
+.global lbl_8038D9C4
+lbl_8038D9C4:
+.incbin "baserom.dol", 0x38A9C4, 0x20
+
+.global lbl_8038D9E4
+lbl_8038D9E4:
+.incbin "baserom.dol", 0x38A9E4, 0x2C
+
+.global lbl_8038DA10
+lbl_8038DA10:
+.incbin "baserom.dol", 0x38AA10, 0x2C
+
+.global lbl_8038DA3C
+lbl_8038DA3C:
+.incbin "baserom.dol", 0x38AA3C, 0x2C
+
+.global lbl_8038DA68
+lbl_8038DA68:
+.incbin "baserom.dol", 0x38AA68, 0x2C
+
+.global lbl_8038DA94
+lbl_8038DA94:
+.incbin "baserom.dol", 0x38AA94, 0x2C
+
+.global lbl_8038DAC0
+lbl_8038DAC0:
+.incbin "baserom.dol", 0x38AAC0, 0x2C
+
+.global lbl_8038DAEC
+lbl_8038DAEC:
+.incbin "baserom.dol", 0x38AAEC, 0x54
+
+.global lbl_8038DB40
+lbl_8038DB40:
+.incbin "baserom.dol", 0x38AB40, 0x44
+
+.global lbl_8038DB84
+lbl_8038DB84:
+.incbin "baserom.dol", 0x38AB84, 0x98
+
+.global lbl_8038DC1C
+lbl_8038DC1C:
+.incbin "baserom.dol", 0x38AC1C, 0x20
+
+.global lbl_8038DC3C
+lbl_8038DC3C:
+.incbin "baserom.dol", 0x38AC3C, 0x20
+
+.global lbl_8038DC5C
+lbl_8038DC5C:
+.incbin "baserom.dol", 0x38AC5C, 0x20
+
+.global lbl_8038DC7C
+lbl_8038DC7C:
+.incbin "baserom.dol", 0x38AC7C, 0x20
+
+.global lbl_8038DC9C
+lbl_8038DC9C:
+.incbin "baserom.dol", 0x38AC9C, 0x54
+
+.global lbl_8038DCF0
+lbl_8038DCF0:
+.incbin "baserom.dol", 0x38ACF0, 0x1C
+
+.global lbl_8038DD0C
+lbl_8038DD0C:
+.incbin "baserom.dol", 0x38AD0C, 0x1C
+
+.global lbl_8038DD28
+lbl_8038DD28:
+.incbin "baserom.dol", 0x38AD28, 0x1C
+
+.global lbl_8038DD44
+lbl_8038DD44:
+.incbin "baserom.dol", 0x38AD44, 0x74
+
+.global lbl_8038DDB8
+lbl_8038DDB8:
+.incbin "baserom.dol", 0x38ADB8, 0x60
+
+.global lbl_8038DE18
+lbl_8038DE18:
+.incbin "baserom.dol", 0x38AE18, 0x74
+
+.global lbl_8038DE8C
+lbl_8038DE8C:
+.incbin "baserom.dol", 0x38AE8C, 0x9C
+
+.global lbl_8038DF28
+lbl_8038DF28:
+.incbin "baserom.dol", 0x38AF28, 0x24
+
+.global lbl_8038DF4C
+lbl_8038DF4C:
+.incbin "baserom.dol", 0x38AF4C, 0x24
+
+.global lbl_8038DF70
+lbl_8038DF70:
+.incbin "baserom.dol", 0x38AF70, 0x2C
+
+.global lbl_8038DF9C
+lbl_8038DF9C:
+.incbin "baserom.dol", 0x38AF9C, 0x80
+
+.global lbl_8038E01C
+lbl_8038E01C:
+.incbin "baserom.dol", 0x38B01C, 0x4C
+
+.global lbl_8038E068
+lbl_8038E068:
+.incbin "baserom.dol", 0x38B068, 0xB4
+
+.global lbl_8038E11C
+lbl_8038E11C:
+.incbin "baserom.dol", 0x38B11C, 0x48
+
+.global lbl_8038E164
+lbl_8038E164:
+.incbin "baserom.dol", 0x38B164, 0x54
+
+.global lbl_8038E1B8
+lbl_8038E1B8:
+.incbin "baserom.dol", 0x38B1B8, 0x28
+
+.global lbl_8038E1E0
+lbl_8038E1E0:
+.incbin "baserom.dol", 0x38B1E0, 0x14
+
+.global lbl_8038E1F4
+lbl_8038E1F4:
+.incbin "baserom.dol", 0x38B1F4, 0x1C
+
+.global lbl_8038E210
+lbl_8038E210:
+.incbin "baserom.dol", 0x38B210, 0x3C
+
+.global lbl_8038E24C
+lbl_8038E24C:
+.incbin "baserom.dol", 0x38B24C, 0x64
+
+.global lbl_8038E2B0
+lbl_8038E2B0:
+.incbin "baserom.dol", 0x38B2B0, 0xBC
+
+.global lbl_8038E36C
+lbl_8038E36C:
+.incbin "baserom.dol", 0x38B36C, 0xBC
+
+.global lbl_8038E428
+lbl_8038E428:
+.incbin "baserom.dol", 0x38B428, 0x2C
+
+.global lbl_8038E454
+lbl_8038E454:
+.incbin "baserom.dol", 0x38B454, 0x48
+
+.global lbl_8038E49C
+lbl_8038E49C:
+.incbin "baserom.dol", 0x38B49C, 0x24
+
+.global lbl_8038E4C0
+lbl_8038E4C0:
+.incbin "baserom.dol", 0x38B4C0, 0x8C
+
+.global lbl_8038E54C
+lbl_8038E54C:
+.incbin "baserom.dol", 0x38B54C, 0x58
+
+.global lbl_8038E5A4
+lbl_8038E5A4:
+.incbin "baserom.dol", 0x38B5A4, 0x6C
+
+.global lbl_8038E610
+lbl_8038E610:
+.incbin "baserom.dol", 0x38B610, 0x48
+
+.global lbl_8038E658
+lbl_8038E658:
+.incbin "baserom.dol", 0x38B658, 0x70
+
+.global lbl_8038E6C8
+lbl_8038E6C8:
+.incbin "baserom.dol", 0x38B6C8, 0x4C
+
+.global lbl_8038E714
+lbl_8038E714:
+.incbin "baserom.dol", 0x38B714, 0x4C
+
+.global lbl_8038E760
+lbl_8038E760:
+.incbin "baserom.dol", 0x38B760, 0x1C
+
+.global lbl_8038E77C
+lbl_8038E77C:
+.incbin "baserom.dol", 0x38B77C, 0x50
+
+.global lbl_8038E7CC
+lbl_8038E7CC:
+.incbin "baserom.dol", 0x38B7CC, 0x28
+
+.global lbl_8038E7F4
+lbl_8038E7F4:
+.incbin "baserom.dol", 0x38B7F4, 0x4C
+
+.global lbl_8038E840
+lbl_8038E840:
+.incbin "baserom.dol", 0x38B840, 0x30
+
+.global lbl_8038E870
+lbl_8038E870:
+.incbin "baserom.dol", 0x38B870, 0x9C
+
+.global lbl_8038E90C
+lbl_8038E90C:
+.incbin "baserom.dol", 0x38B90C, 0xB4
+
+.global lbl_8038E9C0
+lbl_8038E9C0:
+.incbin "baserom.dol", 0x38B9C0, 0x70
+
+.global lbl_8038EA30
+lbl_8038EA30:
+.incbin "baserom.dol", 0x38BA30, 0x40
+
+.global lbl_8038EA70
+lbl_8038EA70:
+.incbin "baserom.dol", 0x38BA70, 0x8C
+
+.global lbl_8038EAFC
+lbl_8038EAFC:
+.incbin "baserom.dol", 0x38BAFC, 0x38
+
+.global lbl_8038EB34
+lbl_8038EB34:
+.incbin "baserom.dol", 0x38BB34, 0x1C
+
+.global lbl_8038EB50
+lbl_8038EB50:
+.incbin "baserom.dol", 0x38BB50, 0x3C
+
+.global lbl_8038EB8C
+lbl_8038EB8C:
+.incbin "baserom.dol", 0x38BB8C, 0x70
+
+.global lbl_8038EBFC
+lbl_8038EBFC:
+.incbin "baserom.dol", 0x38BBFC, 0x4C
+
+.global lbl_8038EC48
+lbl_8038EC48:
+.incbin "baserom.dol", 0x38BC48, 0xE4
+
+.global lbl_8038ED2C
+lbl_8038ED2C:
+.incbin "baserom.dol", 0x38BD2C, 0xFC
+
+.global lbl_8038EE28
+lbl_8038EE28:
+.incbin "baserom.dol", 0x38BE28, 0x100
+
+.global lbl_8038EF28
+lbl_8038EF28:
+.incbin "baserom.dol", 0x38BF28, 0x48
+
+.global lbl_8038EF70
+lbl_8038EF70:
+.incbin "baserom.dol", 0x38BF70, 0x38
+
+.global lbl_8038EFA8
+lbl_8038EFA8:
+.incbin "baserom.dol", 0x38BFA8, 0x68
+
+.global lbl_8038F010
+lbl_8038F010:
+.incbin "baserom.dol", 0x38C010, 0x38
+
+.global lbl_8038F048
+lbl_8038F048:
+.incbin "baserom.dol", 0x38C048, 0x60
+
+.global lbl_8038F0A8
+lbl_8038F0A8:
+.incbin "baserom.dol", 0x38C0A8, 0x7C
+
+.global lbl_8038F124
+lbl_8038F124:
+.incbin "baserom.dol", 0x38C124, 0x14
+
+.global lbl_8038F138
+lbl_8038F138:
+.incbin "baserom.dol", 0x38C138, 0x4C
+
+.global lbl_8038F184
+lbl_8038F184:
+.incbin "baserom.dol", 0x38C184, 0x1C
+
+.global lbl_8038F1A0
+lbl_8038F1A0:
+.incbin "baserom.dol", 0x38C1A0, 0x9C
+
+.global lbl_8038F23C
+lbl_8038F23C:
+.incbin "baserom.dol", 0x38C23C, 0x60
+
+.global lbl_8038F29C
+lbl_8038F29C:
+.incbin "baserom.dol", 0x38C29C, 0x6C
+
+.global lbl_8038F308
+lbl_8038F308:
+.incbin "baserom.dol", 0x38C308, 0x6C
+
+.global lbl_8038F374
+lbl_8038F374:
+.incbin "baserom.dol", 0x38C374, 0x40
+
+.global lbl_8038F3B4
+lbl_8038F3B4:
+.incbin "baserom.dol", 0x38C3B4, 0x10
+
+.global lbl_8038F3C4
+lbl_8038F3C4:
+.incbin "baserom.dol", 0x38C3C4, 0x2C
+
+.global lbl_8038F3F0
+lbl_8038F3F0:
+.incbin "baserom.dol", 0x38C3F0, 0x7C
+
+.global lbl_8038F46C
+lbl_8038F46C:
+.incbin "baserom.dol", 0x38C46C, 0x38
+
+.global lbl_8038F4A4
+lbl_8038F4A4:
+.incbin "baserom.dol", 0x38C4A4, 0x3C
+
+.global lbl_8038F4E0
+lbl_8038F4E0:
+.incbin "baserom.dol", 0x38C4E0, 0x3C
+
+.global lbl_8038F51C
+lbl_8038F51C:
+.incbin "baserom.dol", 0x38C51C, 0x3C
+
+.global lbl_8038F558
+lbl_8038F558:
+.incbin "baserom.dol", 0x38C558, 0x20
+
+.global lbl_8038F578
+lbl_8038F578:
+.incbin "baserom.dol", 0x38C578, 0x3C
+
+.global lbl_8038F5B4
+lbl_8038F5B4:
+.incbin "baserom.dol", 0x38C5B4, 0x64
+
+.global lbl_8038F618
+lbl_8038F618:
+.incbin "baserom.dol", 0x38C618, 0x40
+
+.global lbl_8038F658
+lbl_8038F658:
+.incbin "baserom.dol", 0x38C658, 0x9C
+
+.global lbl_8038F6F4
+lbl_8038F6F4:
+.incbin "baserom.dol", 0x38C6F4, 0x54
+
+.global lbl_8038F748
+lbl_8038F748:
+.incbin "baserom.dol", 0x38C748, 0x5C
+
+.global lbl_8038F7A4
+lbl_8038F7A4:
+.incbin "baserom.dol", 0x38C7A4, 0x38
+
+.global lbl_8038F7DC
+lbl_8038F7DC:
+.incbin "baserom.dol", 0x38C7DC, 0x7C
+
+.global lbl_8038F858
+lbl_8038F858:
+.incbin "baserom.dol", 0x38C858, 0x5C
+
+.global lbl_8038F8B4
+lbl_8038F8B4:
+.incbin "baserom.dol", 0x38C8B4, 0xA8
+
+.global lbl_8038F95C
+lbl_8038F95C:
+.incbin "baserom.dol", 0x38C95C, 0x64
+
+.global lbl_8038F9C0
+lbl_8038F9C0:
+.incbin "baserom.dol", 0x38C9C0, 0x38
+
+.global lbl_8038F9F8
+lbl_8038F9F8:
+.incbin "baserom.dol", 0x38C9F8, 0x18
+
+.global lbl_8038FA10
+lbl_8038FA10:
+.incbin "baserom.dol", 0x38CA10, 0x10
+
+.global lbl_8038FA20
+lbl_8038FA20:
+.incbin "baserom.dol", 0x38CA20, 0x18
+
+.global lbl_8038FA38
+lbl_8038FA38:
+.incbin "baserom.dol", 0x38CA38, 0x10
+
+.global lbl_8038FA48
+lbl_8038FA48:
+.incbin "baserom.dol", 0x38CA48, 0xC
+
+.global lbl_8038FA54
+lbl_8038FA54:
+.incbin "baserom.dol", 0x38CA54, 0xC
+
+.global lbl_8038FA60
+lbl_8038FA60:
+.incbin "baserom.dol", 0x38CA60, 0xC
+
+.global lbl_8038FA6C
+lbl_8038FA6C:
+.incbin "baserom.dol", 0x38CA6C, 0xC
+
+.global lbl_8038FA78
+lbl_8038FA78:
+.incbin "baserom.dol", 0x38CA78, 0xC
+
+.global lbl_8038FA84
+lbl_8038FA84:
+.incbin "baserom.dol", 0x38CA84, 0xC
+
+.global lbl_8038FA90
+lbl_8038FA90:
+.incbin "baserom.dol", 0x38CA90, 0xC
+
+.global lbl_8038FA9C
+lbl_8038FA9C:
+.incbin "baserom.dol", 0x38CA9C, 0xC
+
+.global lbl_8038FAA8
+lbl_8038FAA8:
+.incbin "baserom.dol", 0x38CAA8, 0xC
+
+.global lbl_8038FAB4
+lbl_8038FAB4:
+.incbin "baserom.dol", 0x38CAB4, 0xC
+
+.global lbl_8038FAC0
+lbl_8038FAC0:
+.incbin "baserom.dol", 0x38CAC0, 0xC
+
+.global lbl_8038FACC
+lbl_8038FACC:
+.incbin "baserom.dol", 0x38CACC, 0xC
+
+.global lbl_8038FAD8
+lbl_8038FAD8:
+.incbin "baserom.dol", 0x38CAD8, 0xC
+
+.global lbl_8038FAE4
+lbl_8038FAE4:
+.incbin "baserom.dol", 0x38CAE4, 0xC
+
+.global lbl_8038FAF0
+lbl_8038FAF0:
+.incbin "baserom.dol", 0x38CAF0, 0xC
+
+.global lbl_8038FAFC
+lbl_8038FAFC:
+.incbin "baserom.dol", 0x38CAFC, 0xC
+
+.global lbl_8038FB08
+lbl_8038FB08:
+.incbin "baserom.dol", 0x38CB08, 0xC
+
+.global lbl_8038FB14
+lbl_8038FB14:
+.incbin "baserom.dol", 0x38CB14, 0xC
+
+.global lbl_8038FB20
+lbl_8038FB20:
+.incbin "baserom.dol", 0x38CB20, 0xC
+
+.global lbl_8038FB2C
+lbl_8038FB2C:
+.incbin "baserom.dol", 0x38CB2C, 0xC
+
+.global lbl_8038FB38
+lbl_8038FB38:
+.incbin "baserom.dol", 0x38CB38, 0xC
+
+.global lbl_8038FB44
+lbl_8038FB44:
+.incbin "baserom.dol", 0x38CB44, 0xC
+
+.global lbl_8038FB50
+lbl_8038FB50:
+.incbin "baserom.dol", 0x38CB50, 0xC
+
+.global lbl_8038FB5C
+lbl_8038FB5C:
+.incbin "baserom.dol", 0x38CB5C, 0x60
+
+.global lbl_8038FBBC
+lbl_8038FBBC:
+.incbin "baserom.dol", 0x38CBBC, 0x18
+
+.global lbl_8038FBD4
+lbl_8038FBD4:
+.incbin "baserom.dol", 0x38CBD4, 0x50
+
+.global lbl_8038FC24
+lbl_8038FC24:
+.incbin "baserom.dol", 0x38CC24, 0x14
+
+.global lbl_8038FC38
+lbl_8038FC38:
+.incbin "baserom.dol", 0x38CC38, 0x70
+
+.global lbl_8038FCA8
+lbl_8038FCA8:
+.incbin "baserom.dol", 0x38CCA8, 0x1368
+
+.global lbl_80391010
+lbl_80391010:
+.incbin "baserom.dol", 0x38E010, 0x498
+
+.global lbl_803914A8
+lbl_803914A8:
+.incbin "baserom.dol", 0x38E4A8, 0x28C
+
+.global lbl_80391734
+lbl_80391734:
+.incbin "baserom.dol", 0x38E734, 0xC
+
+.global lbl_80391740
+lbl_80391740:
+.incbin "baserom.dol", 0x38E740, 0x14
+
+.global lbl_80391754
+lbl_80391754:
+.incbin "baserom.dol", 0x38E754, 0x14
+
+.global lbl_80391768
+lbl_80391768:
+.incbin "baserom.dol", 0x38E768, 0x14
+
+.global lbl_8039177C
+lbl_8039177C:
+.incbin "baserom.dol", 0x38E77C, 0x14
+
+.global lbl_80391790
+lbl_80391790:
+.incbin "baserom.dol", 0x38E790, 0x14
+
+.global lbl_803917A4
+lbl_803917A4:
+.incbin "baserom.dol", 0x38E7A4, 0x14
+
+.global lbl_803917B8
+lbl_803917B8:
+.incbin "baserom.dol", 0x38E7B8, 0x14
+
+.global lbl_803917CC
+lbl_803917CC:
+.incbin "baserom.dol", 0x38E7CC, 0x14
+
+.global lbl_803917E0
+lbl_803917E0:
+.incbin "baserom.dol", 0x38E7E0, 0x14
+
+.global lbl_803917F4
+lbl_803917F4:
+.incbin "baserom.dol", 0x38E7F4, 0x14
+
+.global lbl_80391808
+lbl_80391808:
+.incbin "baserom.dol", 0x38E808, 0x50
+
+.global lbl_80391858
+lbl_80391858:
+.incbin "baserom.dol", 0x38E858, 0x60
+
+.global lbl_803918B8
+lbl_803918B8:
+.incbin "baserom.dol", 0x38E8B8, 0xC
+
+.global lbl_803918C4
+lbl_803918C4:
+.incbin "baserom.dol", 0x38E8C4, 0xC
+
+.global lbl_803918D0
+lbl_803918D0:
+.incbin "baserom.dol", 0x38E8D0, 0xC
+
+.global lbl_803918DC
+lbl_803918DC:
+.incbin "baserom.dol", 0x38E8DC, 0xC
+
+.global lbl_803918E8
+lbl_803918E8:
+.incbin "baserom.dol", 0x38E8E8, 0xC
+
+.global lbl_803918F4
+lbl_803918F4:
+.incbin "baserom.dol", 0x38E8F4, 0xC
+
+.global lbl_80391900
+lbl_80391900:
+.incbin "baserom.dol", 0x38E900, 0xC
+
+.global lbl_8039190C
+lbl_8039190C:
+.incbin "baserom.dol", 0x38E90C, 0xC
+
+.global lbl_80391918
+lbl_80391918:
+.incbin "baserom.dol", 0x38E918, 0xC
+
+.global lbl_80391924
+lbl_80391924:
+.incbin "baserom.dol", 0x38E924, 0xC
+
+.global lbl_80391930
+lbl_80391930:
+.incbin "baserom.dol", 0x38E930, 0xC
+
+.global lbl_8039193C
+lbl_8039193C:
+.incbin "baserom.dol", 0x38E93C, 0xC
+
+.global lbl_80391948
+lbl_80391948:
+.incbin "baserom.dol", 0x38E948, 0xC
+
+.global lbl_80391954
+lbl_80391954:
+.incbin "baserom.dol", 0x38E954, 0xC
+
+.global lbl_80391960
+lbl_80391960:
+.incbin "baserom.dol", 0x38E960, 0xC
+
+.global lbl_8039196C
+lbl_8039196C:
+.incbin "baserom.dol", 0x38E96C, 0xC
+
+.global lbl_80391978
+lbl_80391978:
+.incbin "baserom.dol", 0x38E978, 0xC
+
+.global lbl_80391984
+lbl_80391984:
+.incbin "baserom.dol", 0x38E984, 0xC
+
+.global lbl_80391990
+lbl_80391990:
+.incbin "baserom.dol", 0x38E990, 0xC
+
+.global lbl_8039199C
+lbl_8039199C:
+.incbin "baserom.dol", 0x38E99C, 0xC
+
+.global lbl_803919A8
+lbl_803919A8:
+.incbin "baserom.dol", 0x38E9A8, 0x30
+
+.global lbl_803919D8
+lbl_803919D8:
+.incbin "baserom.dol", 0x38E9D8, 0xC
+
+.global lbl_803919E4
+lbl_803919E4:
+.incbin "baserom.dol", 0x38E9E4, 0xC
+
+.global lbl_803919F0
+lbl_803919F0:
+.incbin "baserom.dol", 0x38E9F0, 0xC
+
+.global lbl_803919FC
+lbl_803919FC:
+.incbin "baserom.dol", 0x38E9FC, 0xC
+
+.global lbl_80391A08
+lbl_80391A08:
+.incbin "baserom.dol", 0x38EA08, 0xC
+
+.global lbl_80391A14
+lbl_80391A14:
+.incbin "baserom.dol", 0x38EA14, 0xC
+
+.global lbl_80391A20
+lbl_80391A20:
+.incbin "baserom.dol", 0x38EA20, 0xC
+
+.global lbl_80391A2C
+lbl_80391A2C:
+.incbin "baserom.dol", 0x38EA2C, 0xC
+
+.global lbl_80391A38
+lbl_80391A38:
+.incbin "baserom.dol", 0x38EA38, 0xC
+
+.global lbl_80391A44
+lbl_80391A44:
+.incbin "baserom.dol", 0x38EA44, 0xC
+
+.global lbl_80391A50
+lbl_80391A50:
+.incbin "baserom.dol", 0x38EA50, 0xC
+
+.global lbl_80391A5C
+lbl_80391A5C:
+.incbin "baserom.dol", 0x38EA5C, 0x100
+
+.global lbl_80391B5C
+lbl_80391B5C:
+.incbin "baserom.dol", 0x38EB5C, 0x20
+
+.global lbl_80391B7C
+lbl_80391B7C:
+.incbin "baserom.dol", 0x38EB7C, 0x10
+
+.global lbl_80391B8C
+lbl_80391B8C:
+.incbin "baserom.dol", 0x38EB8C, 0x14
+
+.global lbl_80391BA0
+lbl_80391BA0:
+.incbin "baserom.dol", 0x38EBA0, 0xC
+
+.global lbl_80391BAC
+lbl_80391BAC:
+.incbin "baserom.dol", 0x38EBAC, 0xC
+
+.global lbl_80391BB8
+lbl_80391BB8:
+.incbin "baserom.dol", 0x38EBB8, 0xC
+
+.global lbl_80391BC4
+lbl_80391BC4:
+.incbin "baserom.dol", 0x38EBC4, 0xC
+
+.global lbl_80391BD0
+lbl_80391BD0:
+.incbin "baserom.dol", 0x38EBD0, 0xC
+
+.global lbl_80391BDC
+lbl_80391BDC:
+.incbin "baserom.dol", 0x38EBDC, 0xC
+
+.global lbl_80391BE8
+lbl_80391BE8:
+.incbin "baserom.dol", 0x38EBE8, 0xC
+
+.global lbl_80391BF4
+lbl_80391BF4:
+.incbin "baserom.dol", 0x38EBF4, 0xC
+
+.global lbl_80391C00
+lbl_80391C00:
+.incbin "baserom.dol", 0x38EC00, 0xC
+
+.global lbl_80391C0C
+lbl_80391C0C:
+.incbin "baserom.dol", 0x38EC0C, 0xC
+
+.global lbl_80391C18
+lbl_80391C18:
+.incbin "baserom.dol", 0x38EC18, 0xC
+
+.global lbl_80391C24
+lbl_80391C24:
+.incbin "baserom.dol", 0x38EC24, 0xC
+
+.global lbl_80391C30
+lbl_80391C30:
+.incbin "baserom.dol", 0x38EC30, 0xC
+
+.global lbl_80391C3C
+lbl_80391C3C:
+.incbin "baserom.dol", 0x38EC3C, 0xC
+
+.global lbl_80391C48
+lbl_80391C48:
+.incbin "baserom.dol", 0x38EC48, 0xC
+
+.global lbl_80391C54
+lbl_80391C54:
+.incbin "baserom.dol", 0x38EC54, 0xC
+
+.global lbl_80391C60
+lbl_80391C60:
+.incbin "baserom.dol", 0x38EC60, 0xC
+
+.global lbl_80391C6C
+lbl_80391C6C:
+.incbin "baserom.dol", 0x38EC6C, 0xC
+
+.global lbl_80391C78
+lbl_80391C78:
+.incbin "baserom.dol", 0x38EC78, 0xC
+
+.global lbl_80391C84
+lbl_80391C84:
+.incbin "baserom.dol", 0x38EC84, 0x18
+
+.global lbl_80391C9C
+lbl_80391C9C:
+.incbin "baserom.dol", 0x38EC9C, 0x30
+
+.global lbl_80391CCC
+lbl_80391CCC:
+.incbin "baserom.dol", 0x38ECCC, 0xC
+
+.global lbl_80391CD8
+lbl_80391CD8:
+.incbin "baserom.dol", 0x38ECD8, 0x48
+
+.global lbl_80391D20
+lbl_80391D20:
+.incbin "baserom.dol", 0x38ED20, 0x18
+
+.global lbl_80391D38
+lbl_80391D38:
+.incbin "baserom.dol", 0x38ED38, 0xC
+
+.global lbl_80391D44
+lbl_80391D44:
+.incbin "baserom.dol", 0x38ED44, 0x10
+
+.global lbl_80391D54
+lbl_80391D54:
+.incbin "baserom.dol", 0x38ED54, 0xC
+
+.global lbl_80391D60
+lbl_80391D60:
+.incbin "baserom.dol", 0x38ED60, 0xC
+
+.global lbl_80391D6C
+lbl_80391D6C:
+.incbin "baserom.dol", 0x38ED6C, 0xC
+
+.global lbl_80391D78
+lbl_80391D78:
+.incbin "baserom.dol", 0x38ED78, 0xC
+
+.global lbl_80391D84
+lbl_80391D84:
+.incbin "baserom.dol", 0x38ED84, 0x10
+
+.global lbl_80391D94
+lbl_80391D94:
+.incbin "baserom.dol", 0x38ED94, 0x60
+
+.global lbl_80391DF4
+lbl_80391DF4:
+.incbin "baserom.dol", 0x38EDF4, 0xC
+
+.global lbl_80391E00
+lbl_80391E00:
+.incbin "baserom.dol", 0x38EE00, 0xC
+
+.global lbl_80391E0C
+lbl_80391E0C:
+.incbin "baserom.dol", 0x38EE0C, 0xC
+
+.global lbl_80391E18
+lbl_80391E18:
+.incbin "baserom.dol", 0x38EE18, 0xC
+
+.global lbl_80391E24
+lbl_80391E24:
+.incbin "baserom.dol", 0x38EE24, 0xC
+
+.global lbl_80391E30
+lbl_80391E30:
+.incbin "baserom.dol", 0x38EE30, 0xC
+
+.global lbl_80391E3C
+lbl_80391E3C:
+.incbin "baserom.dol", 0x38EE3C, 0xC
+
+.global lbl_80391E48
+lbl_80391E48:
+.incbin "baserom.dol", 0x38EE48, 0x30
+
+.global lbl_80391E78
+lbl_80391E78:
+.incbin "baserom.dol", 0x38EE78, 0x14
+
+.global lbl_80391E8C
+lbl_80391E8C:
+.incbin "baserom.dol", 0x38EE8C, 0x14
+
+.global lbl_80391EA0
+lbl_80391EA0:
+.incbin "baserom.dol", 0x38EEA0, 0x20
+
+.global lbl_80391EC0
+lbl_80391EC0:
+.incbin "baserom.dol", 0x38EEC0, 0xC
+
+.global lbl_80391ECC
+lbl_80391ECC:
+.incbin "baserom.dol", 0x38EECC, 0xC
+
+.global lbl_80391ED8
+lbl_80391ED8:
+.incbin "baserom.dol", 0x38EED8, 0xC
+
+.global lbl_80391EE4
+lbl_80391EE4:
+.incbin "baserom.dol", 0x38EEE4, 0xC
+
+.global lbl_80391EF0
+lbl_80391EF0:
+.incbin "baserom.dol", 0x38EEF0, 0xC
+
+.global lbl_80391EFC
+lbl_80391EFC:
+.incbin "baserom.dol", 0x38EEFC, 0xC
+
+.global lbl_80391F08
+lbl_80391F08:
+.incbin "baserom.dol", 0x38EF08, 0xC
+
+.global lbl_80391F14
+lbl_80391F14:
+.incbin "baserom.dol", 0x38EF14, 0xC
+
+.global lbl_80391F20
+lbl_80391F20:
+.incbin "baserom.dol", 0x38EF20, 0xC
+
+.global lbl_80391F2C
+lbl_80391F2C:
+.incbin "baserom.dol", 0x38EF2C, 0x18
+
+.global lbl_80391F44
+lbl_80391F44:
+.incbin "baserom.dol", 0x38EF44, 0xC
+
+.global lbl_80391F50
+lbl_80391F50:
+.incbin "baserom.dol", 0x38EF50, 0xC
+
+.global lbl_80391F5C
+lbl_80391F5C:
+.incbin "baserom.dol", 0x38EF5C, 0xC
+
+.global lbl_80391F68
+lbl_80391F68:
+.incbin "baserom.dol", 0x38EF68, 0xC
+
+.global lbl_80391F74
+lbl_80391F74:
+.incbin "baserom.dol", 0x38EF74, 0xC
+
+.global lbl_80391F80
+lbl_80391F80:
+.incbin "baserom.dol", 0x38EF80, 0xC
+
+.global lbl_80391F8C
+lbl_80391F8C:
+.incbin "baserom.dol", 0x38EF8C, 0xC
+
+.global lbl_80391F98
+lbl_80391F98:
+.incbin "baserom.dol", 0x38EF98, 0xC
+
+.global lbl_80391FA4
+lbl_80391FA4:
+.incbin "baserom.dol", 0x38EFA4, 0xC
+
+.global lbl_80391FB0
+lbl_80391FB0:
+.incbin "baserom.dol", 0x38EFB0, 0xC
+
+.global lbl_80391FBC
+lbl_80391FBC:
+.incbin "baserom.dol", 0x38EFBC, 0xC
+
+.global lbl_80391FC8
+lbl_80391FC8:
+.incbin "baserom.dol", 0x38EFC8, 0xC
+
+.global lbl_80391FD4
+lbl_80391FD4:
+.incbin "baserom.dol", 0x38EFD4, 0xC
+
+.global lbl_80391FE0
+lbl_80391FE0:
+.incbin "baserom.dol", 0x38EFE0, 0xC
+
+.global lbl_80391FEC
+lbl_80391FEC:
+.incbin "baserom.dol", 0x38EFEC, 0xC
+
+.global lbl_80391FF8
+lbl_80391FF8:
+.incbin "baserom.dol", 0x38EFF8, 0xC
+
+.global lbl_80392004
+lbl_80392004:
+.incbin "baserom.dol", 0x38F004, 0xC
+
+.global lbl_80392010
+lbl_80392010:
+.incbin "baserom.dol", 0x38F010, 0xC
+
+.global lbl_8039201C
+lbl_8039201C:
+.incbin "baserom.dol", 0x38F01C, 0xC
+
+.global lbl_80392028
+lbl_80392028:
+.incbin "baserom.dol", 0x38F028, 0xC
+
+.global lbl_80392034
+lbl_80392034:
+.incbin "baserom.dol", 0x38F034, 0xC
+
+.global lbl_80392040
+lbl_80392040:
+.incbin "baserom.dol", 0x38F040, 0xC
+
+.global lbl_8039204C
+lbl_8039204C:
+.incbin "baserom.dol", 0x38F04C, 0xC
+
+.global lbl_80392058
+lbl_80392058:
+.incbin "baserom.dol", 0x38F058, 0xC
+
+.global lbl_80392064
+lbl_80392064:
+.incbin "baserom.dol", 0x38F064, 0xC
+
+.global lbl_80392070
+lbl_80392070:
+.incbin "baserom.dol", 0x38F070, 0xC
+
+.global lbl_8039207C
+lbl_8039207C:
+.incbin "baserom.dol", 0x38F07C, 0xC
+
+.global lbl_80392088
+lbl_80392088:
+.incbin "baserom.dol", 0x38F088, 0xC
+
+.global lbl_80392094
+lbl_80392094:
+.incbin "baserom.dol", 0x38F094, 0x5AC
+

--- a/asm/rodata/rodata_d_a_itembase_static.s
+++ b/asm/rodata/rodata_d_a_itembase_static.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803792b0 - 0x803792e8
+
+.global lbl_803792B0
+lbl_803792B0:
+.incbin "baserom.dol", 0x3762B0, 0x38
+

--- a/asm/rodata/rodata_d_a_no_chg_room.s
+++ b/asm/rodata/rodata_d_a_no_chg_room.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80392640 - 0x80392680
+
+.global lbl_80392640
+lbl_80392640:
+.incbin "baserom.dol", 0x38F640, 0x40
+

--- a/asm/rodata/rodata_d_a_npc.s
+++ b/asm/rodata/rodata_d_a_npc.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80392680 - 0x80392a18
+
+.global lbl_80392680
+lbl_80392680:
+.incbin "baserom.dol", 0x38F680, 0x30
+
+.global lbl_803926B0
+lbl_803926B0:
+.incbin "baserom.dol", 0x38F6B0, 0x30
+
+.global lbl_803926E0
+lbl_803926E0:
+.incbin "baserom.dol", 0x38F6E0, 0x30
+
+.global lbl_80392710
+lbl_80392710:
+.incbin "baserom.dol", 0x38F710, 0x308
+

--- a/asm/rodata/rodata_d_a_npc_cd.s
+++ b/asm/rodata/rodata_d_a_npc_cd.s
@@ -1,0 +1,155 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80392a18 - 0x80393250
+
+.global lbl_80392A18
+lbl_80392A18:
+.incbin "baserom.dol", 0x38FA18, 0x18
+
+.global lbl_80392A30
+lbl_80392A30:
+.incbin "baserom.dol", 0x38FA30, 0x18
+
+.global lbl_80392A48
+lbl_80392A48:
+.incbin "baserom.dol", 0x38FA48, 0x18
+
+.global lbl_80392A60
+lbl_80392A60:
+.incbin "baserom.dol", 0x38FA60, 0x18
+
+.global lbl_80392A78
+lbl_80392A78:
+.incbin "baserom.dol", 0x38FA78, 0x18
+
+.global lbl_80392A90
+lbl_80392A90:
+.incbin "baserom.dol", 0x38FA90, 0x18
+
+.global lbl_80392AA8
+lbl_80392AA8:
+.incbin "baserom.dol", 0x38FAA8, 0x18
+
+.global lbl_80392AC0
+lbl_80392AC0:
+.incbin "baserom.dol", 0x38FAC0, 0x18
+
+.global lbl_80392AD8
+lbl_80392AD8:
+.incbin "baserom.dol", 0x38FAD8, 0x18
+
+.global lbl_80392AF0
+lbl_80392AF0:
+.incbin "baserom.dol", 0x38FAF0, 0x18
+
+.global lbl_80392B08
+lbl_80392B08:
+.incbin "baserom.dol", 0x38FB08, 0x18
+
+.global lbl_80392B20
+lbl_80392B20:
+.incbin "baserom.dol", 0x38FB20, 0x18
+
+.global lbl_80392B38
+lbl_80392B38:
+.incbin "baserom.dol", 0x38FB38, 0x18
+
+.global lbl_80392B50
+lbl_80392B50:
+.incbin "baserom.dol", 0x38FB50, 0x18
+
+.global lbl_80392B68
+lbl_80392B68:
+.incbin "baserom.dol", 0x38FB68, 0x18
+
+.global lbl_80392B80
+lbl_80392B80:
+.incbin "baserom.dol", 0x38FB80, 0x18
+
+.global lbl_80392B98
+lbl_80392B98:
+.incbin "baserom.dol", 0x38FB98, 0x18
+
+.global lbl_80392BB0
+lbl_80392BB0:
+.incbin "baserom.dol", 0x38FBB0, 0x18
+
+.global lbl_80392BC8
+lbl_80392BC8:
+.incbin "baserom.dol", 0x38FBC8, 0x18
+
+.global lbl_80392BE0
+lbl_80392BE0:
+.incbin "baserom.dol", 0x38FBE0, 0x18
+
+.global lbl_80392BF8
+lbl_80392BF8:
+.incbin "baserom.dol", 0x38FBF8, 0x18
+
+.global lbl_80392C10
+lbl_80392C10:
+.incbin "baserom.dol", 0x38FC10, 0x18
+
+.global lbl_80392C28
+lbl_80392C28:
+.incbin "baserom.dol", 0x38FC28, 0x18
+
+.global lbl_80392C40
+lbl_80392C40:
+.incbin "baserom.dol", 0x38FC40, 0x18
+
+.global lbl_80392C58
+lbl_80392C58:
+.incbin "baserom.dol", 0x38FC58, 0x18
+
+.global lbl_80392C70
+lbl_80392C70:
+.incbin "baserom.dol", 0x38FC70, 0x18
+
+.global lbl_80392C88
+lbl_80392C88:
+.incbin "baserom.dol", 0x38FC88, 0x18
+
+.global lbl_80392CA0
+lbl_80392CA0:
+.incbin "baserom.dol", 0x38FCA0, 0x18
+
+.global lbl_80392CB8
+lbl_80392CB8:
+.incbin "baserom.dol", 0x38FCB8, 0x18
+
+.global lbl_80392CD0
+lbl_80392CD0:
+.incbin "baserom.dol", 0x38FCD0, 0x18
+
+.global lbl_80392CE8
+lbl_80392CE8:
+.incbin "baserom.dol", 0x38FCE8, 0x48
+
+.global lbl_80392D30
+lbl_80392D30:
+.incbin "baserom.dol", 0x38FD30, 0x48
+
+.global lbl_80392D78
+lbl_80392D78:
+.incbin "baserom.dol", 0x38FD78, 0x50
+
+.global lbl_80392DC8
+lbl_80392DC8:
+.incbin "baserom.dol", 0x38FDC8, 0x50
+
+.global lbl_80392E18
+lbl_80392E18:
+.incbin "baserom.dol", 0x38FE18, 0x44
+
+.global lbl_80392E5C
+lbl_80392E5C:
+.incbin "baserom.dol", 0x38FE5C, 0x168
+
+.global lbl_80392FC4
+lbl_80392FC4:
+.incbin "baserom.dol", 0x38FFC4, 0x24
+
+.global lbl_80392FE8
+lbl_80392FE8:
+.incbin "baserom.dol", 0x38FFE8, 0x268
+

--- a/asm/rodata/rodata_d_a_npc_cd2.s
+++ b/asm/rodata/rodata_d_a_npc_cd2.s
@@ -1,0 +1,159 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80393250 - 0x80393d88
+
+.global lbl_80393250
+lbl_80393250:
+.incbin "baserom.dol", 0x390250, 0x18
+
+.global lbl_80393268
+lbl_80393268:
+.incbin "baserom.dol", 0x390268, 0x18
+
+.global lbl_80393280
+lbl_80393280:
+.incbin "baserom.dol", 0x390280, 0x18
+
+.global lbl_80393298
+lbl_80393298:
+.incbin "baserom.dol", 0x390298, 0x18
+
+.global lbl_803932B0
+lbl_803932B0:
+.incbin "baserom.dol", 0x3902B0, 0x18
+
+.global lbl_803932C8
+lbl_803932C8:
+.incbin "baserom.dol", 0x3902C8, 0x18
+
+.global lbl_803932E0
+lbl_803932E0:
+.incbin "baserom.dol", 0x3902E0, 0x18
+
+.global lbl_803932F8
+lbl_803932F8:
+.incbin "baserom.dol", 0x3902F8, 0x18
+
+.global lbl_80393310
+lbl_80393310:
+.incbin "baserom.dol", 0x390310, 0x18
+
+.global lbl_80393328
+lbl_80393328:
+.incbin "baserom.dol", 0x390328, 0x18
+
+.global lbl_80393340
+lbl_80393340:
+.incbin "baserom.dol", 0x390340, 0x18
+
+.global lbl_80393358
+lbl_80393358:
+.incbin "baserom.dol", 0x390358, 0x18
+
+.global lbl_80393370
+lbl_80393370:
+.incbin "baserom.dol", 0x390370, 0x18
+
+.global lbl_80393388
+lbl_80393388:
+.incbin "baserom.dol", 0x390388, 0x18
+
+.global lbl_803933A0
+lbl_803933A0:
+.incbin "baserom.dol", 0x3903A0, 0x18
+
+.global lbl_803933B8
+lbl_803933B8:
+.incbin "baserom.dol", 0x3903B8, 0x18
+
+.global lbl_803933D0
+lbl_803933D0:
+.incbin "baserom.dol", 0x3903D0, 0x18
+
+.global lbl_803933E8
+lbl_803933E8:
+.incbin "baserom.dol", 0x3903E8, 0x18
+
+.global lbl_80393400
+lbl_80393400:
+.incbin "baserom.dol", 0x390400, 0x18
+
+.global lbl_80393418
+lbl_80393418:
+.incbin "baserom.dol", 0x390418, 0x18
+
+.global lbl_80393430
+lbl_80393430:
+.incbin "baserom.dol", 0x390430, 0x18
+
+.global lbl_80393448
+lbl_80393448:
+.incbin "baserom.dol", 0x390448, 0x18
+
+.global lbl_80393460
+lbl_80393460:
+.incbin "baserom.dol", 0x390460, 0x18
+
+.global lbl_80393478
+lbl_80393478:
+.incbin "baserom.dol", 0x390478, 0x18
+
+.global lbl_80393490
+lbl_80393490:
+.incbin "baserom.dol", 0x390490, 0x18
+
+.global lbl_803934A8
+lbl_803934A8:
+.incbin "baserom.dol", 0x3904A8, 0x18
+
+.global lbl_803934C0
+lbl_803934C0:
+.incbin "baserom.dol", 0x3904C0, 0x18
+
+.global lbl_803934D8
+lbl_803934D8:
+.incbin "baserom.dol", 0x3904D8, 0x18
+
+.global lbl_803934F0
+lbl_803934F0:
+.incbin "baserom.dol", 0x3904F0, 0x18
+
+.global lbl_80393508
+lbl_80393508:
+.incbin "baserom.dol", 0x390508, 0x18
+
+.global lbl_80393520
+lbl_80393520:
+.incbin "baserom.dol", 0x390520, 0x68
+
+.global lbl_80393588
+lbl_80393588:
+.incbin "baserom.dol", 0x390588, 0x68
+
+.global lbl_803935F0
+lbl_803935F0:
+.incbin "baserom.dol", 0x3905F0, 0x1B0
+
+.global lbl_803937A0
+lbl_803937A0:
+.incbin "baserom.dol", 0x3907A0, 0x1B0
+
+.global lbl_80393950
+lbl_80393950:
+.incbin "baserom.dol", 0x390950, 0x44
+
+.global lbl_80393994
+lbl_80393994:
+.incbin "baserom.dol", 0x390994, 0x168
+
+.global lbl_80393AFC
+lbl_80393AFC:
+.incbin "baserom.dol", 0x390AFC, 0xC
+
+.global lbl_80393B08
+lbl_80393B08:
+.incbin "baserom.dol", 0x390B08, 0x68
+
+.global lbl_80393B70
+lbl_80393B70:
+.incbin "baserom.dol", 0x390B70, 0x218
+

--- a/asm/rodata/rodata_d_a_obj.s
+++ b/asm/rodata/rodata_d_a_obj.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379298 - 0x803792b0
+
+.global lbl_80379298
+lbl_80379298:
+.incbin "baserom.dol", 0x376298, 0x10
+
+.global lbl_803792A8
+lbl_803792A8:
+.incbin "baserom.dol", 0x3762A8, 0x8
+

--- a/asm/rodata/rodata_d_a_obj_item.s
+++ b/asm/rodata/rodata_d_a_obj_item.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80393d88 - 0x80393d98
+
+.global lbl_80393D88
+lbl_80393D88:
+.incbin "baserom.dol", 0x390D88, 0x10
+

--- a/asm/rodata/rodata_d_a_player.s
+++ b/asm/rodata/rodata_d_a_player.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80393da8 - 0x80393dc0
+
+.global lbl_80393DA8
+lbl_80393DA8:
+.incbin "baserom.dol", 0x390DA8, 0xC
+
+.global lbl_80393DB4
+lbl_80393DB4:
+.incbin "baserom.dol", 0x390DB4, 0xC
+

--- a/asm/rodata/rodata_d_a_shop_item_static.s
+++ b/asm/rodata/rodata_d_a_shop_item_static.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803792e8 - 0x803797f8
+
+.global lbl_803792E8
+lbl_803792E8:
+.incbin "baserom.dol", 0x3762E8, 0x450
+
+.global lbl_80379738
+lbl_80379738:
+.incbin "baserom.dol", 0x376738, 0xC0
+

--- a/asm/rodata/rodata_d_attention.s
+++ b/asm/rodata/rodata_d_attention.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a770 - 0x8037a780
+
+.global lbl_8037A770
+lbl_8037A770:
+.incbin "baserom.dol", 0x377770, 0x10
+

--- a/asm/rodata/rodata_d_bright_check.s
+++ b/asm/rodata/rodata_d_bright_check.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394910 - 0x803949f0
+
+.global lbl_80394910
+lbl_80394910:
+.incbin "baserom.dol", 0x391910, 0x28
+
+.global lbl_80394938
+lbl_80394938:
+.incbin "baserom.dol", 0x391938, 0x28
+
+.global lbl_80394960
+lbl_80394960:
+.incbin "baserom.dol", 0x391960, 0x50
+
+.global lbl_803949B0
+lbl_803949B0:
+.incbin "baserom.dol", 0x3919B0, 0x28
+
+.global lbl_803949D8
+lbl_803949D8:
+.incbin "baserom.dol", 0x3919D8, 0x18
+

--- a/asm/rodata/rodata_d_cam_param.s
+++ b/asm/rodata/rodata_d_cam_param.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a7e0 - 0x8037a7f0
+
+.global lbl_8037A7E0
+lbl_8037A7E0:
+.incbin "baserom.dol", 0x3777E0, 0x10
+

--- a/asm/rodata/rodata_d_camera.s
+++ b/asm/rodata/rodata_d_camera.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80393dc0 - 0x80394308
+
+.global lbl_80393DC0
+lbl_80393DC0:
+.incbin "baserom.dol", 0x390DC0, 0x198
+
+.global lbl_80393F58
+lbl_80393F58:
+.incbin "baserom.dol", 0x390F58, 0x10
+
+.global lbl_80393F68
+lbl_80393F68:
+.incbin "baserom.dol", 0x390F68, 0x3A0
+

--- a/asm/rodata/rodata_d_cc_d.s
+++ b/asm/rodata/rodata_d_cc_d.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a780 - 0x8037a7e0
+
+.global lbl_8037A780
+lbl_8037A780:
+.incbin "baserom.dol", 0x377780, 0x60
+

--- a/asm/rodata/rodata_d_com_inf_game.s
+++ b/asm/rodata/rodata_d_com_inf_game.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80378f38 - 0x803790b0
+
+.global lbl_80378F38
+lbl_80378F38:
+.incbin "baserom.dol", 0x375F38, 0x178
+

--- a/asm/rodata/rodata_d_com_static.s
+++ b/asm/rodata/rodata_d_com_static.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803790b0 - 0x803790c0
+
+.global lbl_803790B0
+lbl_803790B0:
+.incbin "baserom.dol", 0x3760B0, 0x10
+

--- a/asm/rodata/rodata_d_demo.s
+++ b/asm/rodata/rodata_d_demo.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803797f8 - 0x80379840
+
+.global lbl_803797F8
+lbl_803797F8:
+.incbin "baserom.dol", 0x3767F8, 0x48
+

--- a/asm/rodata/rodata_d_drawlist.s
+++ b/asm/rodata/rodata_d_drawlist.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a178 - 0x8037a1c0
+
+.global lbl_8037A178
+lbl_8037A178:
+.incbin "baserom.dol", 0x377178, 0x2C
+
+.global lbl_8037A1A4
+lbl_8037A1A4:
+.incbin "baserom.dol", 0x3771A4, 0xC
+
+.global lbl_8037A1B0
+lbl_8037A1B0:
+.incbin "baserom.dol", 0x3771B0, 0x10
+

--- a/asm/rodata/rodata_d_envse.s
+++ b/asm/rodata/rodata_d_envse.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394308 - 0x80394310
+
+.global lbl_80394308
+lbl_80394308:
+.incbin "baserom.dol", 0x391308, 0x8
+

--- a/asm/rodata/rodata_d_error_msg.s
+++ b/asm/rodata/rodata_d_error_msg.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037b140 - 0x8038d658
+
+.global lbl_8037B140
+lbl_8037B140:
+.incbin "baserom.dol", 0x378140, 0x40
+
+.global lbl_8037B180
+lbl_8037B180:
+.incbin "baserom.dol", 0x378180, 0x260
+
+.global lbl_8037B3E0
+lbl_8037B3E0:
+.incbin "baserom.dol", 0x3783E0, 0x12260
+
+.global lbl_8038D640
+lbl_8038D640:
+.incbin "baserom.dol", 0x38A640, 0x18
+

--- a/asm/rodata/rodata_d_ev_camera.s
+++ b/asm/rodata/rodata_d_ev_camera.s
@@ -1,0 +1,63 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a7f0 - 0x8037ad68
+
+.global lbl_8037A7F0
+lbl_8037A7F0:
+.incbin "baserom.dol", 0x3777F0, 0xC
+
+.global lbl_8037A7FC
+lbl_8037A7FC:
+.incbin "baserom.dol", 0x3777FC, 0x10
+
+.global lbl_8037A80C
+lbl_8037A80C:
+.incbin "baserom.dol", 0x37780C, 0x1C
+
+.global lbl_8037A828
+lbl_8037A828:
+.incbin "baserom.dol", 0x377828, 0x1C
+
+.global lbl_8037A844
+lbl_8037A844:
+.incbin "baserom.dol", 0x377844, 0x14
+
+.global lbl_8037A858
+lbl_8037A858:
+.incbin "baserom.dol", 0x377858, 0x14
+
+.global lbl_8037A86C
+lbl_8037A86C:
+.incbin "baserom.dol", 0x37786C, 0x18
+
+.global lbl_8037A884
+lbl_8037A884:
+.incbin "baserom.dol", 0x377884, 0x18
+
+.global lbl_8037A89C
+lbl_8037A89C:
+.incbin "baserom.dol", 0x37789C, 0x16C
+
+.global lbl_8037AA08
+lbl_8037AA08:
+.incbin "baserom.dol", 0x377A08, 0x38
+
+.global lbl_8037AA40
+lbl_8037AA40:
+.incbin "baserom.dol", 0x377A40, 0x64
+
+.global lbl_8037AAA4
+lbl_8037AAA4:
+.incbin "baserom.dol", 0x377AA4, 0x18
+
+.global lbl_8037AABC
+lbl_8037AABC:
+.incbin "baserom.dol", 0x377ABC, 0x28
+
+.global lbl_8037AAE4
+lbl_8037AAE4:
+.incbin "baserom.dol", 0x377AE4, 0x10
+
+.global lbl_8037AAF4
+lbl_8037AAF4:
+.incbin "baserom.dol", 0x377AF4, 0x274
+

--- a/asm/rodata/rodata_d_event.s
+++ b/asm/rodata/rodata_d_event.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379d80 - 0x80379dd0
+
+.global lbl_80379D80
+lbl_80379D80:
+.incbin "baserom.dol", 0x376D80, 0x50
+

--- a/asm/rodata/rodata_d_event_data.s
+++ b/asm/rodata/rodata_d_event_data.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379dd0 - 0x80379f50
+
+.global lbl_80379DD0
+lbl_80379DD0:
+.incbin "baserom.dol", 0x376DD0, 0x180
+

--- a/asm/rodata/rodata_d_event_manager.s
+++ b/asm/rodata/rodata_d_event_manager.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379f50 - 0x8037a108
+
+.global lbl_80379F50
+lbl_80379F50:
+.incbin "baserom.dol", 0x376F50, 0x10
+
+.global lbl_80379F60
+lbl_80379F60:
+.incbin "baserom.dol", 0x376F60, 0x1A8
+

--- a/asm/rodata/rodata_d_eye_hl.s
+++ b/asm/rodata/rodata_d_eye_hl.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037b100 - 0x8037b140
+
+.global lbl_8037B100
+lbl_8037B100:
+.incbin "baserom.dol", 0x378100, 0x40
+

--- a/asm/rodata/rodata_d_file_sel_info.s
+++ b/asm/rodata/rodata_d_file_sel_info.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803948b8 - 0x80394910
+
+.global lbl_803948B8
+lbl_803948B8:
+.incbin "baserom.dol", 0x3918B8, 0x58
+

--- a/asm/rodata/rodata_d_file_sel_warning.s
+++ b/asm/rodata/rodata_d_file_sel_warning.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394828 - 0x803948b8
+
+.global lbl_80394828
+lbl_80394828:
+.incbin "baserom.dol", 0x391828, 0x90
+

--- a/asm/rodata/rodata_d_file_select.s
+++ b/asm/rodata/rodata_d_file_select.s
@@ -1,0 +1,31 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394310 - 0x80394828
+
+.global lbl_80394310
+lbl_80394310:
+.incbin "baserom.dol", 0x391310, 0x14
+
+.global lbl_80394324
+lbl_80394324:
+.incbin "baserom.dol", 0x391324, 0x14
+
+.global lbl_80394338
+lbl_80394338:
+.incbin "baserom.dol", 0x391338, 0x14
+
+.global lbl_8039434C
+lbl_8039434C:
+.incbin "baserom.dol", 0x39134C, 0x14
+
+.global lbl_80394360
+lbl_80394360:
+.incbin "baserom.dol", 0x391360, 0x14
+
+.global lbl_80394374
+lbl_80394374:
+.incbin "baserom.dol", 0x391374, 0x14
+
+.global lbl_80394388
+lbl_80394388:
+.incbin "baserom.dol", 0x391388, 0x4A0
+

--- a/asm/rodata/rodata_d_gameover.s
+++ b/asm/rodata/rodata_d_gameover.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394c28 - 0x80394c60
+
+.global lbl_80394C28
+lbl_80394C28:
+.incbin "baserom.dol", 0x391C28, 0x38
+

--- a/asm/rodata/rodata_d_insect.s
+++ b/asm/rodata/rodata_d_insect.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80393d98 - 0x80393da8
+
+.global lbl_80393D98
+lbl_80393D98:
+.incbin "baserom.dol", 0x390D98, 0x10
+

--- a/asm/rodata/rodata_d_item.s
+++ b/asm/rodata/rodata_d_item.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037b0d0 - 0x8037b0d8
+
+.global lbl_8037B0D0
+lbl_8037B0D0:
+.incbin "baserom.dol", 0x3780D0, 0x8
+

--- a/asm/rodata/rodata_d_item_data.s
+++ b/asm/rodata/rodata_d_item_data.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037ad68 - 0x8037b0d0
+
+.global lbl_8037AD68
+lbl_8037AD68:
+.incbin "baserom.dol", 0x377D68, 0x368
+

--- a/asm/rodata/rodata_d_k_wmark.s
+++ b/asm/rodata/rodata_d_k_wmark.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a488 - 0x8039a4a0
+
+.global lbl_8039A488
+lbl_8039A488:
+.incbin "baserom.dol", 0x397488, 0xC
+
+.global lbl_8039A494
+lbl_8039A494:
+.incbin "baserom.dol", 0x397494, 0xC
+

--- a/asm/rodata/rodata_d_kankyo.s
+++ b/asm/rodata/rodata_d_kankyo.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394c60 - 0x80394f38
+
+.global lbl_80394C60
+lbl_80394C60:
+.incbin "baserom.dol", 0x391C60, 0xC
+
+.global lbl_80394C6C
+lbl_80394C6C:
+.incbin "baserom.dol", 0x391C6C, 0x2CC
+

--- a/asm/rodata/rodata_d_kankyo_data.s
+++ b/asm/rodata/rodata_d_kankyo_data.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a1c0 - 0x8037a368
+
+.global lbl_8037A1C0
+lbl_8037A1C0:
+.incbin "baserom.dol", 0x3771C0, 0x1A8
+

--- a/asm/rodata/rodata_d_kankyo_rain.s
+++ b/asm/rodata/rodata_d_kankyo_rain.s
@@ -1,0 +1,31 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a4c0 - 0x8037a620
+
+.global lbl_8037A4C0
+lbl_8037A4C0:
+.incbin "baserom.dol", 0x3774C0, 0x28
+
+.global lbl_8037A4E8
+lbl_8037A4E8:
+.incbin "baserom.dol", 0x3774E8, 0x20
+
+.global lbl_8037A508
+lbl_8037A508:
+.incbin "baserom.dol", 0x377508, 0x20
+
+.global lbl_8037A528
+lbl_8037A528:
+.incbin "baserom.dol", 0x377528, 0x20
+
+.global lbl_8037A548
+lbl_8037A548:
+.incbin "baserom.dol", 0x377548, 0x20
+
+.global lbl_8037A568
+lbl_8037A568:
+.incbin "baserom.dol", 0x377568, 0x10
+
+.global lbl_8037A578
+lbl_8037A578:
+.incbin "baserom.dol", 0x377578, 0xA8
+

--- a/asm/rodata/rodata_d_kankyo_wether.s
+++ b/asm/rodata/rodata_d_kankyo_wether.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a368 - 0x8037a4c0
+
+.global lbl_8037A368
+lbl_8037A368:
+.incbin "baserom.dol", 0x377368, 0x158
+

--- a/asm/rodata/rodata_d_kantera_icon_meter.s
+++ b/asm/rodata/rodata_d_kantera_icon_meter.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394f50 - 0x80394f70
+
+.global lbl_80394F50
+lbl_80394F50:
+.incbin "baserom.dol", 0x391F50, 0x20
+

--- a/asm/rodata/rodata_d_ky_thunder.s
+++ b/asm/rodata/rodata_d_ky_thunder.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394f40 - 0x80394f50
+
+.global lbl_80394F40
+lbl_80394F40:
+.incbin "baserom.dol", 0x391F40, 0x10
+

--- a/asm/rodata/rodata_d_kyeff.s
+++ b/asm/rodata/rodata_d_kyeff.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394f38 - 0x80394f40
+
+.global lbl_80394F38
+lbl_80394F38:
+.incbin "baserom.dol", 0x391F38, 0x8
+

--- a/asm/rodata/rodata_d_map.s
+++ b/asm/rodata/rodata_d_map.s
@@ -1,0 +1,31 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80378e48 - 0x80378f38
+
+.global lbl_80378E48
+lbl_80378E48:
+.incbin "baserom.dol", 0x375E48, 0x44
+
+.global lbl_80378E8C
+lbl_80378E8C:
+.incbin "baserom.dol", 0x375E8C, 0x24
+
+.global lbl_80378EB0
+lbl_80378EB0:
+.incbin "baserom.dol", 0x375EB0, 0x24
+
+.global lbl_80378ED4
+lbl_80378ED4:
+.incbin "baserom.dol", 0x375ED4, 0x24
+
+.global lbl_80378EF8
+lbl_80378EF8:
+.incbin "baserom.dol", 0x375EF8, 0x10
+
+.global lbl_80378F08
+lbl_80378F08:
+.incbin "baserom.dol", 0x375F08, 0x1C
+
+.global lbl_80378F24
+lbl_80378F24:
+.incbin "baserom.dol", 0x375F24, 0x14
+

--- a/asm/rodata/rodata_d_map_path.s
+++ b/asm/rodata/rodata_d_map_path.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379c30 - 0x80379c58
+
+.global lbl_80379C30
+lbl_80379C30:
+.incbin "baserom.dol", 0x376C30, 0x1C
+
+.global lbl_80379C4C
+lbl_80379C4C:
+.incbin "baserom.dol", 0x376C4C, 0xC
+

--- a/asm/rodata/rodata_d_map_path_dmap.s
+++ b/asm/rodata/rodata_d_map_path_dmap.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379c58 - 0x80379d80
+
+.global lbl_80379C58
+lbl_80379C58:
+.incbin "baserom.dol", 0x376C58, 0x30
+
+.global lbl_80379C88
+lbl_80379C88:
+.incbin "baserom.dol", 0x376C88, 0x30
+
+.global lbl_80379CB8
+lbl_80379CB8:
+.incbin "baserom.dol", 0x376CB8, 0x84
+
+.global lbl_80379D3C
+lbl_80379D3C:
+.incbin "baserom.dol", 0x376D3C, 0x20
+
+.global lbl_80379D5C
+lbl_80379D5C:
+.incbin "baserom.dol", 0x376D5C, 0x24
+

--- a/asm/rodata/rodata_d_menu_calibration.s
+++ b/asm/rodata/rodata_d_menu_calibration.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394f70 - 0x80394f78
+
+.global lbl_80394F70
+lbl_80394F70:
+.incbin "baserom.dol", 0x391F70, 0x8
+

--- a/asm/rodata/rodata_d_menu_collect.s
+++ b/asm/rodata/rodata_d_menu_collect.s
@@ -1,0 +1,103 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394f78 - 0x80395518
+
+.global lbl_80394F78
+lbl_80394F78:
+.incbin "baserom.dol", 0x391F78, 0x10
+
+.global lbl_80394F88
+lbl_80394F88:
+.incbin "baserom.dol", 0x391F88, 0x18
+
+.global lbl_80394FA0
+lbl_80394FA0:
+.incbin "baserom.dol", 0x391FA0, 0x18
+
+.global lbl_80394FB8
+lbl_80394FB8:
+.incbin "baserom.dol", 0x391FB8, 0x18
+
+.global lbl_80394FD0
+lbl_80394FD0:
+.incbin "baserom.dol", 0x391FD0, 0x18
+
+.global lbl_80394FE8
+lbl_80394FE8:
+.incbin "baserom.dol", 0x391FE8, 0x28
+
+.global lbl_80395010
+lbl_80395010:
+.incbin "baserom.dol", 0x392010, 0x28
+
+.global lbl_80395038
+lbl_80395038:
+.incbin "baserom.dol", 0x392038, 0xC
+
+.global lbl_80395044
+lbl_80395044:
+.incbin "baserom.dol", 0x392044, 0xC
+
+.global lbl_80395050
+lbl_80395050:
+.incbin "baserom.dol", 0x392050, 0x28
+
+.global lbl_80395078
+lbl_80395078:
+.incbin "baserom.dol", 0x392078, 0x20
+
+.global lbl_80395098
+lbl_80395098:
+.incbin "baserom.dol", 0x392098, 0x10
+
+.global lbl_803950A8
+lbl_803950A8:
+.incbin "baserom.dol", 0x3920A8, 0x10
+
+.global lbl_803950B8
+lbl_803950B8:
+.incbin "baserom.dol", 0x3920B8, 0x18
+
+.global lbl_803950D0
+lbl_803950D0:
+.incbin "baserom.dol", 0x3920D0, 0x48
+
+.global lbl_80395118
+lbl_80395118:
+.incbin "baserom.dol", 0x392118, 0x150
+
+.global lbl_80395268
+lbl_80395268:
+.incbin "baserom.dol", 0x392268, 0x28
+
+.global lbl_80395290
+lbl_80395290:
+.incbin "baserom.dol", 0x392290, 0x28
+
+.global lbl_803952B8
+lbl_803952B8:
+.incbin "baserom.dol", 0x3922B8, 0x14
+
+.global lbl_803952CC
+lbl_803952CC:
+.incbin "baserom.dol", 0x3922CC, 0x14
+
+.global lbl_803952E0
+lbl_803952E0:
+.incbin "baserom.dol", 0x3922E0, 0x14
+
+.global lbl_803952F4
+lbl_803952F4:
+.incbin "baserom.dol", 0x3922F4, 0x14
+
+.global lbl_80395308
+lbl_80395308:
+.incbin "baserom.dol", 0x392308, 0x14
+
+.global lbl_8039531C
+lbl_8039531C:
+.incbin "baserom.dol", 0x39231C, 0x14
+
+.global lbl_80395330
+lbl_80395330:
+.incbin "baserom.dol", 0x392330, 0x1E8
+

--- a/asm/rodata/rodata_d_menu_dmap.s
+++ b/asm/rodata/rodata_d_menu_dmap.s
@@ -1,0 +1,71 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80395518 - 0x80395860
+
+.global lbl_80395518
+lbl_80395518:
+.incbin "baserom.dol", 0x392518, 0x28
+
+.global lbl_80395540
+lbl_80395540:
+.incbin "baserom.dol", 0x392540, 0x28
+
+.global lbl_80395568
+lbl_80395568:
+.incbin "baserom.dol", 0x392568, 0x28
+
+.global lbl_80395590
+lbl_80395590:
+.incbin "baserom.dol", 0x392590, 0x28
+
+.global lbl_803955B8
+lbl_803955B8:
+.incbin "baserom.dol", 0x3925B8, 0x10
+
+.global lbl_803955C8
+lbl_803955C8:
+.incbin "baserom.dol", 0x3925C8, 0x28
+
+.global lbl_803955F0
+lbl_803955F0:
+.incbin "baserom.dol", 0x3925F0, 0x28
+
+.global lbl_80395618
+lbl_80395618:
+.incbin "baserom.dol", 0x392618, 0x10
+
+.global lbl_80395628
+lbl_80395628:
+.incbin "baserom.dol", 0x392628, 0x20
+
+.global lbl_80395648
+lbl_80395648:
+.incbin "baserom.dol", 0x392648, 0x40
+
+.global lbl_80395688
+lbl_80395688:
+.incbin "baserom.dol", 0x392688, 0x40
+
+.global lbl_803956C8
+lbl_803956C8:
+.incbin "baserom.dol", 0x3926C8, 0x40
+
+.global lbl_80395708
+lbl_80395708:
+.incbin "baserom.dol", 0x392708, 0x10
+
+.global lbl_80395718
+lbl_80395718:
+.incbin "baserom.dol", 0x392718, 0x18
+
+.global lbl_80395730
+lbl_80395730:
+.incbin "baserom.dol", 0x392730, 0x18
+
+.global lbl_80395748
+lbl_80395748:
+.incbin "baserom.dol", 0x392748, 0x18
+
+.global lbl_80395760
+lbl_80395760:
+.incbin "baserom.dol", 0x392760, 0x100
+

--- a/asm/rodata/rodata_d_menu_dmap_map.s
+++ b/asm/rodata/rodata_d_menu_dmap_map.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80395860 - 0x803959c0
+
+.global lbl_80395860
+lbl_80395860:
+.incbin "baserom.dol", 0x392860, 0xF0
+
+.global lbl_80395950
+lbl_80395950:
+.incbin "baserom.dol", 0x392950, 0x24
+
+.global lbl_80395974
+lbl_80395974:
+.incbin "baserom.dol", 0x392974, 0x24
+
+.global lbl_80395998
+lbl_80395998:
+.incbin "baserom.dol", 0x392998, 0x28
+

--- a/asm/rodata/rodata_d_menu_fishing.s
+++ b/asm/rodata/rodata_d_menu_fishing.s
@@ -1,0 +1,71 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80395d90 - 0x803960d0
+
+.global lbl_80395D90
+lbl_80395D90:
+.incbin "baserom.dol", 0x392D90, 0x30
+
+.global lbl_80395DC0
+lbl_80395DC0:
+.incbin "baserom.dol", 0x392DC0, 0x30
+
+.global lbl_80395DF0
+lbl_80395DF0:
+.incbin "baserom.dol", 0x392DF0, 0x30
+
+.global lbl_80395E20
+lbl_80395E20:
+.incbin "baserom.dol", 0x392E20, 0x30
+
+.global lbl_80395E50
+lbl_80395E50:
+.incbin "baserom.dol", 0x392E50, 0x30
+
+.global lbl_80395E80
+lbl_80395E80:
+.incbin "baserom.dol", 0x392E80, 0x30
+
+.global lbl_80395EB0
+lbl_80395EB0:
+.incbin "baserom.dol", 0x392EB0, 0x30
+
+.global lbl_80395EE0
+lbl_80395EE0:
+.incbin "baserom.dol", 0x392EE0, 0x30
+
+.global lbl_80395F10
+lbl_80395F10:
+.incbin "baserom.dol", 0x392F10, 0x30
+
+.global lbl_80395F40
+lbl_80395F40:
+.incbin "baserom.dol", 0x392F40, 0x30
+
+.global lbl_80395F70
+lbl_80395F70:
+.incbin "baserom.dol", 0x392F70, 0x30
+
+.global lbl_80395FA0
+lbl_80395FA0:
+.incbin "baserom.dol", 0x392FA0, 0x30
+
+.global lbl_80395FD0
+lbl_80395FD0:
+.incbin "baserom.dol", 0x392FD0, 0x30
+
+.global lbl_80396000
+lbl_80396000:
+.incbin "baserom.dol", 0x393000, 0x18
+
+.global lbl_80396018
+lbl_80396018:
+.incbin "baserom.dol", 0x393018, 0x28
+
+.global lbl_80396040
+lbl_80396040:
+.incbin "baserom.dol", 0x393040, 0x28
+
+.global lbl_80396068
+lbl_80396068:
+.incbin "baserom.dol", 0x393068, 0x68
+

--- a/asm/rodata/rodata_d_menu_fmap.s
+++ b/asm/rodata/rodata_d_menu_fmap.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803960d0 - 0x803961b0
+
+.global lbl_803960D0
+lbl_803960D0:
+.incbin "baserom.dol", 0x3930D0, 0x18
+
+.global lbl_803960E8
+lbl_803960E8:
+.incbin "baserom.dol", 0x3930E8, 0xC8
+

--- a/asm/rodata/rodata_d_menu_fmap2D.s
+++ b/asm/rodata/rodata_d_menu_fmap2D.s
@@ -1,0 +1,99 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80396248 - 0x80396690
+
+.global lbl_80396248
+lbl_80396248:
+.incbin "baserom.dol", 0x393248, 0x20
+
+.global lbl_80396268
+lbl_80396268:
+.incbin "baserom.dol", 0x393268, 0x20
+
+.global lbl_80396288
+lbl_80396288:
+.incbin "baserom.dol", 0x393288, 0x18
+
+.global lbl_803962A0
+lbl_803962A0:
+.incbin "baserom.dol", 0x3932A0, 0x18
+
+.global lbl_803962B8
+lbl_803962B8:
+.incbin "baserom.dol", 0x3932B8, 0x38
+
+.global lbl_803962F0
+lbl_803962F0:
+.incbin "baserom.dol", 0x3932F0, 0x38
+
+.global lbl_80396328
+lbl_80396328:
+.incbin "baserom.dol", 0x393328, 0x28
+
+.global lbl_80396350
+lbl_80396350:
+.incbin "baserom.dol", 0x393350, 0x28
+
+.global lbl_80396378
+lbl_80396378:
+.incbin "baserom.dol", 0x393378, 0x28
+
+.global lbl_803963A0
+lbl_803963A0:
+.incbin "baserom.dol", 0x3933A0, 0x28
+
+.global lbl_803963C8
+lbl_803963C8:
+.incbin "baserom.dol", 0x3933C8, 0x28
+
+.global lbl_803963F0
+lbl_803963F0:
+.incbin "baserom.dol", 0x3933F0, 0x28
+
+.global lbl_80396418
+lbl_80396418:
+.incbin "baserom.dol", 0x393418, 0x28
+
+.global lbl_80396440
+lbl_80396440:
+.incbin "baserom.dol", 0x393440, 0x28
+
+.global lbl_80396468
+lbl_80396468:
+.incbin "baserom.dol", 0x393468, 0x28
+
+.global lbl_80396490
+lbl_80396490:
+.incbin "baserom.dol", 0x393490, 0x28
+
+.global lbl_803964B8
+lbl_803964B8:
+.incbin "baserom.dol", 0x3934B8, 0x38
+
+.global lbl_803964F0
+lbl_803964F0:
+.incbin "baserom.dol", 0x3934F0, 0x18
+
+.global lbl_80396508
+lbl_80396508:
+.incbin "baserom.dol", 0x393508, 0x28
+
+.global lbl_80396530
+lbl_80396530:
+.incbin "baserom.dol", 0x393530, 0x28
+
+.global lbl_80396558
+lbl_80396558:
+.incbin "baserom.dol", 0x393558, 0x28
+
+.global lbl_80396580
+lbl_80396580:
+.incbin "baserom.dol", 0x393580, 0x28
+
+.global lbl_803965A8
+lbl_803965A8:
+.incbin "baserom.dol", 0x3935A8, 0x28
+
+.global lbl_803965D0
+lbl_803965D0:
+.incbin "baserom.dol", 0x3935D0, 0xC0
+

--- a/asm/rodata/rodata_d_menu_fmap_map.s
+++ b/asm/rodata/rodata_d_menu_fmap_map.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803961b0 - 0x80396248
+
+.global lbl_803961B0
+lbl_803961B0:
+.incbin "baserom.dol", 0x3931B0, 0x20
+
+.global lbl_803961D0
+lbl_803961D0:
+.incbin "baserom.dol", 0x3931D0, 0x24
+
+.global lbl_803961F4
+lbl_803961F4:
+.incbin "baserom.dol", 0x3931F4, 0x24
+
+.global lbl_80396218
+lbl_80396218:
+.incbin "baserom.dol", 0x393218, 0x24
+
+.global lbl_8039623C
+lbl_8039623C:
+.incbin "baserom.dol", 0x39323C, 0xC
+

--- a/asm/rodata/rodata_d_menu_insect.s
+++ b/asm/rodata/rodata_d_menu_insect.s
@@ -1,0 +1,27 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80396690 - 0x80396950
+
+.global lbl_80396690
+lbl_80396690:
+.incbin "baserom.dol", 0x393690, 0xC0
+
+.global lbl_80396750
+lbl_80396750:
+.incbin "baserom.dol", 0x393750, 0xC0
+
+.global lbl_80396810
+lbl_80396810:
+.incbin "baserom.dol", 0x393810, 0x28
+
+.global lbl_80396838
+lbl_80396838:
+.incbin "baserom.dol", 0x393838, 0x28
+
+.global lbl_80396860
+lbl_80396860:
+.incbin "baserom.dol", 0x393860, 0x60
+
+.global lbl_803968C0
+lbl_803968C0:
+.incbin "baserom.dol", 0x3938C0, 0x90
+

--- a/asm/rodata/rodata_d_menu_item_explain.s
+++ b/asm/rodata/rodata_d_menu_item_explain.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80396950 - 0x803969c8
+
+.global lbl_80396950
+lbl_80396950:
+.incbin "baserom.dol", 0x393950, 0x20
+
+.global lbl_80396970
+lbl_80396970:
+.incbin "baserom.dol", 0x393970, 0x20
+
+.global lbl_80396990
+lbl_80396990:
+.incbin "baserom.dol", 0x393990, 0x38
+

--- a/asm/rodata/rodata_d_menu_letter.s
+++ b/asm/rodata/rodata_d_menu_letter.s
@@ -1,0 +1,83 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803969c8 - 0x80396ea8
+
+.global lbl_803969C8
+lbl_803969C8:
+.incbin "baserom.dol", 0x3939C8, 0x30
+
+.global lbl_803969F8
+lbl_803969F8:
+.incbin "baserom.dol", 0x3939F8, 0x30
+
+.global lbl_80396A28
+lbl_80396A28:
+.incbin "baserom.dol", 0x393A28, 0x30
+
+.global lbl_80396A58
+lbl_80396A58:
+.incbin "baserom.dol", 0x393A58, 0x30
+
+.global lbl_80396A88
+lbl_80396A88:
+.incbin "baserom.dol", 0x393A88, 0x30
+
+.global lbl_80396AB8
+lbl_80396AB8:
+.incbin "baserom.dol", 0x393AB8, 0x30
+
+.global lbl_80396AE8
+lbl_80396AE8:
+.incbin "baserom.dol", 0x393AE8, 0x30
+
+.global lbl_80396B18
+lbl_80396B18:
+.incbin "baserom.dol", 0x393B18, 0x30
+
+.global lbl_80396B48
+lbl_80396B48:
+.incbin "baserom.dol", 0x393B48, 0x30
+
+.global lbl_80396B78
+lbl_80396B78:
+.incbin "baserom.dol", 0x393B78, 0x30
+
+.global lbl_80396BA8
+lbl_80396BA8:
+.incbin "baserom.dol", 0x393BA8, 0x30
+
+.global lbl_80396BD8
+lbl_80396BD8:
+.incbin "baserom.dol", 0x393BD8, 0x30
+
+.global lbl_80396C08
+lbl_80396C08:
+.incbin "baserom.dol", 0x393C08, 0x30
+
+.global lbl_80396C38
+lbl_80396C38:
+.incbin "baserom.dol", 0x393C38, 0x48
+
+.global lbl_80396C80
+lbl_80396C80:
+.incbin "baserom.dol", 0x393C80, 0x48
+
+.global lbl_80396CC8
+lbl_80396CC8:
+.incbin "baserom.dol", 0x393CC8, 0x48
+
+.global lbl_80396D10
+lbl_80396D10:
+.incbin "baserom.dol", 0x393D10, 0x60
+
+.global lbl_80396D70
+lbl_80396D70:
+.incbin "baserom.dol", 0x393D70, 0x28
+
+.global lbl_80396D98
+lbl_80396D98:
+.incbin "baserom.dol", 0x393D98, 0x28
+
+.global lbl_80396DC0
+lbl_80396DC0:
+.incbin "baserom.dol", 0x393DC0, 0xE8
+

--- a/asm/rodata/rodata_d_menu_map_common.s
+++ b/asm/rodata/rodata_d_menu_map_common.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803959c0 - 0x80395d90
+
+.global lbl_803959C0
+lbl_803959C0:
+.incbin "baserom.dol", 0x3929C0, 0x3D0
+

--- a/asm/rodata/rodata_d_menu_option.s
+++ b/asm/rodata/rodata_d_menu_option.s
@@ -1,0 +1,215 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80396ea8 - 0x80397738
+
+.global lbl_80396EA8
+lbl_80396EA8:
+.incbin "baserom.dol", 0x393EA8, 0x10
+
+.global lbl_80396EB8
+lbl_80396EB8:
+.incbin "baserom.dol", 0x393EB8, 0x28
+
+.global lbl_80396EE0
+lbl_80396EE0:
+.incbin "baserom.dol", 0x393EE0, 0x28
+
+.global lbl_80396F08
+lbl_80396F08:
+.incbin "baserom.dol", 0x393F08, 0x10
+
+.global lbl_80396F18
+lbl_80396F18:
+.incbin "baserom.dol", 0x393F18, 0x10
+
+.global lbl_80396F28
+lbl_80396F28:
+.incbin "baserom.dol", 0x393F28, 0x10
+
+.global lbl_80396F38
+lbl_80396F38:
+.incbin "baserom.dol", 0x393F38, 0x10
+
+.global lbl_80396F48
+lbl_80396F48:
+.incbin "baserom.dol", 0x393F48, 0x10
+
+.global lbl_80396F58
+lbl_80396F58:
+.incbin "baserom.dol", 0x393F58, 0x30
+
+.global lbl_80396F88
+lbl_80396F88:
+.incbin "baserom.dol", 0x393F88, 0x30
+
+.global lbl_80396FB8
+lbl_80396FB8:
+.incbin "baserom.dol", 0x393FB8, 0x30
+
+.global lbl_80396FE8
+lbl_80396FE8:
+.incbin "baserom.dol", 0x393FE8, 0x30
+
+.global lbl_80397018
+lbl_80397018:
+.incbin "baserom.dol", 0x394018, 0x30
+
+.global lbl_80397048
+lbl_80397048:
+.incbin "baserom.dol", 0x394048, 0x30
+
+.global lbl_80397078
+lbl_80397078:
+.incbin "baserom.dol", 0x394078, 0x30
+
+.global lbl_803970A8
+lbl_803970A8:
+.incbin "baserom.dol", 0x3940A8, 0x30
+
+.global lbl_803970D8
+lbl_803970D8:
+.incbin "baserom.dol", 0x3940D8, 0x30
+
+.global lbl_80397108
+lbl_80397108:
+.incbin "baserom.dol", 0x394108, 0x30
+
+.global lbl_80397138
+lbl_80397138:
+.incbin "baserom.dol", 0x394138, 0x28
+
+.global lbl_80397160
+lbl_80397160:
+.incbin "baserom.dol", 0x394160, 0x28
+
+.global lbl_80397188
+lbl_80397188:
+.incbin "baserom.dol", 0x394188, 0x30
+
+.global lbl_803971B8
+lbl_803971B8:
+.incbin "baserom.dol", 0x3941B8, 0x28
+
+.global lbl_803971E0
+lbl_803971E0:
+.incbin "baserom.dol", 0x3941E0, 0x28
+
+.global lbl_80397208
+lbl_80397208:
+.incbin "baserom.dol", 0x394208, 0x10
+
+.global lbl_80397218
+lbl_80397218:
+.incbin "baserom.dol", 0x394218, 0x10
+
+.global lbl_80397228
+lbl_80397228:
+.incbin "baserom.dol", 0x394228, 0x10
+
+.global lbl_80397238
+lbl_80397238:
+.incbin "baserom.dol", 0x394238, 0x10
+
+.global lbl_80397248
+lbl_80397248:
+.incbin "baserom.dol", 0x394248, 0x10
+
+.global lbl_80397258
+lbl_80397258:
+.incbin "baserom.dol", 0x394258, 0x10
+
+.global lbl_80397268
+lbl_80397268:
+.incbin "baserom.dol", 0x394268, 0x10
+
+.global lbl_80397278
+lbl_80397278:
+.incbin "baserom.dol", 0x394278, 0x10
+
+.global lbl_80397288
+lbl_80397288:
+.incbin "baserom.dol", 0x394288, 0x10
+
+.global lbl_80397298
+lbl_80397298:
+.incbin "baserom.dol", 0x394298, 0x10
+
+.global lbl_803972A8
+lbl_803972A8:
+.incbin "baserom.dol", 0x3942A8, 0x10
+
+.global lbl_803972B8
+lbl_803972B8:
+.incbin "baserom.dol", 0x3942B8, 0x10
+
+.global lbl_803972C8
+lbl_803972C8:
+.incbin "baserom.dol", 0x3942C8, 0x30
+
+.global lbl_803972F8
+lbl_803972F8:
+.incbin "baserom.dol", 0x3942F8, 0x30
+
+.global lbl_80397328
+lbl_80397328:
+.incbin "baserom.dol", 0x394328, 0x30
+
+.global lbl_80397358
+lbl_80397358:
+.incbin "baserom.dol", 0x394358, 0x30
+
+.global lbl_80397388
+lbl_80397388:
+.incbin "baserom.dol", 0x394388, 0x30
+
+.global lbl_803973B8
+lbl_803973B8:
+.incbin "baserom.dol", 0x3943B8, 0x30
+
+.global lbl_803973E8
+lbl_803973E8:
+.incbin "baserom.dol", 0x3943E8, 0x30
+
+.global lbl_80397418
+lbl_80397418:
+.incbin "baserom.dol", 0x394418, 0x30
+
+.global lbl_80397448
+lbl_80397448:
+.incbin "baserom.dol", 0x394448, 0x30
+
+.global lbl_80397478
+lbl_80397478:
+.incbin "baserom.dol", 0x394478, 0x30
+
+.global lbl_803974A8
+lbl_803974A8:
+.incbin "baserom.dol", 0x3944A8, 0x30
+
+.global lbl_803974D8
+lbl_803974D8:
+.incbin "baserom.dol", 0x3944D8, 0x20
+
+.global lbl_803974F8
+lbl_803974F8:
+.incbin "baserom.dol", 0x3944F8, 0x18
+
+.global lbl_80397510
+lbl_80397510:
+.incbin "baserom.dol", 0x394510, 0x50
+
+.global lbl_80397560
+lbl_80397560:
+.incbin "baserom.dol", 0x394560, 0x28
+
+.global lbl_80397588
+lbl_80397588:
+.incbin "baserom.dol", 0x394588, 0x28
+
+.global lbl_803975B0
+lbl_803975B0:
+.incbin "baserom.dol", 0x3945B0, 0x28
+
+.global lbl_803975D8
+lbl_803975D8:
+.incbin "baserom.dol", 0x3945D8, 0x160
+

--- a/asm/rodata/rodata_d_menu_ring.s
+++ b/asm/rodata/rodata_d_menu_ring.s
@@ -1,0 +1,47 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80397738 - 0x80397960
+
+.global lbl_80397738
+lbl_80397738:
+.incbin "baserom.dol", 0x394738, 0x28
+
+.global lbl_80397760
+lbl_80397760:
+.incbin "baserom.dol", 0x394760, 0x28
+
+.global lbl_80397788
+lbl_80397788:
+.incbin "baserom.dol", 0x394788, 0x28
+
+.global lbl_803977B0
+lbl_803977B0:
+.incbin "baserom.dol", 0x3947B0, 0x28
+
+.global lbl_803977D8
+lbl_803977D8:
+.incbin "baserom.dol", 0x3947D8, 0x28
+
+.global lbl_80397800
+lbl_80397800:
+.incbin "baserom.dol", 0x394800, 0x28
+
+.global lbl_80397828
+lbl_80397828:
+.incbin "baserom.dol", 0x394828, 0x28
+
+.global lbl_80397850
+lbl_80397850:
+.incbin "baserom.dol", 0x394850, 0x28
+
+.global lbl_80397878
+lbl_80397878:
+.incbin "baserom.dol", 0x394878, 0x28
+
+.global lbl_803978A0
+lbl_803978A0:
+.incbin "baserom.dol", 0x3948A0, 0x28
+
+.global lbl_803978C8
+lbl_803978C8:
+.incbin "baserom.dol", 0x3948C8, 0x98
+

--- a/asm/rodata/rodata_d_menu_save.s
+++ b/asm/rodata/rodata_d_menu_save.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80397960 - 0x80397a18
+
+.global lbl_80397960
+lbl_80397960:
+.incbin "baserom.dol", 0x394960, 0xB8
+

--- a/asm/rodata/rodata_d_menu_skill.s
+++ b/asm/rodata/rodata_d_menu_skill.s
@@ -1,0 +1,87 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80397a18 - 0x80397e38
+
+.global lbl_80397A18
+lbl_80397A18:
+.incbin "baserom.dol", 0x394A18, 0x1C
+
+.global lbl_80397A34
+lbl_80397A34:
+.incbin "baserom.dol", 0x394A34, 0x1C
+
+.global lbl_80397A50
+lbl_80397A50:
+.incbin "baserom.dol", 0x394A50, 0x38
+
+.global lbl_80397A88
+lbl_80397A88:
+.incbin "baserom.dol", 0x394A88, 0x38
+
+.global lbl_80397AC0
+lbl_80397AC0:
+.incbin "baserom.dol", 0x394AC0, 0x38
+
+.global lbl_80397AF8
+lbl_80397AF8:
+.incbin "baserom.dol", 0x394AF8, 0x38
+
+.global lbl_80397B30
+lbl_80397B30:
+.incbin "baserom.dol", 0x394B30, 0x38
+
+.global lbl_80397B68
+lbl_80397B68:
+.incbin "baserom.dol", 0x394B68, 0x38
+
+.global lbl_80397BA0
+lbl_80397BA0:
+.incbin "baserom.dol", 0x394BA0, 0x38
+
+.global lbl_80397BD8
+lbl_80397BD8:
+.incbin "baserom.dol", 0x394BD8, 0x38
+
+.global lbl_80397C10
+lbl_80397C10:
+.incbin "baserom.dol", 0x394C10, 0x38
+
+.global lbl_80397C48
+lbl_80397C48:
+.incbin "baserom.dol", 0x394C48, 0x38
+
+.global lbl_80397C80
+lbl_80397C80:
+.incbin "baserom.dol", 0x394C80, 0x38
+
+.global lbl_80397CB8
+lbl_80397CB8:
+.incbin "baserom.dol", 0x394CB8, 0x38
+
+.global lbl_80397CF0
+lbl_80397CF0:
+.incbin "baserom.dol", 0x394CF0, 0x20
+
+.global lbl_80397D10
+lbl_80397D10:
+.incbin "baserom.dol", 0x394D10, 0x20
+
+.global lbl_80397D30
+lbl_80397D30:
+.incbin "baserom.dol", 0x394D30, 0x28
+
+.global lbl_80397D58
+lbl_80397D58:
+.incbin "baserom.dol", 0x394D58, 0x28
+
+.global lbl_80397D80
+lbl_80397D80:
+.incbin "baserom.dol", 0x394D80, 0x1C
+
+.global lbl_80397D9C
+lbl_80397D9C:
+.incbin "baserom.dol", 0x394D9C, 0x1C
+
+.global lbl_80397DB8
+lbl_80397DB8:
+.incbin "baserom.dol", 0x394DB8, 0x80
+

--- a/asm/rodata/rodata_d_menu_window.s
+++ b/asm/rodata/rodata_d_menu_window.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80397e38 - 0x80397e50
+
+.global lbl_80397E38
+lbl_80397E38:
+.incbin "baserom.dol", 0x394E38, 0x18
+

--- a/asm/rodata/rodata_d_meter2.s
+++ b/asm/rodata/rodata_d_meter2.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399338 - 0x80399350
+
+.global lbl_80399338
+lbl_80399338:
+.incbin "baserom.dol", 0x396338, 0x18
+

--- a/asm/rodata/rodata_d_meter2_draw.s
+++ b/asm/rodata/rodata_d_meter2_draw.s
@@ -1,0 +1,95 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80398258 - 0x80398a78
+
+.global lbl_80398258
+lbl_80398258:
+.incbin "baserom.dol", 0x395258, 0x28
+
+.global lbl_80398280
+lbl_80398280:
+.incbin "baserom.dol", 0x395280, 0x28
+
+.global lbl_803982A8
+lbl_803982A8:
+.incbin "baserom.dol", 0x3952A8, 0x28
+
+.global lbl_803982D0
+lbl_803982D0:
+.incbin "baserom.dol", 0x3952D0, 0x28
+
+.global lbl_803982F8
+lbl_803982F8:
+.incbin "baserom.dol", 0x3952F8, 0x28
+
+.global lbl_80398320
+lbl_80398320:
+.incbin "baserom.dol", 0x395320, 0xA0
+
+.global lbl_803983C0
+lbl_803983C0:
+.incbin "baserom.dol", 0x3953C0, 0xA0
+
+.global lbl_80398460
+lbl_80398460:
+.incbin "baserom.dol", 0x395460, 0xA0
+
+.global lbl_80398500
+lbl_80398500:
+.incbin "baserom.dol", 0x395500, 0xA0
+
+.global lbl_803985A0
+lbl_803985A0:
+.incbin "baserom.dol", 0x3955A0, 0xA0
+
+.global lbl_80398640
+lbl_80398640:
+.incbin "baserom.dol", 0x395640, 0x80
+
+.global lbl_803986C0
+lbl_803986C0:
+.incbin "baserom.dol", 0x3956C0, 0x80
+
+.global lbl_80398740
+lbl_80398740:
+.incbin "baserom.dol", 0x395740, 0x80
+
+.global lbl_803987C0
+lbl_803987C0:
+.incbin "baserom.dol", 0x3957C0, 0x20
+
+.global lbl_803987E0
+lbl_803987E0:
+.incbin "baserom.dol", 0x3957E0, 0x20
+
+.global lbl_80398800
+lbl_80398800:
+.incbin "baserom.dol", 0x395800, 0x28
+
+.global lbl_80398828
+lbl_80398828:
+.incbin "baserom.dol", 0x395828, 0x28
+
+.global lbl_80398850
+lbl_80398850:
+.incbin "baserom.dol", 0x395850, 0x28
+
+.global lbl_80398878
+lbl_80398878:
+.incbin "baserom.dol", 0x395878, 0x20
+
+.global lbl_80398898
+lbl_80398898:
+.incbin "baserom.dol", 0x395898, 0x10
+
+.global lbl_803988A8
+lbl_803988A8:
+.incbin "baserom.dol", 0x3958A8, 0x10
+
+.global lbl_803988B8
+lbl_803988B8:
+.incbin "baserom.dol", 0x3958B8, 0x18
+
+.global lbl_803988D0
+lbl_803988D0:
+.incbin "baserom.dol", 0x3958D0, 0x1A8
+

--- a/asm/rodata/rodata_d_meter2_info.s
+++ b/asm/rodata/rodata_d_meter2_info.s
@@ -1,0 +1,55 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80398a78 - 0x80399338
+
+.global lbl_80398A78
+lbl_80398A78:
+.incbin "baserom.dol", 0x395A78, 0x94
+
+.global lbl_80398B0C
+lbl_80398B0C:
+.incbin "baserom.dol", 0x395B0C, 0x94
+
+.global lbl_80398BA0
+lbl_80398BA0:
+.incbin "baserom.dol", 0x395BA0, 0x94
+
+.global lbl_80398C34
+lbl_80398C34:
+.incbin "baserom.dol", 0x395C34, 0x94
+
+.global lbl_80398CC8
+lbl_80398CC8:
+.incbin "baserom.dol", 0x395CC8, 0x94
+
+.global lbl_80398D5C
+lbl_80398D5C:
+.incbin "baserom.dol", 0x395D5C, 0x94
+
+.global lbl_80398DF0
+lbl_80398DF0:
+.incbin "baserom.dol", 0x395DF0, 0x94
+
+.global lbl_80398E84
+lbl_80398E84:
+.incbin "baserom.dol", 0x395E84, 0x94
+
+.global lbl_80398F18
+lbl_80398F18:
+.incbin "baserom.dol", 0x395F18, 0x94
+
+.global lbl_80398FAC
+lbl_80398FAC:
+.incbin "baserom.dol", 0x395FAC, 0x94
+
+.global lbl_80399040
+lbl_80399040:
+.incbin "baserom.dol", 0x396040, 0x94
+
+.global lbl_803990D4
+lbl_803990D4:
+.incbin "baserom.dol", 0x3960D4, 0x94
+
+.global lbl_80399168
+lbl_80399168:
+.incbin "baserom.dol", 0x396168, 0x1D0
+

--- a/asm/rodata/rodata_d_meter_HIO.s
+++ b/asm/rodata/rodata_d_meter_HIO.s
@@ -1,0 +1,87 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80397e50 - 0x80398048
+
+.global lbl_80397E50
+lbl_80397E50:
+.incbin "baserom.dol", 0x394E50, 0x18
+
+.global lbl_80397E68
+lbl_80397E68:
+.incbin "baserom.dol", 0x394E68, 0x18
+
+.global lbl_80397E80
+lbl_80397E80:
+.incbin "baserom.dol", 0x394E80, 0x18
+
+.global lbl_80397E98
+lbl_80397E98:
+.incbin "baserom.dol", 0x394E98, 0x18
+
+.global lbl_80397EB0
+lbl_80397EB0:
+.incbin "baserom.dol", 0x394EB0, 0x18
+
+.global lbl_80397EC8
+lbl_80397EC8:
+.incbin "baserom.dol", 0x394EC8, 0x18
+
+.global lbl_80397EE0
+lbl_80397EE0:
+.incbin "baserom.dol", 0x394EE0, 0x18
+
+.global lbl_80397EF8
+lbl_80397EF8:
+.incbin "baserom.dol", 0x394EF8, 0x18
+
+.global lbl_80397F10
+lbl_80397F10:
+.incbin "baserom.dol", 0x394F10, 0x18
+
+.global lbl_80397F28
+lbl_80397F28:
+.incbin "baserom.dol", 0x394F28, 0x18
+
+.global lbl_80397F40
+lbl_80397F40:
+.incbin "baserom.dol", 0x394F40, 0x18
+
+.global lbl_80397F58
+lbl_80397F58:
+.incbin "baserom.dol", 0x394F58, 0x18
+
+.global lbl_80397F70
+lbl_80397F70:
+.incbin "baserom.dol", 0x394F70, 0x18
+
+.global lbl_80397F88
+lbl_80397F88:
+.incbin "baserom.dol", 0x394F88, 0x18
+
+.global lbl_80397FA0
+lbl_80397FA0:
+.incbin "baserom.dol", 0x394FA0, 0x18
+
+.global lbl_80397FB8
+lbl_80397FB8:
+.incbin "baserom.dol", 0x394FB8, 0x18
+
+.global lbl_80397FD0
+lbl_80397FD0:
+.incbin "baserom.dol", 0x394FD0, 0x18
+
+.global lbl_80397FE8
+lbl_80397FE8:
+.incbin "baserom.dol", 0x394FE8, 0x18
+
+.global lbl_80398000
+lbl_80398000:
+.incbin "baserom.dol", 0x395000, 0x18
+
+.global lbl_80398018
+lbl_80398018:
+.incbin "baserom.dol", 0x395018, 0x18
+
+.global lbl_80398030
+lbl_80398030:
+.incbin "baserom.dol", 0x395030, 0x18
+

--- a/asm/rodata/rodata_d_meter_button.s
+++ b/asm/rodata/rodata_d_meter_button.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80398048 - 0x80398158
+
+.global lbl_80398048
+lbl_80398048:
+.incbin "baserom.dol", 0x395048, 0x50
+
+.global lbl_80398098
+lbl_80398098:
+.incbin "baserom.dol", 0x395098, 0x50
+
+.global lbl_803980E8
+lbl_803980E8:
+.incbin "baserom.dol", 0x3950E8, 0x70
+

--- a/asm/rodata/rodata_d_meter_haihai.s
+++ b/asm/rodata/rodata_d_meter_haihai.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80398158 - 0x803981b0
+
+.global lbl_80398158
+lbl_80398158:
+.incbin "baserom.dol", 0x395158, 0x58
+

--- a/asm/rodata/rodata_d_meter_hakusha.s
+++ b/asm/rodata/rodata_d_meter_hakusha.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803981b0 - 0x80398208
+
+.global lbl_803981B0
+lbl_803981B0:
+.incbin "baserom.dol", 0x3951B0, 0x58
+

--- a/asm/rodata/rodata_d_meter_map.s
+++ b/asm/rodata/rodata_d_meter_map.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80398208 - 0x80398210
+
+.global lbl_80398208
+lbl_80398208:
+.incbin "baserom.dol", 0x395208, 0x8
+

--- a/asm/rodata/rodata_d_meter_string.s
+++ b/asm/rodata/rodata_d_meter_string.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80398210 - 0x80398258
+
+.global lbl_80398210
+lbl_80398210:
+.incbin "baserom.dol", 0x395210, 0x48
+

--- a/asm/rodata/rodata_d_msg_class.s
+++ b/asm/rodata/rodata_d_msg_class.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803995c8 - 0x80399660
+
+.global lbl_803995C8
+lbl_803995C8:
+.incbin "baserom.dol", 0x3965C8, 0x24
+
+.global lbl_803995EC
+lbl_803995EC:
+.incbin "baserom.dol", 0x3965EC, 0x24
+
+.global lbl_80399610
+lbl_80399610:
+.incbin "baserom.dol", 0x396610, 0x50
+

--- a/asm/rodata/rodata_d_msg_flow.s
+++ b/asm/rodata/rodata_d_msg_flow.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399cb0 - 0x80399cc8
+
+.global lbl_80399CB0
+lbl_80399CB0:
+.incbin "baserom.dol", 0x396CB0, 0x18
+

--- a/asm/rodata/rodata_d_msg_object.s
+++ b/asm/rodata/rodata_d_msg_object.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399660 - 0x803996e8
+
+.global lbl_80399660
+lbl_80399660:
+.incbin "baserom.dol", 0x396660, 0x88
+

--- a/asm/rodata/rodata_d_msg_out_font.s
+++ b/asm/rodata/rodata_d_msg_out_font.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399350 - 0x803995c8
+
+.global lbl_80399350
+lbl_80399350:
+.incbin "baserom.dol", 0x396350, 0x278
+

--- a/asm/rodata/rodata_d_msg_scrn_3select.s
+++ b/asm/rodata/rodata_d_msg_scrn_3select.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399708 - 0x803998a0
+
+.global lbl_80399708
+lbl_80399708:
+.incbin "baserom.dol", 0x396708, 0x120
+
+.global lbl_80399828
+lbl_80399828:
+.incbin "baserom.dol", 0x396828, 0xC
+
+.global lbl_80399834
+lbl_80399834:
+.incbin "baserom.dol", 0x396834, 0xC
+
+.global lbl_80399840
+lbl_80399840:
+.incbin "baserom.dol", 0x396840, 0x60
+

--- a/asm/rodata/rodata_d_msg_scrn_arrow.s
+++ b/asm/rodata/rodata_d_msg_scrn_arrow.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803998a0 - 0x803998f8
+
+.global lbl_803998A0
+lbl_803998A0:
+.incbin "baserom.dol", 0x3968A0, 0x58
+

--- a/asm/rodata/rodata_d_msg_scrn_boss.s
+++ b/asm/rodata/rodata_d_msg_scrn_boss.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803998f8 - 0x80399910
+
+.global lbl_803998F8
+lbl_803998F8:
+.incbin "baserom.dol", 0x3968F8, 0x18
+

--- a/asm/rodata/rodata_d_msg_scrn_explain.s
+++ b/asm/rodata/rodata_d_msg_scrn_explain.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399910 - 0x80399990
+
+.global lbl_80399910
+lbl_80399910:
+.incbin "baserom.dol", 0x396910, 0x80
+

--- a/asm/rodata/rodata_d_msg_scrn_howl.s
+++ b/asm/rodata/rodata_d_msg_scrn_howl.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399a20 - 0x80399a80
+
+.global lbl_80399A20
+lbl_80399A20:
+.incbin "baserom.dol", 0x396A20, 0x60
+

--- a/asm/rodata/rodata_d_msg_scrn_item.s
+++ b/asm/rodata/rodata_d_msg_scrn_item.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399990 - 0x80399a20
+
+.global lbl_80399990
+lbl_80399990:
+.incbin "baserom.dol", 0x396990, 0x90
+

--- a/asm/rodata/rodata_d_msg_scrn_jimaku.s
+++ b/asm/rodata/rodata_d_msg_scrn_jimaku.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399a80 - 0x80399aa0
+
+.global lbl_80399A80
+lbl_80399A80:
+.incbin "baserom.dol", 0x396A80, 0x20
+

--- a/asm/rodata/rodata_d_msg_scrn_kanban.s
+++ b/asm/rodata/rodata_d_msg_scrn_kanban.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399aa0 - 0x80399b08
+
+.global lbl_80399AA0
+lbl_80399AA0:
+.incbin "baserom.dol", 0x396AA0, 0x18
+
+.global lbl_80399AB8
+lbl_80399AB8:
+.incbin "baserom.dol", 0x396AB8, 0x50
+

--- a/asm/rodata/rodata_d_msg_scrn_light.s
+++ b/asm/rodata/rodata_d_msg_scrn_light.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399b08 - 0x80399b78
+
+.global lbl_80399B08
+lbl_80399B08:
+.incbin "baserom.dol", 0x396B08, 0x70
+

--- a/asm/rodata/rodata_d_msg_scrn_place.s
+++ b/asm/rodata/rodata_d_msg_scrn_place.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399b78 - 0x80399b98
+
+.global lbl_80399B78
+lbl_80399B78:
+.incbin "baserom.dol", 0x396B78, 0x20
+

--- a/asm/rodata/rodata_d_msg_scrn_staff.s
+++ b/asm/rodata/rodata_d_msg_scrn_staff.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399b98 - 0x80399bb0
+
+.global lbl_80399B98
+lbl_80399B98:
+.incbin "baserom.dol", 0x396B98, 0x18
+

--- a/asm/rodata/rodata_d_msg_scrn_talk.s
+++ b/asm/rodata/rodata_d_msg_scrn_talk.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399bb0 - 0x80399c18
+
+.global lbl_80399BB0
+lbl_80399BB0:
+.incbin "baserom.dol", 0x396BB0, 0x68
+

--- a/asm/rodata/rodata_d_msg_scrn_tree.s
+++ b/asm/rodata/rodata_d_msg_scrn_tree.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399c18 - 0x80399c98
+
+.global lbl_80399C18
+lbl_80399C18:
+.incbin "baserom.dol", 0x396C18, 0x18
+
+.global lbl_80399C30
+lbl_80399C30:
+.incbin "baserom.dol", 0x396C30, 0x68
+

--- a/asm/rodata/rodata_d_msg_string_base.s
+++ b/asm/rodata/rodata_d_msg_string_base.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399c98 - 0x80399cb0
+
+.global lbl_80399C98
+lbl_80399C98:
+.incbin "baserom.dol", 0x396C98, 0x18
+

--- a/asm/rodata/rodata_d_msg_unit.s
+++ b/asm/rodata/rodata_d_msg_unit.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803996e8 - 0x80399708
+
+.global lbl_803996E8
+lbl_803996E8:
+.incbin "baserom.dol", 0x3966E8, 0x20
+

--- a/asm/rodata/rodata_d_name.s
+++ b/asm/rodata/rodata_d_name.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399cc8 - 0x80399fe0
+
+.global lbl_80399CC8
+lbl_80399CC8:
+.incbin "baserom.dol", 0x396CC8, 0x318
+

--- a/asm/rodata/rodata_d_particle.s
+++ b/asm/rodata/rodata_d_particle.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a108 - 0x8037a178
+
+.global lbl_8037A108
+lbl_8037A108:
+.incbin "baserom.dol", 0x377108, 0xC
+
+.global lbl_8037A114
+lbl_8037A114:
+.incbin "baserom.dol", 0x377114, 0xC
+
+.global lbl_8037A120
+lbl_8037A120:
+.incbin "baserom.dol", 0x377120, 0xC
+
+.global lbl_8037A12C
+lbl_8037A12C:
+.incbin "baserom.dol", 0x37712C, 0x4C
+

--- a/asm/rodata/rodata_d_resorce.s
+++ b/asm/rodata/rodata_d_resorce.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80379840 - 0x80379c30
+
+.global lbl_80379840
+lbl_80379840:
+.incbin "baserom.dol", 0x376840, 0x64
+
+.global lbl_803798A4
+lbl_803798A4:
+.incbin "baserom.dol", 0x3768A4, 0x14
+
+.global lbl_803798B8
+lbl_803798B8:
+.incbin "baserom.dol", 0x3768B8, 0x378
+

--- a/asm/rodata/rodata_d_s_logo.s
+++ b/asm/rodata/rodata_d_s_logo.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80399fe0 - 0x8039a2a8
+
+.global lbl_80399FE0
+lbl_80399FE0:
+.incbin "baserom.dol", 0x396FE0, 0x1C
+
+.global lbl_80399FFC
+lbl_80399FFC:
+.incbin "baserom.dol", 0x396FFC, 0x2AC
+

--- a/asm/rodata/rodata_d_s_name.s
+++ b/asm/rodata/rodata_d_s_name.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a2a8 - 0x8039a2c8
+
+.global lbl_8039A2A8
+lbl_8039A2A8:
+.incbin "baserom.dol", 0x3972A8, 0x20
+

--- a/asm/rodata/rodata_d_s_play.s
+++ b/asm/rodata/rodata_d_s_play.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a2c8 - 0x8039a388
+
+.global lbl_8039A2C8
+lbl_8039A2C8:
+.incbin "baserom.dol", 0x3972C8, 0x10
+
+.global lbl_8039A2D8
+lbl_8039A2D8:
+.incbin "baserom.dol", 0x3972D8, 0xB0
+

--- a/asm/rodata/rodata_d_s_room.s
+++ b/asm/rodata/rodata_d_s_room.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a388 - 0x8039a3d8
+
+.global lbl_8039A388
+lbl_8039A388:
+.incbin "baserom.dol", 0x397388, 0x50
+

--- a/asm/rodata/rodata_d_save.s
+++ b/asm/rodata/rodata_d_save.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803790c0 - 0x80379298
+
+.global lbl_803790C0
+lbl_803790C0:
+.incbin "baserom.dol", 0x3760C0, 0x174
+
+.global lbl_80379234
+lbl_80379234:
+.incbin "baserom.dol", 0x376234, 0x64
+

--- a/asm/rodata/rodata_d_scope.s
+++ b/asm/rodata/rodata_d_scope.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803949f0 - 0x80394a10
+
+.global lbl_803949F0
+lbl_803949F0:
+.incbin "baserom.dol", 0x3919F0, 0x20
+

--- a/asm/rodata/rodata_d_select_cursor.s
+++ b/asm/rodata/rodata_d_select_cursor.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394a10 - 0x80394c10
+
+.global lbl_80394A10
+lbl_80394A10:
+.incbin "baserom.dol", 0x391A10, 0x20
+
+.global lbl_80394A30
+lbl_80394A30:
+.incbin "baserom.dol", 0x391A30, 0x20
+
+.global lbl_80394A50
+lbl_80394A50:
+.incbin "baserom.dol", 0x391A50, 0x40
+
+.global lbl_80394A90
+lbl_80394A90:
+.incbin "baserom.dol", 0x391A90, 0x10
+
+.global lbl_80394AA0
+lbl_80394AA0:
+.incbin "baserom.dol", 0x391AA0, 0x170
+

--- a/asm/rodata/rodata_d_shop_system.s
+++ b/asm/rodata/rodata_d_shop_system.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80394c10 - 0x80394c28
+
+.global lbl_80394C10
+lbl_80394C10:
+.incbin "baserom.dol", 0x391C10, 0x18
+

--- a/asm/rodata/rodata_d_stage.s
+++ b/asm/rodata/rodata_d_stage.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80378a50 - 0x80378e48
+
+.global lbl_80378A50
+lbl_80378A50:
+.incbin "baserom.dol", 0x375A50, 0x3F8
+

--- a/asm/rodata/rodata_d_timer.s
+++ b/asm/rodata/rodata_d_timer.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a3d8 - 0x8039a488
+
+.global lbl_8039A3D8
+lbl_8039A3D8:
+.incbin "baserom.dol", 0x3973D8, 0xB0
+

--- a/asm/rodata/rodata_d_tresure.s
+++ b/asm/rodata/rodata_d_tresure.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037b0d8 - 0x8037b100
+
+.global lbl_8037B0D8
+lbl_8037B0D8:
+.incbin "baserom.dol", 0x3780D8, 0x28
+

--- a/asm/rodata/rodata_d_vib_pattern.s
+++ b/asm/rodata/rodata_d_vib_pattern.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8037a620 - 0x8037a770
+
+.global lbl_8037A620
+lbl_8037A620:
+.incbin "baserom.dol", 0x377620, 0x58
+
+.global lbl_8037A678
+lbl_8037A678:
+.incbin "baserom.dol", 0x377678, 0x58
+
+.global lbl_8037A6D0
+lbl_8037A6D0:
+.incbin "baserom.dol", 0x3776D0, 0x50
+
+.global lbl_8037A720
+lbl_8037A720:
+.incbin "baserom.dol", 0x377720, 0x50
+

--- a/asm/rodata/rodata_dispatch.s
+++ b/asm/rodata/rodata_dispatch.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2890 - 0x803a28d0
+
+.global lbl_803A2890
+lbl_803A2890:
+.incbin "baserom.dol", 0x39F890, 0x1C
+
+.global lbl_803A28AC
+lbl_803A28AC:
+.incbin "baserom.dol", 0x39F8AC, 0x24
+

--- a/asm/rodata/rodata_dolphin_trk_glue.s
+++ b/asm/rodata/rodata_dolphin_trk_glue.s
@@ -1,0 +1,39 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2c08 - 0x803a2d10
+
+.global lbl_803A2C08
+lbl_803A2C08:
+.incbin "baserom.dol", 0x39FC08, 0x4
+
+.global lbl_803A2C0C
+lbl_803A2C0C:
+.incbin "baserom.dol", 0x39FC0C, 0x4
+
+.global lbl_803A2C10
+lbl_803A2C10:
+.incbin "baserom.dol", 0x39FC10, 0x18
+
+.global lbl_803A2C28
+lbl_803A2C28:
+.incbin "baserom.dol", 0x39FC28, 0x18
+
+.global lbl_803A2C40
+lbl_803A2C40:
+.incbin "baserom.dol", 0x39FC40, 0x24
+
+.global lbl_803A2C64
+lbl_803A2C64:
+.incbin "baserom.dol", 0x39FC64, 0x24
+
+.global lbl_803A2C88
+lbl_803A2C88:
+.incbin "baserom.dol", 0x39FC88, 0x2C
+
+.global lbl_803A2CB4
+lbl_803A2CB4:
+.incbin "baserom.dol", 0x39FCB4, 0x30
+
+.global lbl_803A2CE4
+lbl_803A2CE4:
+.incbin "baserom.dol", 0x39FCE4, 0x2C
+

--- a/asm/rodata/rodata_e_exp.s
+++ b/asm/rodata/rodata_e_exp.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2340 - 0x803a2370
+
+.global lbl_803A2340
+lbl_803A2340:
+.incbin "baserom.dol", 0x39F340, 0x10
+
+.global lbl_803A2350
+lbl_803A2350:
+.incbin "baserom.dol", 0x39F350, 0x10
+
+.global lbl_803A2360
+lbl_803A2360:
+.incbin "baserom.dol", 0x39F360, 0x10
+

--- a/asm/rodata/rodata_e_fmod.s
+++ b/asm/rodata/rodata_e_fmod.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2370 - 0x803a2380
+
+.global lbl_803A2370
+lbl_803A2370:
+.incbin "baserom.dol", 0x39F370, 0x10
+

--- a/asm/rodata/rodata_e_pow.s
+++ b/asm/rodata/rodata_e_pow.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2380 - 0x803a23b0
+
+.global lbl_803A2380
+lbl_803A2380:
+.incbin "baserom.dol", 0x39F380, 0x10
+
+.global lbl_803A2390
+lbl_803A2390:
+.incbin "baserom.dol", 0x39F390, 0x10
+
+.global lbl_803A23A0
+lbl_803A23A0:
+.incbin "baserom.dol", 0x39F3A0, 0x10
+

--- a/asm/rodata/rodata_e_rem_pio2.s
+++ b/asm/rodata/rodata_e_rem_pio2.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a23b0 - 0x803a2538
+
+.global lbl_803A23B0
+lbl_803A23B0:
+.incbin "baserom.dol", 0x39F3B0, 0x108
+
+.global lbl_803A24B8
+lbl_803A24B8:
+.incbin "baserom.dol", 0x39F4B8, 0x80
+

--- a/asm/rodata/rodata_f_op_actor.s
+++ b/asm/rodata/rodata_f_op_actor.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80378878 - 0x80378880
+
+.global lbl_80378878
+lbl_80378878:
+.incbin "baserom.dol", 0x375878, 0x8
+

--- a/asm/rodata/rodata_f_op_actor_mng.s
+++ b/asm/rodata/rodata_f_op_actor_mng.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80378880 - 0x80378a50
+
+.global lbl_80378880
+lbl_80378880:
+.incbin "baserom.dol", 0x375880, 0xC
+
+.global lbl_8037888C
+lbl_8037888C:
+.incbin "baserom.dol", 0x37588C, 0xC
+
+.global lbl_80378898
+lbl_80378898:
+.incbin "baserom.dol", 0x375898, 0x30
+
+.global lbl_803788C8
+lbl_803788C8:
+.incbin "baserom.dol", 0x3758C8, 0x188
+

--- a/asm/rodata/rodata_functionvalue.s
+++ b/asm/rodata/rodata_functionvalue.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039a9f0 - 0x8039aa00
+
+.global lbl_8039A9F0
+lbl_8039A9F0:
+.incbin "baserom.dol", 0x3979F0, 0x10
+

--- a/asm/rodata/rodata_fvb.s
+++ b/asm/rodata/rodata_fvb.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039aa00 - 0x8039aa40
+
+.global lbl_8039AA00
+lbl_8039AA00:
+.incbin "baserom.dol", 0x397A00, 0x40
+

--- a/asm/rodata/rodata_jstudio-control.s
+++ b/asm/rodata/rodata_jstudio-control.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039aa40 - 0x8039aa68
+
+.global lbl_8039AA40
+lbl_8039AA40:
+.incbin "baserom.dol", 0x397A40, 0xC
+
+.global lbl_8039AA4C
+lbl_8039AA4C:
+.incbin "baserom.dol", 0x397A4C, 0xC
+
+.global lbl_8039AA58
+lbl_8039AA58:
+.incbin "baserom.dol", 0x397A58, 0x10
+

--- a/asm/rodata/rodata_jstudio-object.s
+++ b/asm/rodata/rodata_jstudio-object.s
@@ -1,0 +1,91 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039aa68 - 0x8039ab88
+
+.global lbl_8039AA68
+lbl_8039AA68:
+.incbin "baserom.dol", 0x397A68, 0xC
+
+.global lbl_8039AA74
+lbl_8039AA74:
+.incbin "baserom.dol", 0x397A74, 0xC
+
+.global lbl_8039AA80
+lbl_8039AA80:
+.incbin "baserom.dol", 0x397A80, 0xC
+
+.global lbl_8039AA8C
+lbl_8039AA8C:
+.incbin "baserom.dol", 0x397A8C, 0xC
+
+.global lbl_8039AA98
+lbl_8039AA98:
+.incbin "baserom.dol", 0x397A98, 0x10
+
+.global lbl_8039AAA8
+lbl_8039AAA8:
+.incbin "baserom.dol", 0x397AA8, 0xC
+
+.global lbl_8039AAB4
+lbl_8039AAB4:
+.incbin "baserom.dol", 0x397AB4, 0xC
+
+.global lbl_8039AAC0
+lbl_8039AAC0:
+.incbin "baserom.dol", 0x397AC0, 0xC
+
+.global lbl_8039AACC
+lbl_8039AACC:
+.incbin "baserom.dol", 0x397ACC, 0x10
+
+.global lbl_8039AADC
+lbl_8039AADC:
+.incbin "baserom.dol", 0x397ADC, 0xC
+
+.global lbl_8039AAE8
+lbl_8039AAE8:
+.incbin "baserom.dol", 0x397AE8, 0x10
+
+.global lbl_8039AAF8
+lbl_8039AAF8:
+.incbin "baserom.dol", 0x397AF8, 0xC
+
+.global lbl_8039AB04
+lbl_8039AB04:
+.incbin "baserom.dol", 0x397B04, 0xC
+
+.global lbl_8039AB10
+lbl_8039AB10:
+.incbin "baserom.dol", 0x397B10, 0xC
+
+.global lbl_8039AB1C
+lbl_8039AB1C:
+.incbin "baserom.dol", 0x397B1C, 0xC
+
+.global lbl_8039AB28
+lbl_8039AB28:
+.incbin "baserom.dol", 0x397B28, 0xC
+
+.global lbl_8039AB34
+lbl_8039AB34:
+.incbin "baserom.dol", 0x397B34, 0xC
+
+.global lbl_8039AB40
+lbl_8039AB40:
+.incbin "baserom.dol", 0x397B40, 0x10
+
+.global lbl_8039AB50
+lbl_8039AB50:
+.incbin "baserom.dol", 0x397B50, 0xC
+
+.global lbl_8039AB5C
+lbl_8039AB5C:
+.incbin "baserom.dol", 0x397B5C, 0x10
+
+.global lbl_8039AB6C
+lbl_8039AB6C:
+.incbin "baserom.dol", 0x397B6C, 0xC
+
+.global lbl_8039AB78
+lbl_8039AB78:
+.incbin "baserom.dol", 0x397B78, 0x10
+

--- a/asm/rodata/rodata_k_rem_pio2.s
+++ b/asm/rodata/rodata_k_rem_pio2.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2538 - 0x803a2588
+
+.global lbl_803A2538
+lbl_803A2538:
+.incbin "baserom.dol", 0x39F538, 0x10
+
+.global lbl_803A2548
+lbl_803A2548:
+.incbin "baserom.dol", 0x39F548, 0x40
+

--- a/asm/rodata/rodata_k_tan.s
+++ b/asm/rodata/rodata_k_tan.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2588 - 0x803a25f0
+
+.global lbl_803A2588
+lbl_803A2588:
+.incbin "baserom.dol", 0x39F588, 0x68
+

--- a/asm/rodata/rodata_m_Do_MemCard.s
+++ b/asm/rodata/rodata_m_Do_MemCard.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803743f8 - 0x80374408
+
+.global lbl_803743F8
+lbl_803743F8:
+.incbin "baserom.dol", 0x3713F8, 0x10
+

--- a/asm/rodata/rodata_m_Do_MemCardRWmng.s
+++ b/asm/rodata/rodata_m_Do_MemCardRWmng.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80374408 - 0x80374460
+
+.global lbl_80374408
+lbl_80374408:
+.incbin "baserom.dol", 0x371408, 0x58
+

--- a/asm/rodata/rodata_m_Do_Reset.s
+++ b/asm/rodata/rodata_m_Do_Reset.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80374198 - 0x803741a8
+
+.global lbl_80374198
+lbl_80374198:
+.incbin "baserom.dol", 0x371198, 0x10
+

--- a/asm/rodata/rodata_m_Do_audio.s
+++ b/asm/rodata/rodata_m_Do_audio.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80373d68 - 0x80373dd0
+
+.global lbl_80373D68
+lbl_80373D68:
+.incbin "baserom.dol", 0x370D68, 0x68
+

--- a/asm/rodata/rodata_m_Do_dvd_thread.s
+++ b/asm/rodata/rodata_m_Do_dvd_thread.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803741a8 - 0x803743f8
+
+.global lbl_803741A8
+lbl_803741A8:
+.incbin "baserom.dol", 0x3711A8, 0x250
+

--- a/asm/rodata/rodata_m_Do_ext.s
+++ b/asm/rodata/rodata_m_Do_ext.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803740c0 - 0x80374198
+
+.global lbl_803740C0
+lbl_803740C0:
+.incbin "baserom.dol", 0x3710C0, 0x14
+
+.global lbl_803740D4
+lbl_803740D4:
+.incbin "baserom.dol", 0x3710D4, 0x14
+
+.global lbl_803740E8
+lbl_803740E8:
+.incbin "baserom.dol", 0x3710E8, 0x14
+
+.global lbl_803740FC
+lbl_803740FC:
+.incbin "baserom.dol", 0x3710FC, 0x9C
+

--- a/asm/rodata/rodata_m_Do_graphic.s
+++ b/asm/rodata/rodata_m_Do_graphic.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80373dd0 - 0x80373de8
+
+.global lbl_80373DD0
+lbl_80373DD0:
+.incbin "baserom.dol", 0x370DD0, 0x18
+

--- a/asm/rodata/rodata_m_Do_machine.s
+++ b/asm/rodata/rodata_m_Do_machine.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80373de8 - 0x803740c0
+
+.global lbl_80373DE8
+lbl_80373DE8:
+.incbin "baserom.dol", 0x370DE8, 0x2D8
+

--- a/asm/rodata/rodata_m_Do_machine_exception.s
+++ b/asm/rodata/rodata_m_Do_machine_exception.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80374460 - 0x80374640
+
+.global lbl_80374460
+lbl_80374460:
+.incbin "baserom.dol", 0x371460, 0x1E0
+

--- a/asm/rodata/rodata_m_Do_main.s
+++ b/asm/rodata/rodata_m_Do_main.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803739a0 - 0x80373cb0
+
+.global lbl_803739A0
+lbl_803739A0:
+.incbin "baserom.dol", 0x3709A0, 0x310
+

--- a/asm/rodata/rodata_m_Do_printf.s
+++ b/asm/rodata/rodata_m_Do_printf.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x80373cb0 - 0x80373d68
+
+.global lbl_80373CB0
+lbl_80373CB0:
+.incbin "baserom.dol", 0x370CB0, 0xB8
+

--- a/asm/rodata/rodata_main.s
+++ b/asm/rodata/rodata_main.s
@@ -1,0 +1,59 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2d10 - 0x0
+
+.global lbl_803A2D10
+lbl_803A2D10:
+.incbin "baserom.dol", 0x39FD10, 0x14
+
+.global lbl_803A2D24
+lbl_803A2D24:
+.incbin "baserom.dol", 0x39FD24, 0x2C
+
+.global lbl_803A2D50
+lbl_803A2D50:
+.incbin "baserom.dol", 0x39FD50, 0x1C
+
+.global lbl_803A2D6C
+lbl_803A2D6C:
+.incbin "baserom.dol", 0x39FD6C, 0x28
+
+.global lbl_803A2D94
+lbl_803A2D94:
+.incbin "baserom.dol", 0x39FD94, 0x30
+
+.global lbl_803A2DC4
+lbl_803A2DC4:
+.incbin "baserom.dol", 0x39FDC4, 0x14
+
+.global lbl_803A2DD8
+lbl_803A2DD8:
+.incbin "baserom.dol", 0x39FDD8, 0x18
+
+.global lbl_803A2DF0
+lbl_803A2DF0:
+.incbin "baserom.dol", 0x39FDF0, 0x14
+
+.global lbl_803A2E04
+lbl_803A2E04:
+.incbin "baserom.dol", 0x39FE04, 0x2C
+
+.global lbl_803A2E30
+lbl_803A2E30:
+.incbin "baserom.dol", 0x39FE30, 0x1C
+
+.global lbl_803A2E4C
+lbl_803A2E4C:
+.incbin "baserom.dol", 0x39FE4C, 0x28
+
+.global lbl_803A2E74
+lbl_803A2E74:
+.incbin "baserom.dol", 0x39FE74, 0x30
+
+.global lbl_803A2EA4
+lbl_803A2EA4:
+.incbin "baserom.dol", 0x39FEA4, 0x14
+
+.global lbl_803A2EB8
+lbl_803A2EB8:
+.incbin "baserom.dol", 0x39FEB8, 0x28
+

--- a/asm/rodata/rodata_main_TRK.s
+++ b/asm/rodata/rodata_main_TRK.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2bf8 - 0x803a2c08
+
+.global lbl_803A2BF8
+lbl_803A2BF8:
+.incbin "baserom.dol", 0x39FBF8, 0x10
+

--- a/asm/rodata/rodata_msg.s
+++ b/asm/rodata/rodata_msg.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a26b8 - 0x803a26e0
+
+.global lbl_803A26B8
+lbl_803A26B8:
+.incbin "baserom.dol", 0x39F6B8, 0x28
+

--- a/asm/rodata/rodata_msgbuf.s
+++ b/asm/rodata/rodata_msgbuf.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a26e0 - 0x803a2700
+
+.global lbl_803A26E0
+lbl_803A26E0:
+.incbin "baserom.dol", 0x39F6E0, 0x20
+

--- a/asm/rodata/rodata_msghndlr.s
+++ b/asm/rodata/rodata_msghndlr.s
@@ -1,0 +1,67 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a28d0 - 0x803a2ab8
+
+.global lbl_803A28D0
+lbl_803A28D0:
+.incbin "baserom.dol", 0x39F8D0, 0x20
+
+.global lbl_803A28F0
+lbl_803A28F0:
+.incbin "baserom.dol", 0x39F8F0, 0x8
+
+.global lbl_803A28F8
+lbl_803A28F8:
+.incbin "baserom.dol", 0x39F8F8, 0xC
+
+.global lbl_803A2904
+lbl_803A2904:
+.incbin "baserom.dol", 0x39F904, 0xC
+
+.global lbl_803A2910
+lbl_803A2910:
+.incbin "baserom.dol", 0x39F910, 0x20
+
+.global lbl_803A2930
+lbl_803A2930:
+.incbin "baserom.dol", 0x39F930, 0x20
+
+.global lbl_803A2950
+lbl_803A2950:
+.incbin "baserom.dol", 0x39F950, 0x18
+
+.global lbl_803A2968
+lbl_803A2968:
+.incbin "baserom.dol", 0x39F968, 0x28
+
+.global lbl_803A2990
+lbl_803A2990:
+.incbin "baserom.dol", 0x39F990, 0x38
+
+.global lbl_803A29C8
+lbl_803A29C8:
+.incbin "baserom.dol", 0x39F9C8, 0x28
+
+.global lbl_803A29F0
+lbl_803A29F0:
+.incbin "baserom.dol", 0x39F9F0, 0x30
+
+.global lbl_803A2A20
+lbl_803A2A20:
+.incbin "baserom.dol", 0x39FA20, 0x30
+
+.global lbl_803A2A50
+lbl_803A2A50:
+.incbin "baserom.dol", 0x39FA50, 0x30
+
+.global lbl_803A2A80
+lbl_803A2A80:
+.incbin "baserom.dol", 0x39FA80, 0x2C
+
+.global lbl_803A2AAC
+lbl_803A2AAC:
+.incbin "baserom.dol", 0x39FAAC, 0x8
+
+.global lbl_803A2AB4
+lbl_803A2AB4:
+.incbin "baserom.dol", 0x39FAB4, 0x4
+

--- a/asm/rodata/rodata_nubinit.s
+++ b/asm/rodata/rodata_nubinit.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2688 - 0x803a26b8
+
+.global lbl_803A2688
+lbl_803A2688:
+.incbin "baserom.dol", 0x39F688, 0x1C
+
+.global lbl_803A26A4
+lbl_803A26A4:
+.incbin "baserom.dol", 0x39F6A4, 0x14
+

--- a/asm/rodata/rodata_osdsp.s
+++ b/asm/rodata/rodata_osdsp.s
@@ -1,0 +1,11 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039b8b8 - 0x8039b8f8
+
+.global lbl_8039B8B8
+lbl_8039B8B8:
+.incbin "baserom.dol", 0x3988B8, 0x1C
+
+.global lbl_8039B8D4
+lbl_8039B8D4:
+.incbin "baserom.dol", 0x3988D4, 0x24
+

--- a/asm/rodata/rodata_printf.s
+++ b/asm/rodata/rodata_printf.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2318 - 0x803a2340
+
+.global lbl_803A2318
+lbl_803A2318:
+.incbin "baserom.dol", 0x39F318, 0x28
+

--- a/asm/rodata/rodata_ptmf.s
+++ b/asm/rodata/rodata_ptmf.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2180 - 0x803a2190
+
+.global lbl_803A2180
+lbl_803A2180:
+.incbin "baserom.dol", 0x39F180, 0x10
+

--- a/asm/rodata/rodata_runtime.s
+++ b/asm/rodata/rodata_runtime.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2190 - 0x803a21a8
+
+.global lbl_803A2190
+lbl_803A2190:
+.incbin "baserom.dol", 0x39F190, 0x18
+

--- a/asm/rodata/rodata_s_atan.s
+++ b/asm/rodata/rodata_s_atan.s
@@ -1,0 +1,15 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a25f0 - 0x803a2688
+
+.global lbl_803A25F0
+lbl_803A25F0:
+.incbin "baserom.dol", 0x39F5F0, 0x20
+
+.global lbl_803A2610
+lbl_803A2610:
+.incbin "baserom.dol", 0x39F610, 0x20
+
+.global lbl_803A2630
+lbl_803A2630:
+.incbin "baserom.dol", 0x39F630, 0x58
+

--- a/asm/rodata/rodata_serpoll.s
+++ b/asm/rodata/rodata_serpoll.s
@@ -1,0 +1,47 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2700 - 0x803a2890
+
+.global lbl_803A2700
+lbl_803A2700:
+.incbin "baserom.dol", 0x39F700, 0x24
+
+.global lbl_803A2724
+lbl_803A2724:
+.incbin "baserom.dol", 0x39F724, 0x24
+
+.global lbl_803A2748
+lbl_803A2748:
+.incbin "baserom.dol", 0x39F748, 0x24
+
+.global lbl_803A276C
+lbl_803A276C:
+.incbin "baserom.dol", 0x39F76C, 0x20
+
+.global lbl_803A278C
+lbl_803A278C:
+.incbin "baserom.dol", 0x39F78C, 0x20
+
+.global lbl_803A27AC
+lbl_803A27AC:
+.incbin "baserom.dol", 0x39F7AC, 0x24
+
+.global lbl_803A27D0
+lbl_803A27D0:
+.incbin "baserom.dol", 0x39F7D0, 0x24
+
+.global lbl_803A27F4
+lbl_803A27F4:
+.incbin "baserom.dol", 0x39F7F4, 0x1C
+
+.global lbl_803A2810
+lbl_803A2810:
+.incbin "baserom.dol", 0x39F810, 0x34
+
+.global lbl_803A2844
+lbl_803A2844:
+.incbin "baserom.dol", 0x39F844, 0x28
+
+.global lbl_803A286C
+lbl_803A286C:
+.incbin "baserom.dol", 0x39F86C, 0x24
+

--- a/asm/rodata/rodata_stb-data.s
+++ b/asm/rodata/rodata_stb-data.s
@@ -1,0 +1,7 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x8039ab88 - 0x8039aba8
+
+.global lbl_8039AB88
+lbl_8039AB88:
+.incbin "baserom.dol", 0x397B88, 0x20
+

--- a/asm/rodata/rodata_support.s
+++ b/asm/rodata/rodata_support.s
@@ -1,0 +1,19 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2ab8 - 0x803a2b60
+
+.global lbl_803A2AB8
+lbl_803A2AB8:
+.incbin "baserom.dol", 0x39FAB8, 0x18
+
+.global lbl_803A2AD0
+lbl_803A2AD0:
+.incbin "baserom.dol", 0x39FAD0, 0x28
+
+.global lbl_803A2AF8
+lbl_803A2AF8:
+.incbin "baserom.dol", 0x39FAF8, 0x14
+
+.global lbl_803A2B0C
+lbl_803A2B0C:
+.incbin "baserom.dol", 0x39FB0C, 0x54
+

--- a/asm/rodata/rodata_targimpl.s
+++ b/asm/rodata/rodata_targimpl.s
@@ -1,0 +1,23 @@
+.include "macros.inc"
+.section .rodata, "a"  # 0x803a2b60 - 0x803a2bf8
+
+.global lbl_803A2B60
+lbl_803A2B60:
+.incbin "baserom.dol", 0x39FB60, 0x10
+
+.global lbl_803A2B70
+lbl_803A2B70:
+.incbin "baserom.dol", 0x39FB70, 0x28
+
+.global lbl_803A2B98
+lbl_803A2B98:
+.incbin "baserom.dol", 0x39FB98, 0x28
+
+.global lbl_803A2BC0
+lbl_803A2BC0:
+.incbin "baserom.dol", 0x39FBC0, 0x28
+
+.global lbl_803A2BE8
+lbl_803A2BE8:
+.incbin "baserom.dol", 0x39FBE8, 0x10
+

--- a/ldscript.lcf
+++ b/ldscript.lcf
@@ -756,6 +756,7 @@ SECTIONS {
 "__vt__20J3DAnmVisibilityFull" = 0x803cf274;
 
 "__dt__7JKRFileFv" = 0x802D7B90;
+"lbl_8039CE50" = 0x8039CE50;
 }
 FORCEACTIVE {
  getParentPane__7J2DPaneFv

--- a/libs/JSystem/JKernel/JKRSolidHeap.cpp
+++ b/libs/JSystem/JKernel/JKRSolidHeap.cpp
@@ -122,9 +122,7 @@ void* JKRSolidHeap::allocFromHead(u32 size, int alignment) {
         mSolidHead += totalSize;
         mFreeSize -= totalSize;
     } else {
-        // "allocFromHead: cannot alloc memory (0x%x byte).\n"
-        const char* format = lbl_8039CE50;
-        JUTWarningConsole_f(format, totalSize);
+        JUTWarningConsole_f("allocFromHead: cannot alloc memory (0x%x byte).\n", totalSize);
         if (getErrorFlag() == true) {
             callErrorHandler(this, alignedSize, alignment);
         }
@@ -133,21 +131,25 @@ void* JKRSolidHeap::allocFromHead(u32 size, int alignment) {
     return ptr;
 }
 #else
+#if 1
+const char* _allocFromHead_str0 = "allocFromHead: cannot alloc memory (0x%x byte).\n";
+#endif
 asm void* JKRSolidHeap::allocFromHead(u32, int) {
     nofralloc
 #include "JSystem/JKernel/JKRSolidHeap/asm/func_802D0D58.s"
 }
 #endif
 
+#if 1
+const char* _allocFromTail_str0 = "allocFromTail: cannot alloc memory (0x%x byte).\n";
+#endif
 asm void* JKRSolidHeap::allocFromTail(u32, int) {
     nofralloc
 #include "JSystem/JKernel/JKRSolidHeap/asm/func_802D0E20.s"
 }
 
 void JKRSolidHeap::do_free(void* ptr) {
-    // "free: cannot free memory block (%08x)\n"
-    const char* format = lbl_8039CE50 + 0x62;
-    JUTWarningConsole_f(format, ptr);
+    JUTWarningConsole_f("free: cannot free memory block (%08x)\n", ptr);
 }
 
 void JKRSolidHeap::do_freeAll(void) {
@@ -188,16 +190,12 @@ void JKRSolidHeap::do_fillFreeArea(void) {
 }
 
 s32 JKRSolidHeap::do_resize(void* ptr, u32 newSize) {
-    // "resize: cannot resize memory block (%08x: %d)\n"
-    const char* format = lbl_8039CE50 + 0x89;
-    JUTWarningConsole_f(format, ptr, newSize);
+    JUTWarningConsole_f("resize: cannot resize memory block (%08x: %d)\n", ptr, newSize);
     return -1;
 }
 
 s32 JKRSolidHeap::do_getSize(void* ptr) const {
-    // "getSize: cannot get memory block size (%08x)\n"
-    const char* format = lbl_8039CE50 + 0xB8;
-    JUTWarningConsole_f(format, ptr);
+    JUTWarningConsole_f("getSize: cannot get memory block size (%08x)\n", ptr);
     return -1;
 }
 
@@ -210,9 +208,7 @@ bool JKRSolidHeap::check(void) {
     u32 availableSize = mSize;
     if (calculatedSize != availableSize) {
         result = false;
-        // "check: bad total memory block size (%08X, %08X)\n"
-        const char* format = lbl_8039CE50 + 0xE6;
-        JUTWarningConsole_f(format, availableSize, calculatedSize);
+        JUTWarningConsole_f("check: bad total memory block size (%08X, %08X)\n", availableSize, calculatedSize);
     }
 
     unlock();
@@ -230,21 +226,22 @@ bool JKRSolidHeap::dump(void) {
     u32 headSize = ((u32)mSolidHead - (u32)mStart);
     u32 tailSize = ((u32)mEnd - (u32)mSolidTail);
     s32 htSize = headSize + tailSize;
-    const char* format1 = lbl_8039CE50 + 0x117;  // "head %08x: %08x\n"
-    JUTReportConsole_f(format1, mStart, headSize);
-
-    const char* format2 = lbl_8039CE50 + 0x128;  // "tail %08x: %08x\n"
-    JUTReportConsole_f(format2, mSolidTail, ((u32)mEnd - (u32)mSolidTail));
+    JUTReportConsole_f("head %08x: %08x\n", mStart, headSize);
+    JUTReportConsole_f("tail %08x: %08x\n", mSolidTail, ((u32)mEnd - (u32)mSolidTail));
 
     u32 totalSize = mSize;
     float percentage = (float)htSize / (float)totalSize * lbl_80455FA8;
-    const char* format3 = lbl_8039CE50 + 0x139;  // "%d / %d bytes (%6.2f%%) used\n"
-    JUTReportConsole_f(format3, htSize, totalSize, percentage);
+    JUTReportConsole_f("%d / %d bytes (%6.2f%%) used\n", htSize, totalSize, percentage);
     unlock();
 
     return result;
 }
 #else
+#if 1
+const char* _dump_str0 = "head %08x: %08x\n";
+const char* _dump_str1 = "tail %08x: %08x\n";
+const char* _dump_str2 = "%d / %d bytes (%6.2f%%) used\n";
+#endif
 asm bool JKRSolidHeap::dump(void) {
     nofralloc
 #include "JSystem/JKernel/JKRSolidHeap/asm/func_802D10FC.s"

--- a/libs/JSystem/JKernel/JKRSolidHeap.cpp
+++ b/libs/JSystem/JKernel/JKRSolidHeap.cpp
@@ -208,7 +208,8 @@ bool JKRSolidHeap::check(void) {
     u32 availableSize = mSize;
     if (calculatedSize != availableSize) {
         result = false;
-        JUTWarningConsole_f("check: bad total memory block size (%08X, %08X)\n", availableSize, calculatedSize);
+        JUTWarningConsole_f("check: bad total memory block size (%08X, %08X)\n", availableSize,
+                            calculatedSize);
     }
 
     unlock();

--- a/obj_files.mk
+++ b/obj_files.mk
@@ -10,27 +10,41 @@ EXTABINDEX_O_FILES :=                               \
     $(BUILD_DIR)/asm/extabindex.o
 
 TEXT_O_FILES := 						            \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_main.o \
             $(BUILD_DIR)/src/m_Do/m_Do_main.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_printf.o \
             $(BUILD_DIR)/asm/m/Do/m_Do_printf.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_audio.o \
             $(BUILD_DIR)/src/m_Do/m_Do_audio.o    \
             $(BUILD_DIR)/src/m_Do/m_Do_controller_pad.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_graphic.o \
             $(BUILD_DIR)/asm/m/Do/m_Do_graphic.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_machine.o \
             $(BUILD_DIR)/asm/m/Do/m_Do_machine.o    \
             $(BUILD_DIR)/asm/m/Do/m_Do_mtx.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_ext.o \
             $(BUILD_DIR)/asm/m/Do/m_Do_ext.o    \
             $(BUILD_DIR)/asm/m/Do/m_Do_lib.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_Reset.o \
             $(BUILD_DIR)/src/m_Do/m_Do_Reset.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_dvd_thread.o \
             $(BUILD_DIR)/asm/m/Do/dvd/m_Do_dvd_thread.o    \
             $(BUILD_DIR)/asm/m/Do/m_Do_DVDError.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_MemCard.o \
             $(BUILD_DIR)/asm/m/Do/m_Do_MemCard.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_MemCardRWmng.o \
             $(BUILD_DIR)/asm/m/Do/m_Do_MemCardRWmng.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_m_Do_machine_exception.o \
             $(BUILD_DIR)/asm/m/Do/machine/m_Do_machine_exception.o    \
             $(BUILD_DIR)/asm/c/c_damagereaction.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_c_dylink.o \
             $(BUILD_DIR)/asm/c/c_dylink.o    \
             $(BUILD_DIR)/asm/f/ap/f_ap_game.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_f_op_actor.o \
             $(BUILD_DIR)/asm/f/op/f_op_actor.o    \
             $(BUILD_DIR)/asm/f/op/actor/f_op_actor_iter.o    \
             $(BUILD_DIR)/src/f/f_op/f_op_actor_tag.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_f_op_actor_mng.o \
             $(BUILD_DIR)/asm/f/op/actor/f_op_actor_mng.o    \
             $(BUILD_DIR)/asm/f/op/f_op_camera.o    \
             $(BUILD_DIR)/asm/f/op/camera/f_op_camera_mng.o    \
@@ -80,39 +94,61 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/src/f/f_pc/f_pc_draw.o    \
             $(BUILD_DIR)/src/f/f_pc/f_pc_fstcreate_req.o    \
             $(BUILD_DIR)/src/f/f_pc/f_pc_stdcreate_req.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_stage.o \
             $(BUILD_DIR)/src/d/d_stage.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_map.o \
             $(BUILD_DIR)/asm/d/d_map.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_com_inf_game.o \
             $(BUILD_DIR)/src/d/d_com/d_com_inf_game.o  \
+            $(BUILD_DIR)/asm/rodata/rodata_d_com_static.o \
             $(BUILD_DIR)/asm/d/com/d_com_static.o    \
             $(BUILD_DIR)/src/d/d_bomb.o    \
             $(BUILD_DIR)/src/d/d_lib.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_save.o \
             $(BUILD_DIR)/src/d/d_save/d_save.o \
             $(BUILD_DIR)/src/d/d_save/d_save_init.o    \
             $(BUILD_DIR)/asm/d/jnt/d_jnt_col.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_obj.o \
             $(BUILD_DIR)/asm/d/a/d_a_obj.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_itembase_static.o \
             $(BUILD_DIR)/asm/d/a/itembase/d_a_itembase_static.o    \
             $(BUILD_DIR)/src/d/d_a/d_a_item_static.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_shop_item_static.o \
             $(BUILD_DIR)/asm/d/a/shop/item/d_a_shop_item_static.o    \
             $(BUILD_DIR)/src/d/d_a/d_a_horse_static.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_demo.o \
             $(BUILD_DIR)/asm/d/d_demo.o    \
             $(BUILD_DIR)/asm/d/door/d_door_param2.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_resorce.o \
             $(BUILD_DIR)/asm/d/d_resorce.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_map_path.o \
             $(BUILD_DIR)/asm/d/map/d_map_path.o    \
             $(BUILD_DIR)/asm/d/map/path/d_map_path_fmap.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_map_path_dmap.o \
             $(BUILD_DIR)/asm/d/map/path/d_map_path_dmap.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_event.o \
             $(BUILD_DIR)/asm/d/d_event.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_event_data.o \
             $(BUILD_DIR)/asm/d/event/d_event_data.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_event_manager.o \
             $(BUILD_DIR)/asm/d/event/d_event_manager.o    \
             $(BUILD_DIR)/asm/d/event/d_event_lib.o    \
             $(BUILD_DIR)/asm/d/simple/d_simple_model.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_particle.o \
             $(BUILD_DIR)/asm/d/d_particle.o    \
             $(BUILD_DIR)/asm/d/particle/d_particle_copoly.o    \
             $(BUILD_DIR)/asm/d/d_path.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_drawlist.o \
             $(BUILD_DIR)/asm/d/d_drawlist.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_kankyo_data.o \
             $(BUILD_DIR)/src/d/d_kankyo/d_kankyo_data.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_kankyo_wether.o \
             $(BUILD_DIR)/src/d/d_kankyo/d_kankyo_wether.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_kankyo_rain.o \
             $(BUILD_DIR)/src/d/d_kankyo/d_kankyo_rain.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_vib_pattern.o \
             $(BUILD_DIR)/asm/d/d_vibration.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_attention.o \
             $(BUILD_DIR)/src/d/d_attention.o    \
             $(BUILD_DIR)/asm/d/bg/d_bg_pc.o    \
             $(BUILD_DIR)/asm/d/bg/d_bg_plc.o    \
@@ -132,94 +168,170 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/d/bg/w/d_bg_w_base.o    \
             $(BUILD_DIR)/asm/d/bg/w/d_bg_w_kcol.o    \
             $(BUILD_DIR)/asm/d/bg/w/d_bg_w_sv.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_cc_d.o \
             $(BUILD_DIR)/asm/d/cc/d_cc_d.o    \
             $(BUILD_DIR)/asm/d/cc/mass/d_cc_mass_s.o    \
             $(BUILD_DIR)/asm/d/cc/d_cc_s.o    \
             $(BUILD_DIR)/asm/d/cc/d_cc_uty.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_cam_param.o \
             $(BUILD_DIR)/asm/d/cam/d_cam_param.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_ev_camera.o \
             $(BUILD_DIR)/asm/d/ev/d_ev_camera.o    \
             $(BUILD_DIR)/asm/d/spline/d_spline_path.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_item_data.o \
+            $(BUILD_DIR)/asm/rodata/rodata_d_item.o \
             $(BUILD_DIR)/src/d/d_item/d_item.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_tresure.o \
             $(BUILD_DIR)/asm/d/d_tresure.o    \
             $(BUILD_DIR)/asm/d/d_model.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_eye_hl.o \
             $(BUILD_DIR)/asm/d/eye/d_eye_hl.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_error_msg.o \
             $(BUILD_DIR)/asm/d/error/d_error_msg.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_alink.o \
             $(BUILD_DIR)/src/d/d_a/d_a_alink.o    \
             $(BUILD_DIR)/asm/d/a/d_a_itembase.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_no_chg_room.o \
             $(BUILD_DIR)/asm/d/a/no/chg/d_a_no_chg_room.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_npc.o \
             $(BUILD_DIR)/asm/d/a/d_a_npc.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_npc_cd.o \
             $(BUILD_DIR)/asm/d/a/npc/d_a_npc_cd.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_npc_cd2.o \
             $(BUILD_DIR)/asm/d/a/npc/d_a_npc_cd2.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_obj_item.o \
             $(BUILD_DIR)/asm/d/a/obj/d_a_obj_item.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_insect.o \
             $(BUILD_DIR)/asm/d/d_insect.o    \
             $(BUILD_DIR)/asm/d/a/obj/ss/d_a_obj_ss_base.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_a_player.o \
             $(BUILD_DIR)/asm/d/a/d_a_player.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_camera.o \
             $(BUILD_DIR)/src/d/d_camera.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_envse.o \
             $(BUILD_DIR)/asm/d/d_envse.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_file_select.o \
             $(BUILD_DIR)/asm/d/file/d_file_select.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_file_sel_warning.o \
             $(BUILD_DIR)/asm/d/file/sel/d_file_sel_warning.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_file_sel_info.o \
             $(BUILD_DIR)/src/d/d_file/d_file_sel_info.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_bright_check.o \
             $(BUILD_DIR)/asm/d/bright/d_bright_check.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_scope.o \
             $(BUILD_DIR)/asm/d/d_scope.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_select_cursor.o \
             $(BUILD_DIR)/asm/d/select/d_select_cursor.o    \
             $(BUILD_DIR)/asm/d/select/d_select_icon.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_shop_system.o \
             $(BUILD_DIR)/asm/d/shop/d_shop_camera.o    \
             $(BUILD_DIR)/asm/d/shop/item/d_shop_item_ctrl.o    \
             $(BUILD_DIR)/asm/d/shop/d_shop_system.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_gameover.o \
             $(BUILD_DIR)/asm/d/d_gameover.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_kankyo.o \
             $(BUILD_DIR)/src/d/d_kankyo.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_kyeff.o \
             $(BUILD_DIR)/asm/d/d_kyeff.o    \
             $(BUILD_DIR)/asm/d/d_kyeff2.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_ky_thunder.o \
             $(BUILD_DIR)/asm/d/ky/d_ky_thunder.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_kantera_icon_meter.o \
             $(BUILD_DIR)/src/d/d_kantera_icon_meter.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_calibration.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_calibration.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_collect.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_collect.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_dmap.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_dmap.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_dmap_map.o \
             $(BUILD_DIR)/asm/d/menu/dmap/d_menu_dmap_map.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_map_common.o \
             $(BUILD_DIR)/asm/d/menu/map/d_menu_map_common.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_fishing.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_fishing.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_fmap.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_fmap.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_fmap_map.o \
             $(BUILD_DIR)/asm/d/menu/fmap/d_menu_fmap_map.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_fmap2D.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_fmap2D.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_insect.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_insect.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_item_explain.o \
             $(BUILD_DIR)/asm/d/menu/item/d_menu_item_explain.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_letter.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_letter.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_option.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_option.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_ring.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_ring.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_save.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_save.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_skill.o \
             $(BUILD_DIR)/asm/d/menu/d_menu_skill.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_menu_window.o \
             $(BUILD_DIR)/asm/d/menu/window/d_menu_window_HIO.o    \
             $(BUILD_DIR)/asm/d/menu/d_menu_window.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter_HIO.o \
             $(BUILD_DIR)/src/d/d_meter/d_meter_HIO.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter_button.o \
             $(BUILD_DIR)/src/d/d_meter/d_meter_button.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter_haihai.o \
             $(BUILD_DIR)/src/d/d_meter/d_meter_haihai.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter_hakusha.o \
             $(BUILD_DIR)/src/d/d_meter/d_meter_hakusha.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter_map.o \
             $(BUILD_DIR)/src/d/d_meter/d_meter_map.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter_string.o \
             $(BUILD_DIR)/src/d/d_meter/d_meter_string.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter2_draw.o \
             $(BUILD_DIR)/src/d/d_meter2/d_meter2_draw.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter2_info.o \
             $(BUILD_DIR)/src/d/d_meter2/d_meter2_info.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_meter2.o \
             $(BUILD_DIR)/src/d/d_meter2.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_out_font.o \
             $(BUILD_DIR)/asm/d/msg/out/d_msg_out_font.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_class.o \
             $(BUILD_DIR)/asm/d/msg/d_msg_class.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_object.o \
             $(BUILD_DIR)/asm/d/msg/d_msg_object.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_unit.o \
             $(BUILD_DIR)/asm/d/msg/d_msg_unit.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_3select.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_3select.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_arrow.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_arrow.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_boss.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_base.o    \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_boss.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_explain.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_explain.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_item.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_item.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_howl.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_howl.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_jimaku.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_jimaku.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_kanban.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_kanban.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_light.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_light.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_place.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_place.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_staff.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_staff.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_talk.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_talk.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_scrn_tree.o \
             $(BUILD_DIR)/asm/d/msg/scrn/d_msg_scrn_tree.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_string_base.o \
             $(BUILD_DIR)/asm/d/msg/string/d_msg_string_base.o    \
             $(BUILD_DIR)/asm/d/msg/d_msg_string.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_msg_flow.o \
             $(BUILD_DIR)/asm/d/msg/d_msg_flow.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_name.o \
             $(BUILD_DIR)/asm/d/d_name.o    \
             $(BUILD_DIR)/asm/d/npc/d_npc_lib.o    \
             $(BUILD_DIR)/asm/d/ovlp/d_ovlp_fade.o    \
@@ -228,19 +340,27 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/d/pane/d_pane_class.o    \
             $(BUILD_DIR)/asm/d/pane/class/d_pane_class_alpha.o    \
             $(BUILD_DIR)/asm/d/pane/class/d_pane_class_ex.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_s_logo.o \
             $(BUILD_DIR)/asm/d/s/d_s_logo.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_s_name.o \
             $(BUILD_DIR)/asm/d/s/d_s_name.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_s_play.o \
             $(BUILD_DIR)/asm/d/s/d_s_play.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_s_room.o \
             $(BUILD_DIR)/asm/d/s/d_s_room.o    \
             $(BUILD_DIR)/src/d/d_save/d_save_HIO.o    \
             $(BUILD_DIR)/asm/d/save/d_save_HIO.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_timer.o \
             $(BUILD_DIR)/asm/d/d_timer.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_d_k_wmark.o \
             $(BUILD_DIR)/asm/d/k/d_k_wmark.o    \
             $(BUILD_DIR)/asm/d/k/d_k_wpillar.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_DynamicLink.o \
             $(BUILD_DIR)/asm/DynamicLink.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_malloc.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_API_controller_pad.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_API_graphic.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_c_cc_d.o \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_cc_d.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_cc_s.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_counter.o   \
@@ -254,6 +374,7 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_request.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_tag.o   \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_tag_iter.o   \
+            $(BUILD_DIR)/asm/rodata/rodata_c_xyz.o \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_xyz.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_sxyz.o    \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_math.o    \
@@ -277,7 +398,9 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/libs/SSystem/SComponent/c_angle.o    \
             $(BUILD_DIR)/libs/SSystem/SStandard/s_basic.o    \
             $(BUILD_DIR)/asm/JFramework/JFWSystem.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JFWDisplay.o \
             $(BUILD_DIR)/asm/JFramework/JFWDisplay.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DUClipper.o \
             $(BUILD_DIR)/asm/J3DU/J3DUClipper.o    \
             $(BUILD_DIR)/asm/J3DU/J3DUDL.o    \
             $(BUILD_DIR)/asm/JParticle/JPAResourceManager.o    \
@@ -304,16 +427,22 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JStage/JSGSystem.o    \
             $(BUILD_DIR)/asm/JStudio/ctb.o    \
             $(BUILD_DIR)/libs/JSystem/JStudio/functionvalue.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_functionvalue.o \
             $(BUILD_DIR)/asm/JStudio/functionvalue.o    \
             $(BUILD_DIR)/libs/JSystem/JStudio/fvb.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_fvb.o \
             $(BUILD_DIR)/asm/JStudio/fvb.o    \
             $(BUILD_DIR)/asm/JStudio/fvb-data-parse.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_jstudio-control.o \
             $(BUILD_DIR)/asm/JStudio/jstudio-control.o    \
             $(BUILD_DIR)/asm/JStudio/jstudio-math.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_jstudio-object.o \
             $(BUILD_DIR)/asm/JStudio/jstudio-object.o    \
             $(BUILD_DIR)/asm/JStudio/object-id.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_stb-data.o \
             $(BUILD_DIR)/libs/JSystem/JStudio/stb.o    \
             $(BUILD_DIR)/asm/JStudio/stb-data-parse.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_control.o \
             $(BUILD_DIR)/asm/JStudio_JStage/control.o    \
             $(BUILD_DIR)/asm/JStudio_JStage/object.o    \
             $(BUILD_DIR)/asm/JStudio_JStage/object-actor.o    \
@@ -325,6 +454,7 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JStudio_JAudio2/object-sound.o    \
             $(BUILD_DIR)/asm/JStudio_JParticle/control.o    \
             $(BUILD_DIR)/asm/JStudio_JParticle/object-particle.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASCalc.o \
             $(BUILD_DIR)/asm/JAudio2/JASCalc.o    \
             $(BUILD_DIR)/asm/JAudio2/JASTaskThread.o    \
             $(BUILD_DIR)/asm/JAudio2/JASDvdThread.o    \
@@ -334,15 +464,20 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JAudio2/JASProbe.o    \
             $(BUILD_DIR)/asm/JAudio2/JASReport.o    \
             $(BUILD_DIR)/asm/JAudio2/JASCmdStack.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASTrack.o \
             $(BUILD_DIR)/asm/JAudio2/JASTrack.o    \
             $(BUILD_DIR)/asm/JAudio2/JASTrackPort.o    \
             $(BUILD_DIR)/asm/JAudio2/JASRegisterParam.o    \
             $(BUILD_DIR)/asm/JAudio2/JASSeqCtrl.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASSeqParser.o \
             $(BUILD_DIR)/asm/JAudio2/JASSeqParser.o    \
             $(BUILD_DIR)/asm/JAudio2/JASSeqReader.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASAramStream.o \
             $(BUILD_DIR)/asm/JAudio2/JASAramStream.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASBank.o \
             $(BUILD_DIR)/asm/JAudio2/JASBank.o    \
             $(BUILD_DIR)/asm/JAudio2/JASBasicBank.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASVoiceBank.o \
             $(BUILD_DIR)/asm/JAudio2/JASVoiceBank.o    \
             $(BUILD_DIR)/asm/JAudio2/JASBasicInst.o    \
             $(BUILD_DIR)/asm/JAudio2/JASDrumSet.o    \
@@ -353,25 +488,32 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JAudio2/JASWaveArcLoader.o    \
             $(BUILD_DIR)/asm/JAudio2/JASChannel.o    \
             $(BUILD_DIR)/asm/JAudio2/JASLfo.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASOscillator.o \
             $(BUILD_DIR)/asm/JAudio2/JASOscillator.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASAiCtrl.o \
             $(BUILD_DIR)/asm/JAudio2/JASAiCtrl.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASAudioThread.o \
             $(BUILD_DIR)/asm/JAudio2/JASAudioThread.o    \
             $(BUILD_DIR)/asm/JAudio2/JASAudioReseter.o    \
             $(BUILD_DIR)/asm/JAudio2/JASDSPChannel.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JASDSPInterface.o \
             $(BUILD_DIR)/asm/JAudio2/JASDSPInterface.o    \
             $(BUILD_DIR)/asm/JAudio2/JASDriverIF.o    \
             $(BUILD_DIR)/asm/JAudio2/JASSoundParams.o    \
             $(BUILD_DIR)/asm/JAudio2/dspproc.o    \
             $(BUILD_DIR)/asm/JAudio2/dsptask.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_osdsp.o \
             $(BUILD_DIR)/asm/JAudio2/osdsp.o    \
             $(BUILD_DIR)/asm/JAudio2/osdsp/osdsp_task.o    \
             $(BUILD_DIR)/asm/JAudio2/JAIAudible.o    \
             $(BUILD_DIR)/asm/JAudio2/JAIAudience.o    \
             $(BUILD_DIR)/asm/JAudio2/JAISe.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JAISeMgr.o \
             $(BUILD_DIR)/asm/JAudio2/JAISeMgr.o    \
             $(BUILD_DIR)/asm/JAudio2/JAISeq.o    \
             $(BUILD_DIR)/asm/JAudio2/JAISeqDataMgr.o    \
             $(BUILD_DIR)/asm/JAudio2/JAISeqMgr.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JAISound.o \
             $(BUILD_DIR)/asm/JAudio2/JAISound.o    \
             $(BUILD_DIR)/asm/JAudio2/JAISoundChild.o    \
             $(BUILD_DIR)/asm/JAudio2/JAISoundHandles.o    \
@@ -387,6 +529,7 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JAudio2/JAUBankTable.o    \
             $(BUILD_DIR)/libs/JSystem/JAudio2/JAUClusterSound.o    \
             $(BUILD_DIR)/asm/JAudio2/JAUInitializer.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JAUSectionHeap.o \
             $(BUILD_DIR)/asm/JAudio2/JAUSectionHeap.o    \
             $(BUILD_DIR)/asm/JAudio2/JAUSeqCollection.o    \
             $(BUILD_DIR)/asm/JAudio2/JAUSeqDataBlockMgr.o    \
@@ -399,57 +542,83 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JMessage/locale.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2Calc.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2AudioArcLoader.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SoundMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SoundMgr.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SoundStarter.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SoundHandles.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SeMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SeMgr.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SeqMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SeqMgr.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2StatusMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2StatusMgr.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SceneMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SceneMgr.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2FxLineMgr.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SoundInfo.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2Audience.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2Audience.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SoundObject.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SoundObject.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SoundObjMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SoundObjMgr.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2Creature.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2LinkMgr.o \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2EnvSeMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2EnvSeMgr.o    \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2WolfHowlMgr.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2SpeechMgr2.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2SpeechMgr2.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_Z2AudioMgr.o \
             $(BUILD_DIR)/libs/Z2AudioLib/Z2AudioMgr.o    \
             $(BUILD_DIR)/asm/gf/GFGeometry.o    \
             $(BUILD_DIR)/asm/gf/GFLight.o    \
             $(BUILD_DIR)/asm/gf/GFPixel.o    \
             $(BUILD_DIR)/asm/gf/GFTev.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRHeap.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRHeap.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRExpHeap.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRExpHeap.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRSolidHeap.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRSolidHeap_padding.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAssertHeap.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRDisposer.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRThread.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRThread.o    \
             $(BUILD_DIR)/asm/JKernel/JKRThread.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRAram.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAram.o    \
             $(BUILD_DIR)/asm/JKernel/JKRAram.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAramHeap.o    \
             $(BUILD_DIR)/asm/JKernel/JKRAramHeap.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAramBlock.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRAramPiece.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAramPiece.o    \
             $(BUILD_DIR)/asm/JKernel/JKRAramPiece.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRAramStream.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAramStream.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRFileLoader.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRFileLoader.o    \
             $(BUILD_DIR)/asm/JKernel/JKRFileLoader.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRFileFinder.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRFileCache.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRFileCache.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRArchivePub.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRArchivePri.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRMemArchive.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRMemArchive.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRAramArchive.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRAramArchive.o    \
             $(BUILD_DIR)/asm/JKernel/JKRAramArchive.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRDvdArchive.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRDvdArchive.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRCompArchive.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRCompArchive.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRFile.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRDvdFile.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRDvdFile.o    \
             $(BUILD_DIR)/asm/JKernel/JKRDvdFile.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JKRDvdRipper.o \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRDvdRipper.o    \
             $(BUILD_DIR)/asm/JKernel/JKRDvdRipper.o    \
             $(BUILD_DIR)/libs/JSystem/JKernel/JKRDvdAramRipper.o    \
@@ -464,55 +633,73 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/JGadget/linklist.o    \
             $(BUILD_DIR)/libs/JSystem/JGadget/std-vector.o    \
             $(BUILD_DIR)/asm/JGadget/std-vector.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JUTCacheFont.o \
             $(BUILD_DIR)/asm/JUtility/JUTCacheFont.o    \
             $(BUILD_DIR)/asm/JUtility/JUTResource.o    \
             $(BUILD_DIR)/asm/JUtility/JUTTexture.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JUTPalette.o \
             $(BUILD_DIR)/asm/JUtility/JUTPalette.o    \
             $(BUILD_DIR)/asm/JUtility/JUTNameTab.o    \
             $(BUILD_DIR)/asm/JUtility/JUTGraphFifo.o    \
             $(BUILD_DIR)/libs/JSystem/JUtility/JUTFont.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JUTResFont.o \
             $(BUILD_DIR)/libs/JSystem/JUtility/JUTResFont.o    \
             $(BUILD_DIR)/asm/JUtility/JUTDbPrint.o    \
             $(BUILD_DIR)/libs/JSystem/JUtility/JUTGamePad.o    \
             $(BUILD_DIR)/asm/JUtility/JUTGamePad.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JUTException.o \
             $(BUILD_DIR)/asm/JUtility/JUTException.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JUTDirectPrint.o \
             $(BUILD_DIR)/asm/JUtility/JUTDirectPrint.o    \
             $(BUILD_DIR)/asm/JUtility/JUTAssert.o    \
             $(BUILD_DIR)/asm/JUtility/JUTVideo.o    \
             $(BUILD_DIR)/libs/JSystem/JUtility/JUTXfb.o    \
             $(BUILD_DIR)/asm/JUtility/JUTFader.o    \
             $(BUILD_DIR)/asm/JUtility/JUTProcBar.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_JUTConsole.o \
             $(BUILD_DIR)/asm/JUtility/JUTConsole.o    \
             $(BUILD_DIR)/asm/JUtility/JUTDirectFile.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DGrafContext.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DOrthoGraph.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DTevs.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DTevs.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DMaterial.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DMatBlock.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DMatBlock.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DMaterialFactory.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DPrint.o    \
             $(BUILD_DIR)/libs/JSystem/J2DGraph/J2DPane.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DScreen.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DWindow.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DWindow.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DPicture.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DTextBox.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DTextBox.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DWindowEx.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DWindowEx.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DPictureEx.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DPictureEx.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J2DTextBoxEx.o \
             $(BUILD_DIR)/asm/J2DGraph/J2DTextBoxEx.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DAnmLoader.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DAnimation.o    \
             $(BUILD_DIR)/asm/J2DGraph/J2DManage.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DGD.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DSys.o \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DSys.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DVertex.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DTransform.o \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DTransform.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DTexture.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DPacket.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DShapeMtx.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DShapeDraw.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DShape.o \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DShape.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DMaterial.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DMatBlock.o \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DMatBlock.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DTevs.o \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DTevs.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DDrawBuffer.o    \
             $(BUILD_DIR)/asm/J3DGraphBase/J3DStruct.o    \
@@ -523,17 +710,24 @@ TEXT_O_FILES := 						            \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DModel.o    \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DAnimation.o    \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DMaterialAnm.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DSkinDeform.o \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DSkinDeform.o    \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DCluster.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DJoint.o \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DJoint.o    \
             $(BUILD_DIR)/asm/J3DGraphAnimator/J3DMaterialAttach.o    \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DMaterialFactory.o    \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DMaterialFactory/J3DMaterialFactory_v21.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DClusterLoader.o \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DClusterLoader.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DModelLoader.o \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DModelLoader.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DModelLoaderCalcSize.o \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DModelLoaderCalcSize.o    \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DJointFactory.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DShapeFactory.o \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DShapeFactory.o    \
+            $(BUILD_DIR)/asm/rodata/rodata_J3DAnmLoader.o \
             $(BUILD_DIR)/asm/J3DGraphLoader/J3DAnmLoader.o    \
             $(BUILD_DIR)/asm/JMath/JMath.o    \
             $(BUILD_DIR)/libs/JSystem/JMath/random.o    \
@@ -627,11 +821,35 @@ CTORS_O_FILES :=                                    \
 DTORS_O_FILES :=                                    \
     $(BUILD_DIR)/asm/dtors.o
 
-RODATA_O_FILES :=                                   \
-    $(BUILD_DIR)/asm/rodata.o
+RODATA_O_FILES := \
+            $(BUILD_DIR)/asm/rodata/rodata_Padclamp.o \
+            $(BUILD_DIR)/asm/rodata/rodata_ptmf.o \
+            $(BUILD_DIR)/asm/rodata/rodata_runtime.o \
+            $(BUILD_DIR)/asm/rodata/rodata_GCN_mem_alloc.o \
+            $(BUILD_DIR)/asm/rodata/rodata_alloc.o \
+            $(BUILD_DIR)/asm/rodata/rodata_ansi_fp.o \
+            $(BUILD_DIR)/asm/rodata/rodata_printf.o \
+            $(BUILD_DIR)/asm/rodata/rodata_e_exp.o \
+            $(BUILD_DIR)/asm/rodata/rodata_e_fmod.o \
+            $(BUILD_DIR)/asm/rodata/rodata_e_pow.o \
+            $(BUILD_DIR)/asm/rodata/rodata_e_rem_pio2.o \
+            $(BUILD_DIR)/asm/rodata/rodata_k_rem_pio2.o \
+            $(BUILD_DIR)/asm/rodata/rodata_k_tan.o \
+            $(BUILD_DIR)/asm/rodata/rodata_s_atan.o \
+            $(BUILD_DIR)/asm/rodata/rodata_nubinit.o \
+            $(BUILD_DIR)/asm/rodata/rodata_msg.o \
+            $(BUILD_DIR)/asm/rodata/rodata_msgbuf.o \
+            $(BUILD_DIR)/asm/rodata/rodata_serpoll.o \
+            $(BUILD_DIR)/asm/rodata/rodata_dispatch.o \
+            $(BUILD_DIR)/asm/rodata/rodata_msghndlr.o \
+            $(BUILD_DIR)/asm/rodata/rodata_support.o \
+            $(BUILD_DIR)/asm/rodata/rodata_targimpl.o \
+            $(BUILD_DIR)/asm/rodata/rodata_main_TRK.o \
+            $(BUILD_DIR)/asm/rodata/rodata_dolphin_trk_glue.o \
+            $(BUILD_DIR)/asm/rodata/rodata_main.o 
 
 DATA_O_FILES :=                                     \
-    $(BUILD_DIR)/asm/data.o                         \
+    $(BUILD_DIR)/asm/data.o                         
 
 BSS_O_FILES :=                                      \
     $(BUILD_DIR)/asm/bss.o


### PR DESCRIPTION
It's now possible (with a bit of work) to compile and match functions using read-only strings in C++ code. Like this:

![image](https://user-images.githubusercontent.com/3693193/105945034-c307da80-6064-11eb-899f-d8aca2f954b1.png)

This was made possible by adding two compiler options and splitting the rodata.s file into multiple rodata files, one for each TU. The compiler options: `-str readonly,pool -RTTI off`. The first option moves all strings into read-only section (.rodata) and combines all strings into one symbol (@stringBase0). The second option turns off RTTI (Run Time Type Information), when RTTI is enabled the compiler will write the type information in the beginning of the .rodata section for every TU. 
After this everything is  compiling correctly, but the dol file will not match. To generate a match, we need to insert the .rodata from each TU in the correct order. But, because all .rodata is added at the end of the linking, the order is messed up. The fix was to split `rodata.s` into multiple files and add them in the correct order to `obj_files.mk`, i.e., before each TU object file.

![image](https://user-images.githubusercontent.com/3693193/105945703-1595c680-6066-11eb-9a73-73adc4f0539c.png)

The process to enable this for TU's are:
1. Define all strings in the TU (for non-matching and asm functions define a `const char* XXX = XXX;` before the functions). For this method to work the .rodata outputted by the compiler needs to be complete and the correct size.
2. If there are ASM functions that uses the @stringBase0 symbol: add `"lbl_XXXXXXXX" = 0xXXXXXXXX;` in `ldscript.lcf` where the XXXXXXXX is the address of the @stringBase0. 
3. Remove the rodata object file from `obj_files.mk`. Otherwise, we would include the same rodata twice.
4. Check the padding of the .rodata. In the case of JKRSolidHeap,  the read-only data not was aligned to 8 bytes. Although, the elf section said it had an aligned of 8 bytes. This shifted everything by one byte. My solution was to add one byte of padding in it’s own `.s` file. See `rodata_JKRSolidHeap_padding.s`. (Hopefully someone else can find a solution to this problem?)


