### PR TITLE
Fixed incorrect offset in RELs and JKRHeap redefined error.

### DIFF
--- a/libs/JSystem/JUtility/JUTException.cpp
+++ b/libs/JSystem/JUtility/JUTException.cpp
@@ -36,10 +36,6 @@ struct JUTConsoleManager {
     static u8 sManager[4];
 };
 
-struct JKRHeap {
-    static u8 sSystemHeap[4];
-};
-
 //
 // Forward References:
 //

--- a/src/m_Do/m_Do_machine_exception.cpp
+++ b/src/m_Do/m_Do_machine_exception.cpp
@@ -34,6 +34,11 @@ extern "C" void JUTConsole_print_f_va_();
 
 static JUTConsole* sConsole;
 
+#pragma push
+#pragma force_active on
+u8 struct_80450C94[4];
+#pragma pop
+
 /* 80017D7C-80017E08 0126BC 008C+00 3/3 0/0 0/0 .text            print_f__FPCce */
 #pragma push
 #pragma optimization_level 0


### PR DESCRIPTION
Removing the padding from sConsole (#145) caused RELs to fail the checksum test (`./tp check`). This was due to the the compiler not inserting any padding, which could be because the data at 0x80450C98 already was aligned or dol2asm was wrong in assuming that sConsole had padding to begin with. Added a 4 byte array to mimic the padding until we know the problem.

Fixed JKRHeap redefined error introduced by #147.