### PR TITLE
rename mwcceppc_patched.exe to mwcceppc_modded.exe for better windows compatibility

### DIFF
--- a/.github/workflows/ok-check.yml
+++ b/.github/workflows/ok-check.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         token: ${{secrets.MY_REPO_PAT}}
     - name: Copy in dol and compilers
-      run: cp /tmp/baserom.dol ./baserom.dol && cp -r /tmp/mwcc_compiler/ tools/mwcc_compiler && cp tools/mwcc_compiler/2.7/mwcceppc.exe tools/mwcc_compiler/2.7/mwcceppc_patched.exe  && chown root /github/home/
+      run: cp /tmp/baserom.dol ./baserom.dol && cp -r /tmp/mwcc_compiler/ tools/mwcc_compiler && cp tools/mwcc_compiler/2.7/mwcceppc.exe tools/mwcc_compiler/2.7/mwcceppc_modded.exe  && chown root /github/home/
     - name: Run Make (OK)
       run: make all rels && ./tp check --rels

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 AS        := $(DEVKITPPC)/bin/powerpc-eabi-as
 OBJCOPY   := $(DEVKITPPC)/bin/powerpc-eabi-objcopy
 STRIP     := $(DEVKITPPC)/bin/powerpc-eabi-strip
-CC        := $(WINE) tools/mwcc_compiler/$(MWCC_VERSION)/mwcceppc_patched.exe
+CC        := $(WINE) tools/mwcc_compiler/$(MWCC_VERSION)/mwcceppc_modded.exe
 DOLPHIN_LIB_CC := $(WINE) tools/mwcc_compiler/1.2.5/mwcceppc.exe
 FRANK_CC  := $(WINE) tools/mwcc_compiler/1.2.5e/mwcceppc.exe
 LD        := $(WINE_LD) tools/mwcc_compiler/$(MWCC_VERSION)/mwldeppc.exe

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -247,7 +247,7 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
 
     c27_mwcceppc_old = c27.joinpath("mwcceppc.old.exe")
     c27_mwcceppc_orignal = c27.joinpath("mwcceppc.exe")
-    c27_mwcceppc_patched = c27.joinpath("mwcceppc_patched.exe")
+    c27_mwcceppc_patched = c27.joinpath("mwcceppc_modded.exe")
 
     def patch_compiler(src: Path, dst: Path, apply: bool):
         with src.open("rb") as src_file:


### PR DESCRIPTION
Windows treats any executable with `patch` in the name as an installer, and will try to request admin permissions through UAC.
This fixes permission denied errors in mingw.