### PR TITLE
add missing config options

### DIFF
--- a/include/d/d_save/d_save/d_save.h
+++ b/include/d/d_save/d_save/d_save.h
@@ -7,10 +7,10 @@
 #include "global.h"
 
 #define DEFAULT_SELECT_ITEM_INDEX 0
-#define MAX_SELECT_ITEM 3
+#define MAX_SELECT_ITEM 4
+#define MAX_EQUIPMENT 6
 #define MAX_EVENTS 256
 #define MAX_ITEM_SLOTS 24
-#define ITEM_XY_MAX_DUMMY 8
 #define LIGHT_DROP_STAGE 4
 #define LETTER_INFO_BIT 64
 #define BOMB_BAG_MAX 3
@@ -349,11 +349,9 @@ private:
     u16 mMaxLanternOil;
     u16 mCurrentLanternOil;
     u8 unk10;
-    u8 mSelectItem[3];
-    u8 mMixItem[3];
-    u8 unk17;
-    u8 unk18;
-    u8 mEquipment[6];
+    u8 mSelectItem[MAX_SELECT_ITEM]; // For GC: first 2 are X & Y, others unused; For Wii (in order): Left, Right, Down, B
+    u8 mMixItem[MAX_SELECT_ITEM]; // Combo items; For GC: first 2 are X & Y, others unused; For Wii (in order): Left, Right, Down, B
+    u8 mEquipment[MAX_EQUIPMENT];
     u8 mCurrentWallet;
     u8 mMaxMagic;
     u8 mCurrentMagic;
@@ -623,21 +621,33 @@ public:
     u32 checkVibration(void) const;
     u8 getSound(void);
     void setSound(u8);
+    u8 getLockonType(void);
+    void setLockonType(u8);
     u8 getVibration(void);
     void setVibration(u8);
+    u16 getPointerXCalibration(void);
+    void setPointerXCalibration(u16);
+    u8 getPointerYCalibration(void);
+    void setPointerYCalibration(u8);
+    BOOL getIconShortcut(void);
+    void setIconShortcut(BOOL);
+    u8 getCameraControl(void);
+    void setCameraControl(u8);
+    BOOL getPointer(void);
+    void setPointer(BOOL);
 
 private:
     u8 unk0;
     u8 mSoundMode;
-    u8 unk2;
+    u8 mLockonType; // 0 : hold, 1 : switch
     u8 mVibrationStatus;
     u8 unk4;
     u8 unk5;
-    u16 unk6;
-    u8 unk8;
-    u8 unk9;
-    u8 unk10;
-    u8 unk11;
+    u16 mPointerXCalib; // Wii pointer horizontal calibration. Default is 0x015E
+    u8 mPointerYCalib; // Wii pointer vertical calibration. Default is 0x00
+    u8 mIconShortcut; // Wii icon shortcut enabled/disabled.
+    u8 mCameraControl; // 0 : normal, 1 : inverted
+    u8 mPointer; // Wii pointer enabled/disabled.
     u8 padding[4];
 };
 

--- a/src/d/d_save/d_save.cpp
+++ b/src/d/d_save/d_save.cpp
@@ -74,13 +74,13 @@ void dSv_player_status_a_c::init() {
     mCurrentLanternOil = 0;
     unk10 = 0;
 
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < MAX_SELECT_ITEM; i++) {
         mSelectItem[i] = NO_ITEM;
-        mMixItem[i + 1] = NO_ITEM;
+        mMixItem[i] = NO_ITEM;
         dComIfGp_setSelectItem__Fi(i);
     }
 
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < MAX_EQUIPMENT; i++) {
         mEquipment[i] = 0;
     }
 
