### PR TITLE
reduce python dependencies to just build

### DIFF
--- a/tools/libdol2asm/__init__.py
+++ b/tools/libdol2asm/__init__.py
@@ -2,12 +2,12 @@
 from pathlib import Path
 
 from . import globals
-from . import split_asm
 
 from . import settings
 
 VERSION = globals.VERSION
 
 def split(debug_logging, game_path, lib_path, src_path, asm_path, rel_path, inc_path, mk_gen, cpp_gen, asm_gen, sym_gen, rel_gen, process_count, select_modules, select_tu, select_asm):
+    from . import split_asm
     splitter = split_asm.Dol2AsmSplitter(debug_logging, game_path, lib_path, src_path, asm_path, rel_path, inc_path, mk_gen, cpp_gen, asm_gen, sym_gen, rel_gen, process_count, select_modules, select_tu, select_asm)
     return splitter.main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,8 +1,4 @@
 rich
 click
-intervaltree
 yaz0
-numpy
-capstone
-aiofiles
 GitPython


### PR DESCRIPTION
numpy and capstone are only required for disassembling and splitting the dol, so don't install and require them by default