### PR TITLE
JKRArchive: fix SDirEntry confusion

### DIFF
--- a/include/JSystem/JKernel/JKRArchive.h
+++ b/include/JSystem/JKernel/JKRArchive.h
@@ -51,16 +51,15 @@ extern u32 sCurrentDirID__10JKRArchive;  // JKRArchive::sCurrentDirID
 class JKRArchive : public JKRFileLoader {
 public:
     struct SDirEntry {
-        union {
-            u32 type;
-            struct {
-                u8 flags;
-                u8 padding;
-                u16 id;
-            } other;
-        };
-
+        u8 flags;
+        u8 padding;
+        u16 id;
         const char* name;
+    };
+
+    struct SDIDirEntry {
+        u32 type;
+        u32 name_offset;
         u16 field_0x8;
         u16 num_entries;
         s32 first_file_index;
@@ -139,8 +138,8 @@ public:
 
 protected:
     bool isSameName(CArcName&, u32, u16) const;
-    SDirEntry* findResType(u32) const;
-    SDirEntry* findDirectory(const char*, u32) const;
+    SDIDirEntry* findResType(u32) const;
+    SDIDirEntry* findDirectory(const char*, u32) const;
     SDIFileEntry* findTypeResource(u32, const char*) const;
     SDIFileEntry* findFsResource(const char*, u32) const;
     SDIFileEntry* findIdxResource(u32) const;
@@ -175,7 +174,7 @@ protected:
     /* 0x3D */ u8 field_0x3d[3];
     /* 0x40 */ s32 mEntryNum;
     /* 0x44 */ SArcDataInfo* mArcInfoBlock;
-    /* 0x48 */ SDirEntry* mNodes;
+    /* 0x48 */ SDIDirEntry* mNodes;
 
 public:
     /* 0x4C */ SDIFileEntry* mFiles;

--- a/libs/JSystem/JKernel/JKRAramArchive.cpp
+++ b/libs/JSystem/JKernel/JKRAramArchive.cpp
@@ -116,7 +116,7 @@ JKRAramArchive::JKRAramArchive(s32 param_0, JKRArchive::EMountDirection mountDir
         return;
     }
     mVolumeType = 'RARC';
-    mVolumeName = mStringTable + (int)mNodes->name;
+    mVolumeName = mStringTable + mNodes->name_offset;
     JKRFileLoader::sVolumeList.prepend(&mFileLoaderLink);
     mIsMounted = true;
 }
@@ -190,7 +190,7 @@ bool JKRAramArchive::open(s32 entryNum) {
             JKRDvdToMainRam(entryNum, (u8*)mArcInfoBlock, EXPAND_SWITCH_UNKNOWN1, blockSize, NULL,
                             JKRDvdRipper::ALLOC_DIRECTION_FORWARD, 0x20, NULL, NULL);
             DCInvalidateRange(mArcInfoBlock, blockSize);
-            mNodes = (SDirEntry*)((s32)mArcInfoBlock + mArcInfoBlock->node_offset);
+            mNodes = (SDIDirEntry*)((s32)mArcInfoBlock + mArcInfoBlock->node_offset);
             mFiles = (SDIFileEntry*)((s32)mArcInfoBlock + mArcInfoBlock->file_entry_offset);
             mStringTable = (char*)((s32)mArcInfoBlock + mArcInfoBlock->string_table_offset);
             mExpandedSize = NULL;

--- a/libs/JSystem/JKernel/JKRArchivePri.cpp
+++ b/libs/JSystem/JKernel/JKRArchivePri.cpp
@@ -51,8 +51,8 @@ bool JKRArchive::isSameName(JKRArchive::CArcName& name, u32 nameOffset, u16 name
 }
 
 /* 802D63E0-802D641C 2D0D20 003C+00 1/1 0/0 0/0 .text            findResType__10JKRArchiveCFUl */
-JKRArchive::SDirEntry* JKRArchive::findResType(u32 type) const {
-    SDirEntry* node = mNodes;
+JKRArchive::SDIDirEntry* JKRArchive::findResType(u32 type) const {
+    SDIDirEntry* node = mNodes;
     u32 count = 0;
     while (count < mArcInfoBlock->num_nodes) {
         if (node->type == type) {
@@ -68,13 +68,13 @@ JKRArchive::SDirEntry* JKRArchive::findResType(u32 type) const {
 
 /* 802D641C-802D64F4 2D0D5C 00D8+00 0/0 3/3 0/0 .text            findDirectory__10JKRArchiveCFPCcUl
  */
-JKRArchive::SDirEntry* JKRArchive::findDirectory(const char* name, u32 directoryId) const {
+JKRArchive::SDIDirEntry* JKRArchive::findDirectory(const char* name, u32 directoryId) const {
     if (name == NULL) {
         return mNodes + directoryId;
     }
 
     CArcName arcName(&name, '/');
-    SDirEntry* dirEntry = mNodes + directoryId;
+    SDIDirEntry* dirEntry = mNodes + directoryId;
     SDIFileEntry* fileEntry = mFiles + dirEntry->first_file_index;
 
     for (int i = 0; i < dirEntry->num_entries; fileEntry++, i++) {
@@ -94,7 +94,7 @@ JKRArchive::SDirEntry* JKRArchive::findDirectory(const char* name, u32 directory
 JKRArchive::SDIFileEntry* JKRArchive::findTypeResource(u32 type, const char* name) const {
     if (type) {
         CArcName arcName(name);
-        SDirEntry* dirEntry = findResType(type);
+        SDIDirEntry* dirEntry = findResType(type);
         if (dirEntry) {
             SDIFileEntry* fileEntry = mFiles + dirEntry->first_file_index;
             for (int i = 0; i < dirEntry->num_entries; fileEntry++, i++) {
@@ -113,7 +113,7 @@ JKRArchive::SDIFileEntry* JKRArchive::findTypeResource(u32 type, const char* nam
 JKRArchive::SDIFileEntry* JKRArchive::findFsResource(const char* name, u32 directoryId) const {
     if (name) {
         CArcName arcName(&name, '/');
-        SDirEntry* dirEntry = mNodes + directoryId;
+        SDIDirEntry* dirEntry = mNodes + directoryId;
         SDIFileEntry* fileEntry = mFiles + dirEntry->first_file_index;
         for (int i = 0; i < dirEntry->num_entries; fileEntry++, i++) {
             // regalloc doesn't like fileEntry->getNameHash()

--- a/libs/JSystem/JKernel/JKRArchivePub.cpp
+++ b/libs/JSystem/JKernel/JKRArchivePub.cpp
@@ -113,7 +113,7 @@ JKRArchive* JKRArchive::mount(s32 entryNum, JKRArchive::EMountMode mountMode, JK
 
 /* 802D5A38-802D5AC0 2D0378 0088+00 1/0 4/0 0/0 .text            becomeCurrent__10JKRArchiveFPCc */
 bool JKRArchive::becomeCurrent(const char* path) {
-    SDirEntry* dirEntry;
+    SDIDirEntry* dirEntry;
     if (*path == '/') {
         path++;
 
@@ -140,8 +140,8 @@ bool JKRArchive::getDirEntry(SDirEntry* dirEntry, u32 index) const {
     if (!fileEntry)
         return false;
 
-    dirEntry->other.flags = fileEntry->getFlags();
-    dirEntry->other.id = fileEntry->getFileID();
+    dirEntry->flags = fileEntry->getFlags();
+    dirEntry->id = fileEntry->getFileID();
     dirEntry->name = mStringTable + fileEntry->getNameOffset();
     return true;
 }
@@ -338,7 +338,7 @@ u32 JKRArchive::countResource(void) const {
 
 /* 802D6150-802D61B0 2D0A90 0060+00 1/0 4/0 0/0 .text            countFile__10JKRArchiveCFPCc */
 u32 JKRArchive::countFile(const char* path) const {
-    SDirEntry* dirEntry;
+    SDIDirEntry* dirEntry;
     if (*path == '/') {
         path++;
 
@@ -358,7 +358,7 @@ u32 JKRArchive::countFile(const char* path) const {
 
 /* 802D61B0-802D625C 2D0AF0 00AC+00 1/0 4/0 0/0 .text            getFirstFile__10JKRArchiveCFPCc */
 JKRFileFinder* JKRArchive::getFirstFile(const char* path) const {
-    SDirEntry* dirEntry;
+    SDIDirEntry* dirEntry;
     if (*path == '/') {
         path++;
 

--- a/libs/JSystem/JKernel/JKRDvdArchive.cpp
+++ b/libs/JSystem/JKernel/JKRDvdArchive.cpp
@@ -91,7 +91,7 @@ JKRDvdArchive::JKRDvdArchive(s32 entryNum, JKRArchive::EMountDirection mountDire
         return;
 
     mVolumeType = 'RARC';
-    mVolumeName = mStringTable + (u32)mNodes->name;
+    mVolumeName = mStringTable + mNodes->name_offset;
     getVolumeList().prepend(&mFileLoaderLink);
     mIsMounted = true;
 }
@@ -169,7 +169,7 @@ bool JKRDvdArchive::open(s32 entryNum) {
                     sizeof(SArcHeader), NULL, NULL);
     DCInvalidateRange(mArcInfoBlock, arcHeader->file_data_offset);
 
-    mNodes = (SDirEntry*)((int)&mArcInfoBlock->num_nodes + mArcInfoBlock->node_offset);
+    mNodes = (SDIDirEntry*)((int)&mArcInfoBlock->num_nodes + mArcInfoBlock->node_offset);
     mFiles = (SDIFileEntry*)((int)&mArcInfoBlock->num_nodes + mArcInfoBlock->file_entry_offset);
     mStringTable = (char*)((int)&mArcInfoBlock->num_nodes + mArcInfoBlock->string_table_offset);
     mExpandedSize = NULL;

--- a/libs/JSystem/JKernel/JKRFileFinder.cpp
+++ b/libs/JSystem/JKernel/JKRFileFinder.cpp
@@ -53,8 +53,8 @@ bool JKRArcFinder::findNextFile(void) {
             mIsAvailable = mArchive->getDirEntry(&entry, mNextIndex);
             mEntryName = entry.name;
             mEntryFileIndex = mNextIndex;
-            mEntryId = entry.other.id;
-            mEntryTypeFlags = entry.other.flags;
+            mEntryId = entry.id;
+            mEntryTypeFlags = entry.flags;
             mIsFileOrDirectory = (mEntryTypeFlags >> 1) & 1;
             mNextIndex++;
         }

--- a/libs/JSystem/JKernel/JKRMemArchive.cpp
+++ b/libs/JSystem/JKernel/JKRMemArchive.cpp
@@ -156,7 +156,7 @@ JKRMemArchive::JKRMemArchive(long entryNum, JKRArchive::EMountDirection mountDir
     }
 
     mVolumeType = 'RARC';
-    mVolumeName = mStringTable + (u32)mNodes->name;
+    mVolumeName = mStringTable + mNodes->name_offset;
 
     getVolumeList().prepend(&mFileLoaderLink);
     mIsMounted = true;
@@ -172,7 +172,7 @@ JKRMemArchive::JKRMemArchive(void* buffer, u32 bufferSize, JKRMemBreakFlag param
     }
 
     mVolumeType = 'RARC';
-    mVolumeName = mStringTable + (u32)mNodes->name;
+    mVolumeName = mStringTable + mNodes->name_offset;
 
     getVolumeList().prepend(&mFileLoaderLink);
     mIsMounted = true;
@@ -230,7 +230,7 @@ bool JKRMemArchive::open(long entryNum, JKRArchive::EMountDirection mountDirecti
     } else {
         ASSERT(mArcHeader->signature == 'RARC');
         mArcInfoBlock = (SArcDataInfo*)((u8*)mArcHeader + mArcHeader->header_length);
-        mNodes = (SDirEntry*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->node_offset);
+        mNodes = (SDIDirEntry*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->node_offset);
         mFiles = (SDIFileEntry*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->file_entry_offset);
         mStringTable = (char*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->string_table_offset);
 
@@ -263,7 +263,7 @@ bool JKRMemArchive::open(void* buffer, u32 bufferSize, JKRMemBreakFlag flag) {
 
     ASSERT(mArcHeader->signature == 'RARC');
     mArcInfoBlock = (SArcDataInfo*)((u8*)mArcHeader + mArcHeader->header_length);
-    mNodes = (SDirEntry*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->node_offset);
+    mNodes = (SDIDirEntry*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->node_offset);
     mFiles = (SDIFileEntry*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->file_entry_offset);
     mStringTable = (char*)((u8*)&mArcInfoBlock->num_nodes + mArcInfoBlock->string_table_offset);
     mArchiveData =


### PR DESCRIPTION
I believe that the JKRArchive::SDirEntry struct has been confused with another struct that doesn't have a symbol. Most uses of this struct treat the name field as an offset into a name table, while only a couple of uses treat it as a pointer to a string. If I use another struct to fix this discrepancy, the union is no longer required either. I named the new struct SDIDirEntry, derived from the SDIFileEntry struct which has a similar purpose.