### PR TITLE
fake the -MP compiler option

### DIFF
--- a/tools/transform-dep.py
+++ b/tools/transform-dep.py
@@ -3,56 +3,66 @@
 import argparse
 import os
 from platform import uname
+from typing import List
 
 if os.name != 'nt':
     wineprefix = os.environ.get('WINEPREFIX', os.path.join(os.environ['HOME'], '.wine'))
     winedevices = os.path.join(wineprefix, 'dosdevices')
+
 
 def in_wsl() -> bool:
     # wsl1 has Microsoft, wsl2 has microsoft-standard
     release = uname().release
     return 'microsoft-standard' in release or 'Microsoft' in release
 
-def import_d_file(in_file) -> str:
-    out_lines = []
 
-    with open(in_file) as file:
-        for idx, line in enumerate(file):
-            if idx == 0:
-                if line.endswith(' \\\n'):
-                    out_lines.append(line[:-3].replace('\\', '/') + " \\\n")
-                else:
-                    out_lines.append(line.replace('\\', '/'))
+def convert_path(path: str) -> str:
+    # lowercase drive letter
+    path = path[0].lower() + path[1:]
+    if os.name == 'nt':
+        return path.replace('\\', '/')
+    elif path[0] == 'z':
+        # shortcut for z:
+        return path[2:].replace('\\', '/')
+    elif in_wsl():
+        if path.startswith(r'\\wsl'):
+            # first part could be wsl$ or wsl.localhost
+            pos = path.find('\\', 2)
+            pos = path.find('\\', pos + 1)
+            path = path[pos:]
+            return path.replace('\\', '/')
+        else:
+            path = path[0:1] + path[2:]
+            return os.path.join('/mnt', path.replace('\\', '/'))
+    else:
+        # use $WINEPREFIX/dosdevices to resolve path
+        return os.path.realpath(os.path.join(winedevices, path.replace('\\', '/')))
+
+
+def import_d_file(in_file: str) -> str:
+    out_lines: List[str] = []
+
+    with open(in_file, 'r') as file:
+        it = iter(file)
+        line = next(it)
+        if line.endswith(' \\\n'):
+            out_lines.append(line[:-3].replace('\\', '/') + " \\\n")
+        else:
+            out_lines.append(line.replace('\\', '/'))
+
+        for line in it:
+            suffix = ''
+            if line.endswith(' \\\n'):
+                suffix = ' \\'
+                path = line.lstrip()[:-3]
             else:
-                suffix = ''
-                if line.endswith(' \\\n'):
-                    suffix = ' \\'
-                    path = line.lstrip()[:-3]
-                else:
-                    path = line.strip()
-                # lowercase drive letter
-                path = path[0].lower() + path[1:]
-                if os.name == 'nt':
-                    path = path.replace('\\', '/')
-                elif path[0] == 'z':
-                    # shortcut for z:
-                    path = path[2:].replace('\\', '/')
-                elif in_wsl():
-                    if path.startswith(r'\\wsl'):
-                        # first part could be wsl$ or wsl.localhost
-                        pos = path.find('\\', 2)
-                        pos = path.find('\\', pos + 1)
-                        path = path[pos:]
-                        path = path.replace('\\', '/')
-                    else:
-                        path = path[0:1] + path[2:]
-                        path = os.path.join('/mnt', path.replace('\\', '/'))
-                else:
-                    # use $WINEPREFIX/dosdevices to resolve path
-                    path = os.path.realpath(os.path.join(winedevices, path.replace('\\', '/')))
-                out_lines.append(f"\t{path}{suffix}\n")
+                path = line.strip()
+
+            path = convert_path(path)
+            out_lines.append(f"\t{path}{suffix}\n")
 
     return ''.join(out_lines)
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/tools/transform-dep.py
+++ b/tools/transform-dep.py
@@ -50,6 +50,7 @@ def import_d_file(in_file: str) -> str:
         else:
             out_lines.append(line.replace('\\', '/'))
 
+        headers: List[str] = []
         for line in it:
             suffix = ''
             if line.endswith(' \\\n'):
@@ -59,7 +60,10 @@ def import_d_file(in_file: str) -> str:
                 path = line.strip()
 
             path = convert_path(path)
+            headers.append(path)
             out_lines.append(f"\t{path}{suffix}\n")
+        # the metrowerks compiler doesn't support -MP
+        out_lines.extend([f'{header}:\n' for header in headers])
 
     return ''.join(out_lines)
 


### PR DESCRIPTION
There is an issue where the build will get blocked if any include gets deleted (like headers or asm). This is normally resolved with the `-MP` flag, which instructs the compiler to generate phony make targets for each include. However, the metrowerks compiler doesn't support this option, so I made `transform-deps.py` do it instead.