### PR TITLE
makerel.py: Accept arguments from files, allowing rels to build with msys2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,8 @@ docs:
 	
 rels: $(ELF) $(RELS)
 	@echo generating RELs from .plf
-	@$(PYTHON) $(MAKEREL) build --string-table $(BUILD_DIR)/frameworkF.str $(RELS) $(ELF)
+	@echo $(RELS) > build/plf_files
+	$(PYTHON) $(MAKEREL) build --string-table $(BUILD_DIR)/frameworkF.str @build/plf_files $(ELF)
 
 $(ELF): $(LIBS) $(O_FILES)
 	@echo $(O_FILES) > build/o_files

--- a/tools/makerel.py
+++ b/tools/makerel.py
@@ -583,5 +583,27 @@ def load_elfs(str_paths):
     return static, plfs
 
 
+def convert_arg_line_to_args(arg_line: str):
+    return arg_line.split(' ')
+
+
+def _read_args_from_files(args: List[str]):
+    new_args: List[str] = []
+    for arg in args:
+        if not arg or arg[0] != '@':
+            new_args.append(arg)
+        else:
+            with open(arg[1:], 'r') as file:
+                file_args: List[str] = []
+                for line in file:
+                    for file_arg in convert_arg_line_to_args(line.strip()):
+                        file_args.append(file_arg)
+                file_args = _read_args_from_files(file_args)
+                new_args.extend(file_args)
+    
+    return new_args
+
+
 if __name__ == "__main__":
-    makerel()
+    args = _read_args_from_files(sys.argv[1:])
+    makerel(args)


### PR DESCRIPTION
Windows has a command-line argument limit of approximately 32,000 bytes, The arguments to `makerel.py` slightly exceed this, making it impossible to compile rels on Windows. The usual approach for resolving this problem is getting the target program to load arguments from a file. `makerel.py` uses the `click` python library to handle arguments, but this library does not appear to have an accommodation for loading arguments from a file.

This PR adds new functions to `makerel.py` so that it can load arguments from a file, and changes the makefile to use this new functionality, allowing Windows to compile rels. It is a very simple implementation that does not deal with quotes or other syntax supported by the shell.