### PR TITLE
Fix some include capitalization

### DIFF
--- a/src/m_Do/m_Do_DVDError.cpp
+++ b/src/m_Do/m_Do_DVDError.cpp
@@ -8,7 +8,7 @@
 #include "dolphin/types.h"
 #include "m_Do/m_Do_dvd_thread.h"
 #include "m_Do/m_Do_ext.h"
-#include "m_Do/m_Do_reset.h"
+#include "m_Do/m_Do_Reset.h"
 
 //
 // Declarations:

--- a/src/m_Do/m_Do_MemCard.cpp
+++ b/src/m_Do/m_Do_MemCard.cpp
@@ -8,7 +8,7 @@
 #include "MSL_C/MSL_Common/Src/string.h"
 #include "dol2asm.h"
 #include "dolphin/types.h"
-#include "m_Do/m_Do_Ext.h"
+#include "m_Do/m_Do_ext.h"
 #include "m_Do/m_Do_Reset.h"
 
 //

--- a/src/m_Do/m_Do_Reset.cpp
+++ b/src/m_Do/m_Do_Reset.cpp
@@ -12,7 +12,7 @@
 #include "dol2asm.h"
 #include "dolphin/gx/GX.h"
 #include "dolphin/types.h"
-#include "m_Do/m_Do_Audio.h"
+#include "m_Do/m_Do_audio.h"
 #include "m_Do/m_Do_DVDError.h"
 #include "m_Do/m_Do_MemCard.h"
 

--- a/src/m_Do/m_Do_dvd_thread.cpp
+++ b/src/m_Do/m_Do_dvd_thread.cpp
@@ -12,7 +12,7 @@
 #include "dolphin/dvd/dvd.h"
 #include "dolphin/types.h"
 #include "m_Do/m_Do_ext.h"
-#include "m_Do/m_Do_reset.h"
+#include "m_Do/m_Do_Reset.h"
 
 //
 // Types:


### PR DESCRIPTION
On some setups (for example, mine), compiling the repo fails unless the path specified in `#include` directives *exactly* matches the file name. In other words, if the capitalization of `#include`s is wrong, the repo won't build. This PR fixes these kind of issues and allows the repo to build on setups such as mine.