### PR TITLE
tp.py: Explicitly specify utf-8 encoding when opening text files

### DIFF
--- a/tools/tp.py
+++ b/tools/tp.py
@@ -678,7 +678,7 @@ def calculate_progress(build_path, matching, format, print_rels):
 
 
 def find_function_range(asm):
-    with asm.open("r") as file:
+    with asm.open("r", encoding="utf-8") as file:
         lines = file.readlines()
         for line in lines:
             if line.startswith("/* "):
@@ -970,13 +970,13 @@ def find_used_asm_files(non_matching, use_progress_bar=True):
             task = progress.add_task(f"preprocessing...", total=len(cpp_files))
 
             for cpp_file in cpp_files:
-                with cpp_file.open("r") as file:
+                with cpp_file.open("r", encoding="utf-8") as file:
                     includes.update(find_includes(file.readlines(), non_matching))
 
                 progress.update(task, advance=1)
     else:
         for cpp_file in cpp_files:
-            with cpp_file.open("r") as file:
+            with cpp_file.open("r", encoding="utf-8") as file:
                 includes.update(find_includes(file.readlines(), non_matching))
 
     # TODO: NON_MATCHING


### PR DESCRIPTION
When opening a text file, if an encoding is not specified, python will use the "preferred encoding" of the environment it is running in. On Linux, this is typically `utf-8`. On my particular windows machine, the default is `cp1252`. As a result, any system that isn't using `utf-8` as their preferred encoding will get errors like this:

```
D:\git\tp>python3 tools/tp.py progress
--- Progress
Traceback (most recent call last):
  File "tools/tp.py", line 1176, in <module>
    tp()
  File "D:\Python37\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "D:\Python37\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "D:\Python37\lib\site-packages\click\core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "D:\Python37\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "D:\Python37\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "tools/tp.py", line 322, in progress
    calculate_progress(build_path, matching, format, print_rels)
  File "tools/tp.py", line 489, in calculate_progress
    asm_files = find_used_asm_files(not matching, use_progress_bar=(format == "FANCY"))
  File "tools/tp.py", line 974, in find_used_asm_files
    includes.update(find_includes(file.readlines(), non_matching))
  File "D:\Python37\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 276: character maps to <undefined>
```

Explicitly specifying the `utf-8` encoding avoids this problem.