### PR TITLE
Setup fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ clean_rels:
 	rm -f -d -r $(BUILD_DIR)/rel
 	rm -f $(BUILD_PATH)/*.rel
 
-tools: $(ELF2DOL) $(YAZ0)
+tools: dirs $(ELF2DOL) $(YAZ0)
 
 assets:
 	@mkdir -p game

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,5 +9,3 @@ python-Levenshtein
 cxxfilt
 pyelftools
 requests
-zipfile
-shutil

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -295,6 +295,10 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
         )
         sys.exit(1)
 
+    # add execute flag to compilers for WSL
+    if os.name == 'posix':
+        subprocess.run(['chmod', '+x'] + list(compilers.glob("*/*.exe")))
+
     #
     text = Text("--- Extracting game assets")
     text.stylize("bold magenta")

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -4,16 +4,19 @@ tp.py - Various tools used for the zeldaret/tp project.
 
 """
 
+import hashlib
+import io
 import os
 import sys
 import time
-import struct
 import json
 import subprocess
+import logging
 import multiprocessing as mp
 import shutil
 import platform
 import stat
+import zipfile
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple
@@ -21,16 +24,11 @@ from pathlib import Path
 
 try:
     import click
-    import logging
-    import hashlib
     import libdol
     import librel
     import libarc
-    import io
     import extract_game_assets
     import requests
-    import zipfile
-    import shutil
 
     from rich.logging import RichHandler
     from rich.console import Console

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -202,14 +202,12 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
         )
         sys.exit(1)
 
-    c27_lmgr326b = c27.joinpath("Lmgr326b.dll")
-    if not c27_lmgr326b.exists() or not c27_lmgr326b.is_file():
-        c27_lmgr326b = c27.joinpath("lmgr326b.dll")
-    if not c27_lmgr326b.exists() or not c27_lmgr326b.is_file():
-        c27_lmgr326b = c27.joinpath("LMGR326B.dll")
-    if not c27_lmgr326b.exists() or not c27_lmgr326b.is_file():
-        c27_lmgr326b = c27.joinpath("LMGR326B.DLL")
-    if not c27_lmgr326b.exists() or not c27_lmgr326b.is_file():
+    c27_lmgr326b = None
+    for name in os.listdir(c27):
+        if name.lower() == "lmgr326b.dll":
+            c27_lmgr326b = c27.joinpath(name)
+            break
+    if not c27_lmgr326b or not c27_lmgr326b.is_file():
         LOG.error(
             (
                 f"Unable to find 'lmgr326b.dll' in '{c27}': missing file '{c27_lmgr326b}'\n"
@@ -218,15 +216,15 @@ def setup(debug: bool, game_path: Path, tools_path: Path):
         )
         sys.exit(1)
 
-    c27_lmgr326b_cc = c27.joinpath("LMGR326B.dll")
-    if not c27_lmgr326b_cc.exists() or not c27_lmgr326b_cc.is_file():
-        LOG.debug(f"copy: '{c27_lmgr326b}', to: '{c27_lmgr326b_cc}'")
-        shutil.copy(c27_lmgr326b, c27_lmgr326b_cc)
+    def copy_lmgr326b(path: Path):
+        lmgr326b_cc = path.joinpath("LMGR326B.dll")
+        if not lmgr326b_cc.is_file():
+            LOG.debug(f"copy: '{c27_lmgr326b}', to: '{lmgr326b_cc}'")
+            shutil.copy(c27_lmgr326b, lmgr326b_cc)
 
-    c125_lmgr326b_cc = c125.joinpath("LMGR326B.dll")
-    if not c125_lmgr326b_cc.exists() or not c125_lmgr326b_cc.is_file():
-        LOG.debug(f"copy: '{c27_lmgr326b}', to: '{c125_lmgr326b_cc}'")
-        shutil.copy(c27_lmgr326b, c125_lmgr326b_cc)
+    copy_lmgr326b(c27)
+    copy_lmgr326b(c125)
+    copy_lmgr326b(c125e)
 
     c27_mwcceppc = c27.joinpath("mwcceppc.exe")
     if not c27_mwcceppc.exists() or not c27_mwcceppc.is_file():


### PR DESCRIPTION
This PR addresses the following issues:

requirements.txt had 2 entries which were standard python libraries and could not be installed by pip
`make tools` failed until the user created the build directory manually
WSL users wouldn't be able to run the compilers without using `chmod +x` first
`./tp setup` did not copy LMGR326B.dll for 1.2.5e
