### PR TITLE
fix FLOAT_MIN

### DIFF
--- a/include/dolphin/types.h
+++ b/include/dolphin/types.h
@@ -34,7 +34,7 @@ typedef int BOOL;
 #define INT32_MAX (0x7fffffff)
 #define UINT32_MAX (0xffffffff)
 
-#define FLOAT_MIN (-1e31f)
+#define FLOAT_MIN (1.175494351e-38f)
 #define FLOAT_MAX (3.40282346638528860e+38f)
 
 #endif

--- a/src/f_op/f_op_actor.cpp
+++ b/src/f_op/f_op_actor.cpp
@@ -84,8 +84,8 @@ static int fopAc_Execute(void* i_this) {
                 fopAcM_delete(_this);
             }
 
-            if (_this->current.pos.y < FLOAT_MIN) {
-                _this->current.pos.y = FLOAT_MIN;
+            if (_this->current.pos.y < -1e31f) {
+                _this->current.pos.y = -1e31f;
             }
 
             dKy_depth_dist_set(_this);


### PR DESCRIPTION
The FLOAT_MIN macro isn't actually the smallest possible float value. I've replaced it with the FLT_MIN value from visual studio. After this change, both the FLOAT_MIN and FLOAT_MAX macros will be entirely unused. Maybe they should be removed instead?