### PR TITLE
lcf.py: fix wrong variable being checked for "@"

### DIFF
--- a/tools/lcf.py
+++ b/tools/lcf.py
@@ -105,7 +105,7 @@ def lcf_generate(output_path,shiftable,map_file):
             if shiftable==True:        
                 for line in map_file:
                     literals_found = []
-                    if type(symbol['name'])==str and line.find(' '+symbol['name']+' ')!=-1 and name[0] != "@" or type(symbol['label']) == str and line.find(' '+symbol['label']+' ')!=-1:
+                    if type(symbol['name'])==str and line.find(' '+symbol['name']+' ')!=-1 and symbol['name'][0] != "@" or type(symbol['label']) == str and line.find(' '+symbol['label']+' ')!=-1:
                         linesplit = line.split()
                         if len(linesplit) > 3 and linesplit[2]!="NOT":
                             if line.find("lit_")!=-1:


### PR DESCRIPTION
The most recent master has a build error when running `make game`. Upon investigating, I found that the `lcf.py` script is supposed to ignore symbols that start with "@", but it was checking the assembly friendly label instead of the original symbol from the map. Fixing this allowed the build to continue, and it produced a bootable game.