### PR TITLE
Update clang-format-check.sh and make executable

### DIFF
--- a/tools/clang-format-check.sh
+++ b/tools/clang-format-check.sh
@@ -4,11 +4,8 @@ clangFormatTargets=$(find . -type f -regex '.*\.\(cpp\|hpp\|h\|cc\|cxx\)')
 
 for inputFile in $clangFormatTargets
 do
-    clang-format-10 -style=file $inputFile > $inputFile-formatted
-    diff $inputFile $inputFile-formatted
+    clang-format-10 --dry-run --Werror -style=file $inputFile
     if [ $? != 0 ] ; then
         exit 1
-    else
-        rm $inputFile-formatted
     fi
 done


### PR DESCRIPTION
- Update `clang-format-check.sh` to use a different method with the following advantages:
  - Killing execution with Ctrl+C does not leave behind a temp file.
  - Slightly faster.
  - Message that it prints out if there is a mismatch is much easier to read.
- Make `clang-format-check.sh` executable by default.