@@ -102,27 +102,27 @@ void dSv_player_status_a_c::init() {
 }
 
 void dSv_player_status_a_c::setSelectItemIndex(signed int i_no, u8 item_index) {
-    if (i_no < ITEM_XY_MAX_DUMMY / 2) {
+    if (i_no < MAX_SELECT_ITEM) {
         mSelectItem[i_no] = item_index;
     }
 }
 
 u8 dSv_player_status_a_c::getSelectItemIndex(signed int i_no) const {
-    if (i_no < ITEM_XY_MAX_DUMMY / 2) {
+    if (i_no < MAX_SELECT_ITEM) {
         return mSelectItem[i_no];
     }
     return 0;
 }
 
 void dSv_player_status_a_c::setMixItemIndex(signed int i_no, u8 item_index) {
-    if (i_no < ITEM_XY_MAX_DUMMY / 2) {
-        mMixItem[i_no + 1] = item_index;
+    if (i_no < MAX_SELECT_ITEM) {
+        mMixItem[i_no] = item_index;
     }
 }
 
 u8 dSv_player_status_a_c::getMixItemIndex(signed int i_no) const {
-    if (i_no < ITEM_XY_MAX_DUMMY / 2) {
-        return mMixItem[i_no + 1];
+    if (i_no < MAX_SELECT_ITEM) {
+        return mMixItem[i_no];
     }
     return 0;
 }
@@ -313,7 +313,7 @@ void dSv_player_item_c::setItem(int item_slot, u8 item_id) {
             dComIfGp_setSelectItem__Fi(select_item_index);
         }
         select_item_index++;
-    } while (select_item_index < MAX_SELECT_ITEM);
+    } while (select_item_index < MAX_SELECT_ITEM - 1);
 }
 
 #ifdef NONMATCHING
@@ -954,15 +954,15 @@ void dSv_player_config_c::init(void) {
         lbl_80451368->setOutputMode(SOUND_MODE_STEREO);
     }
 
-    unk2 = 0;
+    mLockonType = 0;
     mVibrationStatus = 1;
     unk4 = 0;
     unk5 = 0;
-    unk9 = 0;
-    unk6 = 0x15e;
-    unk8 = 0;
-    unk10 = 0;
-    unk11 = 1;
+    mIconShortcut = 0;
+    mPointerXCalib = 0x15e;
+    mPointerYCalib = 0;
+    mCameraControl = 0;
+    mPointer = 1;
 }
 
 u32 dSv_player_config_c::checkVibration(void) const {
@@ -977,12 +977,60 @@ void dSv_player_config_c::setSound(u8 i_mSoundMode) {
     mSoundMode = i_mSoundMode;
 }
 
+u8 dSv_player_config_c::getLockonType(void) {
+    return mLockonType;
+}
+
+void dSv_player_config_c::setLockonType(u8 i_mLockonType) {
+    mLockonType = i_mLockonType;
+}
+
 u8 dSv_player_config_c::getVibration(void) {
     return mVibrationStatus;
 }
 
 void dSv_player_config_c::setVibration(u8 i_mVibrationStatus) {
     mVibrationStatus = i_mVibrationStatus;
+}
+
+u16 dSv_player_config_c::getPointerXCalibration(void) {
+    return mPointerXCalib;
+}
+
+void dSv_player_config_c::setPointerXCalibration(u16 i_mPointerXCalib) {
+    mPointerXCalib = i_mPointerXCalib;
+}
+
+u8 dSv_player_config_c::getPointerYCalibration(void) {
+    return mPointerYCalib;
+}
+
+void dSv_player_config_c::setPointerYCalibration(u8 i_mPointerYCalib) {
+    mPointerYCalib = i_mPointerYCalib;
+}
+
+BOOL dSv_player_config_c::getIconShortcut(void) {
+    return mIconShortcut;
+}
+
+void dSv_player_config_c::setIconShortcut(BOOL i_mIconShortcut) {
+    mIconShortcut = i_mIconShortcut;
+}
+
+u8 dSv_player_config_c::getCameraControl(void) {
+    return mCameraControl;
+}
+
+void dSv_player_config_c::setCameraControl(u8 i_mCameraControl) {
+    mCameraControl = i_mCameraControl;
+}
+
+BOOL dSv_player_config_c::getPointer(void) {
+    return mPointer;
+}
+
+void dSv_player_config_c::setPointer(BOOL i_mPointer) {
+    mPointer = i_mPointer;
 }
 
 void dSv_player_c::init(void) {


### PR DESCRIPTION
This PR adds corrections and renaming of options which are used only for Wii saves. This includes fixing the the item buttons, and the specification of some configuration options that were flagged as "unknown".

If there's an issue with the modifications' format, I'm open to criticism.