### PR TITLE
WSL compilation fixes

### DIFF
--- a/src/d/d_kyeff.cpp
+++ b/src/d/d_kyeff.cpp
@@ -9,7 +9,7 @@
 #include "d/com/d_com_inf_game.h"
 #include "f_op/f_op_actor.h"
 #include "f_op/f_op_kankyo.h"
-#include "OS/OSTime.h"
+#include "os/OSTime.h"
 #include "d/kankyo/d_kankyo.h"
 #include "d/kankyo/d_kankyo_wether.h"
 #include "dol2asm.h"

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -12,6 +12,8 @@ import json
 import subprocess
 import multiprocessing as mp
 import shutil
+import platform
+import stat
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple
@@ -167,6 +169,16 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
         )
         sys.exit(1)
 
+    c125 = compilers.joinpath("1.2.5")
+    if not c125.exists() or not c125.is_dir():
+        LOG.error(
+            (
+                f"Unable to find MWCC compiler version 1.2.5: missing directory '{c125}'\n"
+                f"Check the README for instructions on how to obtain the compilers"
+            )
+        )
+        sys.exit(1)
+
     c27_lmgr326b = c27.joinpath("Lmgr326b.dll")
     if not c27_lmgr326b.exists() or not c27_lmgr326b.is_file():
         c27_lmgr326b = c27.joinpath("lmgr326b.dll")
@@ -187,6 +199,11 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
     if not c27_lmgr326b_cc.exists() or not c27_lmgr326b_cc.is_file():
         LOG.debug(f"copy: '{c27_lmgr326b}', to: '{c27_lmgr326b_cc}'")
         shutil.copy(c27_lmgr326b, c27_lmgr326b_cc)
+
+    c125_lmgr326b_cc = c125.joinpath("LMGR326B.dll")
+    if not c125_lmgr326b_cc.exists() or not c125_lmgr326b_cc.is_file():
+        LOG.debug(f"copy: '{c27_lmgr326b}', to: '{c125_lmgr326b_cc}'")
+        shutil.copy(c27_lmgr326b, c125_lmgr326b_cc)
 
     c27_mwcceppc = c27.joinpath("mwcceppc.exe")
     if not c27_mwcceppc.exists() or not c27_mwcceppc.is_file():
@@ -231,6 +248,8 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
                 else:
                     data[0x001C6A54] = 0x69
                 dst_file.write(data)
+            if platform.system() == "Linux":
+                os.chmod(dst, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
     if mwcceppc_sha1 == MWCCEPPC_SHA1:
         LOG.debug(f"found original compiler: '{c27_mwcceppc}' ('{mwcceppc_sha1}')")


### PR DESCRIPTION
I've created the rom on WSL and compiled a list of fixes that needed to be done (with references to discord).
1. chmod the patched compiler exe on linux based systems
2. copy LMGR326B.dll to 1.2.5 directory (see https://discord.com/channels/688807550715560050/749052938282074153/1015528825221824512)
3. Wrong capitalization of OS directory in include.