### PR TITLE
improve const correctness

### DIFF
--- a/include/c/c_dylink.h
+++ b/include/c/c_dylink.h
@@ -14,7 +14,7 @@ struct cDylPhs {
 
 struct DynamicNameTableEntry {
     s16 mKey;
-    char* name;
+    const char* name;
 };
 
 int cDyl_InitAsyncIsDone();

--- a/include/d/a/d_a_shop_item_static.h
+++ b/include/d/a/d_a_shop_item_static.h
@@ -4,7 +4,7 @@
 #include "d/a/d_a_itembase.h"
 
 struct ResourceData {
-    char* get_arcName() const { return mArcName; }
+    const char* get_arcName() const { return mArcName; }
     s16 get_bmdName() const { return mBmdName; }
     s16 get_btk1Name() const { return mBtkName; }
     s16 get_bpk1Name() const { return mBpkName; }
@@ -13,7 +13,7 @@ struct ResourceData {
     s16 get_brk1Name() const { return mBrkName; }
     s16 get_btp1Name() const { return mBtpName; }
 
-    /* 0x00 */ char* mArcName;
+    /* 0x00 */ const char* mArcName;
     /* 0x04 */ s16 mBmdName;
     /* 0x06 */ s16 mBtkName;
     /* 0x08 */ s16 mBpkName;

--- a/include/d/d_item_data.h
+++ b/include/d/d_item_data.h
@@ -11,7 +11,7 @@ struct dItem_itemInfo {
 };
 
 struct dItem_itemResource {
-    /* 0x00 */ char* mArcName;
+    /* 0x00 */ const char* mArcName;
     /* 0x04 */ s16 mBmdName;
     /* 0x06 */ s16 mBtkName;
     /* 0x08 */ s16 mBckName;
@@ -25,7 +25,7 @@ struct dItem_itemResource {
 };  // Size: 0x18
 
 struct dItem_fieldItemResource {
-    /* 0x0 */ char* mFieldArc;
+    /* 0x0 */ const char* mFieldArc;
     /* 0x4 */ s16 mItemBmdName;
     /* 0x6 */ s16 mItemBckName;
     /* 0x8 */ s16 mItemBrkName;
@@ -34,7 +34,7 @@ struct dItem_fieldItemResource {
 };  // Size: 0x10
 
 struct dItem_data {
-    static char* getArcName(u8 index) { return item_resource[index].mArcName; }
+    static const char* getArcName(u8 index) { return item_resource[index].mArcName; }
 
     static s16 getBtpName(u8 index) { return item_resource[index].mBtpName; }
 
@@ -56,7 +56,7 @@ struct dItem_data {
 
     static s16 getTexture(u8 index) { return item_resource[index].mTexture; }
 
-    static char* getFieldArc(u8 index) { return field_item_res[index].mFieldArc; }
+    static const char* getFieldArc(u8 index) { return field_item_res[index].mFieldArc; }
 
     static s16 getItemBmdName(u8 index) { return field_item_res[index].mItemBmdName; }
 

--- a/include/d/d_timer.h
+++ b/include/d/d_timer.h
@@ -34,7 +34,7 @@ public:
     /* 8025EB20 */ void hideDenominator();
     /* 8025EC5C */ void deleteScreen();
     /* 8025EE24 */ void changeNumberTexture(J2DPane*, int);
-    /* 8025EECC */ char* getNumber(int);
+    /* 8025EECC */ const char* getNumber(int);
     /* 8025EEF0 */ void setTimer(int);
     /* 8025F180 */ void setCounter(u8, u8);
     /* 8025FA00 */ void setParentPos(f32, f32);

--- a/include/d/kankyo/d_kankyo_data.h
+++ b/include/d/kankyo/d_kankyo_data.h
@@ -21,13 +21,13 @@ enum dKyd_DARKLV {
 
 class dKydata_darkworldInfo_c {
 public:
-    /* 0x0 */ char* stageName;
+    /* 0x0 */ const char* stageName;
     /* 0x4 */ u8 darkLv;
 };  // Size: 0x8
 
 class dKydata_lightsizeInfo_c {
 public:
-    /* 0x0 */ char* stageName;
+    /* 0x0 */ const char* stageName;
     /* 0x4 */ u8 size;
 };  // Size: 0x8
 

--- a/include/d/meter/d_meter2_info.h
+++ b/include/d/meter/d_meter2_info.h
@@ -542,7 +542,7 @@ inline void dMeter2Info_resetDirectUseItem() {
     g_meter2_info.resetDirectUseItem();
 }
 
-char* dMeter2Info_getNumberTextureName(int pIndex);
+const char* dMeter2Info_getNumberTextureName(int pIndex);
 void dMeter2Info_recieveLetter();
 u8 dMeter2Info_getNewLetterNum();
 int dMeter2Info_setNewLetterSender();

--- a/include/dolphin/os/OS.h
+++ b/include/dolphin/os/OS.h
@@ -78,19 +78,19 @@ BOOL OSIsThreadSuspended(OSThread* thread);
 
 u32 OSGetConsoleType(void);
 
-void OSAttention(char* msg, ...);
-void OSPanic(char* file, s32 line, char* fmt, ...);
-void OSReport(char* fmt, ...);
-void OSReport_Error(char* fmt, ...);
-void OSReport_FatalError(char* fmt, ...);
-void OSReport_System(char* fmt, ...);
-void OSReport_Warning(char* fmt, ...);
+void OSAttention(const char* msg, ...);
+void OSPanic(const char* file, s32 line, const char* fmt, ...);
+void OSReport(const char* fmt, ...);
+void OSReport_Error(const char* fmt, ...);
+void OSReport_FatalError(const char* fmt, ...);
+void OSReport_System(const char* fmt, ...);
+void OSReport_Warning(const char* fmt, ...);
 void OSReportDisable(void);
 void OSReportEnable(void);
 void OSReportForceEnableOff(void);
 void OSReportForceEnableOn(void);
-void OSVReport(char* format, va_list list);
-void OSVAttention(char* fmt, va_list args);
+void OSVReport(const char* format, va_list list);
+void OSVAttention(const char* fmt, va_list args);
 void OSReportInit(void);
 
 extern u8 __OSReport_disable;

--- a/src/d/a/d_a_alink.cpp
+++ b/src/d/a/d_a_alink.cpp
@@ -11642,14 +11642,14 @@ SECTION_DATA static u8 rodTopOffset[12] = {
 };
 
 /* 803B2D94-803B2DA0 -00001 000C+00 1/1 0/0 0/0 .data            bodyBrkName$69118 */
-SECTION_DATA static char* bodyBrkName[3] = {
+SECTION_DATA static const char* bodyBrkName[3] = {
     "ml_body_power_down.brk",
     "ml_body_power_up_a.brk",
     "ml_body_power_up_b.brk",
 };
 
 /* 803B2DA0-803B2DAC -00001 000C+00 1/1 0/0 0/0 .data            headBrkName$69119 */
-SECTION_DATA static char* headBrkName[3] = {
+SECTION_DATA static const char* headBrkName[3] = {
     "ml_head_power_down.brk",
     "ml_head_power_up_a.brk",
     "ml_head_power_up_b.brk",

--- a/src/d/d_name.cpp
+++ b/src/d/d_name.cpp
@@ -127,7 +127,7 @@ SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
 };
 
 /* 803C1F5C-803C2060 -00001 0104+00 0/3 0/0 0/0 .data            l_mojiHira */
-SECTION_DATA static char* l_mojiHira[65] = {
+SECTION_DATA static const char* l_mojiHira[65] = {
     "あ", "い", "う", "え", "お", "か", "き", "く", "け", "こ", "さ", "し", "す",
     "せ", "そ", "た", "ち", "つ", "て", "と", "な", "に", "ぬ", "ね", "の", "は",
     "ひ", "ふ", "へ", "ほ", "ま", "み", "む", "め", "も", "や", "　", "ゆ", "　",
@@ -136,7 +136,7 @@ SECTION_DATA static char* l_mojiHira[65] = {
 };
 
 /* 803C2060-803C2164 -00001 0104+00 0/1 0/0 0/0 .data            l_mojiHira2 */
-SECTION_DATA static char* l_mojiHira2[65] = {
+SECTION_DATA static const char* l_mojiHira2[65] = {
     "￥", "￥", "￥", "￥", "￥", "が", "ぎ", "ぐ", "げ", "ご", "ざ", "じ", "ず",
     "ぜ", "ぞ", "だ", "ぢ", "づ", "で", "ど", "￥", "￥", "￥", "￥", "￥", "ば",
     "び", "ぶ", "べ", "ぼ", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥",
@@ -145,7 +145,7 @@ SECTION_DATA static char* l_mojiHira2[65] = {
 };
 
 /* 803C2164-803C2268 -00001 0104+00 0/1 0/0 0/0 .data            l_mojiHira3 */
-SECTION_DATA static char* l_mojiHira3[65] = {
+SECTION_DATA static const char* l_mojiHira3[65] = {
     "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥",
     "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "ぱ",
     "ぴ", "ぷ", "ぺ", "ぽ", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥",
@@ -154,7 +154,7 @@ SECTION_DATA static char* l_mojiHira3[65] = {
 };
 
 /* 803C2268-803C236C -00001 0104+00 0/3 0/0 0/0 .data            l_mojikata */
-SECTION_DATA static char* l_mojikata[65] = {
+SECTION_DATA static const char* l_mojikata[65] = {
     "ア", "イ",       "ウ", "エ", "オ", "カ", "キ", "ク", "ケ", "コ", "サ", "シ", "ス",
     "セ", "\x83\x5C", "タ", "チ", "ツ", "テ", "ト", "ナ", "ニ", "ヌ", "ネ", "ノ", "ハ",
     "ヒ", "フ",       "ヘ", "ホ", "マ", "ミ", "ム", "メ", "モ", "ヤ", "　", "ユ", "　",
@@ -163,7 +163,7 @@ SECTION_DATA static char* l_mojikata[65] = {
 };
 
 /* 803C236C-803C2470 -00001 0104+00 0/1 0/0 0/0 .data            l_mojikata2 */
-SECTION_DATA static char* l_mojikata2[65] = {
+SECTION_DATA static const char* l_mojikata2[65] = {
     "￥", "￥", "ヴ", "￥", "￥", "ガ", "ギ", "グ", "ゲ", "ゴ", "ザ", "ジ", "ズ",
     "ゼ", "ゾ", "ダ", "ヂ", "ヅ", "デ", "ド", "￥", "￥", "￥", "￥", "￥", "バ",
     "ビ", "ブ", "ベ", "ボ", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥",
@@ -172,7 +172,7 @@ SECTION_DATA static char* l_mojikata2[65] = {
 };
 
 /* 803C2470-803C2574 -00001 0104+00 0/1 0/0 0/0 .data            l_mojikata3 */
-SECTION_DATA static char* l_mojikata3[65] = {
+SECTION_DATA static const char* l_mojikata3[65] = {
     "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥",
     "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "パ",
     "ピ", "プ", "ペ", "ポ", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥", "￥",
@@ -181,7 +181,7 @@ SECTION_DATA static char* l_mojikata3[65] = {
 };
 
 /* 803C2574-803C2678 -00001 0104+00 0/3 0/0 0/0 .data            l_mojiEisu */
-SECTION_DATA static char* l_mojiEisu[65] = {
+SECTION_DATA static const char* l_mojiEisu[65] = {
     "A", "N", "a", "n", "1", "B", "O", "b", "o", "2", "C", "P", "c", "p", "3", "D", "Q",
     "d", "q", "4", "E", "R", "e", "r", "5", "F", "S", "f", "s", "6", "G", "T", "g", "t",
     "7", "H", "U", "h", "u", "8", "I", "V", "i", "v", "9", "J", "W", "j", "w", "0", "K",
@@ -799,7 +799,7 @@ void dName_c::selectMojiSet() {
 
 /* 8024F59C-8024F634 249EDC 0098+00 1/1 0/0 0/0 .text            getMoji__7dName_cFv */
 int dName_c::getMoji() {
-    char* moji;
+    const char* moji;
 
     switch (mMojiSet) {
     case MOJI_HIRA:
@@ -1109,7 +1109,7 @@ asm void dName_c::backSpace() {
 
 /* 802501B0-80250284 24AAF0 00D4+00 2/2 0/0 0/0 .text            mojiListChange__7dName_cFv */
 void dName_c::mojiListChange() {
-    char** mojiSet;
+    const char** mojiSet;
 
     switch (mMojiSet) {
     case MOJI_HIRA:

--- a/src/d/d_timer.cpp
+++ b/src/d/d_timer.cpp
@@ -545,7 +545,7 @@ asm void dDlst_TimerScrnDraw_c::changeNumberTexture(J2DPane* param_0, int param_
 #pragma pop
 
 /* 8025EECC-8025EEF0 25980C 0024+00 1/1 0/0 0/0 .text getNumber__21dDlst_TimerScrnDraw_cFi */
-char* dDlst_TimerScrnDraw_c::getNumber(int pIndex) {
+const char* dDlst_TimerScrnDraw_c::getNumber(int pIndex) {
     return dMeter2Info_getNumberTextureName(pIndex);
 }
 

--- a/src/d/event/d_event_manager.cpp
+++ b/src/d/event/d_event_manager.cpp
@@ -164,7 +164,7 @@ s32 dEvent_exception_c::setStartDemo(int mapToolID) {
 
 /* 80046480-800465E8 040DC0 0168+00 1/1 0/0 0/0 .text getEventName__18dEvent_exception_cFv */
 const char* dEvent_exception_c::getEventName() {
-    static char* soecial_names[14] = {
+    static const char* soecial_names[14] = {
         "NORMAL_COMEBACK",  "DEFAULT_START",      "SHUTTER_START",  "SHUTTER_START_STOP",
         "BS_SHUTTER_START", "BS_SHUTTER_START_B", "KNOB_START",     "KNOB_START_B",
         "FMASTER_START",    "FALL_START",         "CRAWLOUT_START", "BOSSWARP_START",
@@ -424,7 +424,7 @@ void dEvent_manager_c::endProc(s16 eventID, int close) {
         }
 
         if (event->mEventState == 2) {
-            char* param = "ALL";
+            const char* param = "ALL";
             fopAcM_Search((fopAcIt_JudgeFunc)allOffObjectCallBack, (void*)param);
             mCameraPlay = 2;
             event->mEventState = 0;
@@ -1221,7 +1221,7 @@ static int dEv_talkman_get_action(int param_0) {
         return -1;
     } else {
         /* 803A82A8-803A82B8 -00001 000C+04 1/1 0/0 0/0 .data            action_table$5100 */
-        static char* action_table[] = {
+        static const char* action_table[] = {
             "WAIT",
             "TALK0",
             "TALK1",

--- a/src/d/file/d_file_sel_info.cpp
+++ b/src/d/file/d_file_sel_info.cpp
@@ -97,7 +97,7 @@ SECTION_DATA static u64 l_htag[20] = {
 };
 
 /* 803BB548-803BB558 -00001 0010+00 1/1 0/0 0/0 .data            amariheartTex$3880 */
-SECTION_DATA static char* amariheartTex[4] = {
+SECTION_DATA static const char* amariheartTex[4] = {
     "tt_heart_00.bti",
     "tt_heart_00.bti",
     "tt_heart_00.bti",

--- a/src/d/meter/d_meter2_draw.cpp
+++ b/src/d/meter/d_meter2_draw.cpp
@@ -273,7 +273,7 @@ SECTION_DEAD static char const* const stringBase_803989BF = "";
 #pragma pop
 
 /* 803BF328-803BF350 -00001 0028+00 1/1 0/0 0/0 .data            bmg_filename$3954 */
-SECTION_DATA static char* bmg_filename[10] = {
+SECTION_DATA static const char* bmg_filename[10] = {
     "zel_00.bmg", "zel_01.bmg", "zel_02.bmg", "zel_03.bmg", "zel_04.bmg",
     "zel_05.bmg", "zel_06.bmg", "zel_07.bmg", "zel_08.bmg", "zel_99.bmg",
 };

--- a/src/d/meter/d_meter2_info.cpp
+++ b/src/d/meter/d_meter2_info.cpp
@@ -1348,8 +1348,8 @@ s16 dMeter2Info_getNowLifeGauge() {
 }
 
 /* 8021E2C8-8021E2DC 218C08 0014+00 0/0 11/11 3/3 .text dMeter2Info_getNumberTextureName__Fi */
-char* dMeter2Info_getNumberTextureName(int nameIdx) {
-    static char* tex_name[10] = {
+const char* dMeter2Info_getNumberTextureName(int nameIdx) {
+    static const char* tex_name[10] = {
         "im_font_number_32_32_ganshinkyo_0_02.bti",
         "im_font_number_32_32_ganshinkyo_1_02.bti",
         "im_font_number_32_32_ganshinkyo_2_02.bti",
@@ -1365,8 +1365,8 @@ char* dMeter2Info_getNumberTextureName(int nameIdx) {
     return tex_name[nameIdx];
 }
 
-char* dMeter2Info_getPlusTextureName() {
-    static char* tex_name;
+const char* dMeter2Info_getPlusTextureName() {
+    static const char* tex_name;
     static s8 initTexName;
 
     if (!initTexName) {

--- a/src/d/msg/d_msg_out_font.cpp
+++ b/src/d/msg/d_msg_out_font.cpp
@@ -800,7 +800,7 @@ asm void COutFont_c::setBlendAnime(J2DPicture* param_0, s16 param_1) {
 
 /* 80228530-80228578 222E70 0048+00 1/1 0/0 0/0 .text            getBtiName__10COutFont_cFi */
 const char* COutFont_c::getBtiName(int nameIdx) {
-    static char* mpIconName[70] = {
+    static const char* mpIconName[70] = {
         "font_00.bti",
         "font_01.bti",
         "font_09.bti",

--- a/src/d/s/d_s_play.cpp
+++ b/src/d/s/d_s_play.cpp
@@ -500,7 +500,7 @@ static int dScnPly_IsDelete(dScnPly_c scnPly) {
 extern "C" char const* const stringBase_8039A2DF;
 
 /* 80450760-80450764 -00001 0004+00 1/0 0/0 0/0 .sdata           T_JOINT_resName */
-extern "C" char* T_JOINT_resName;
+extern "C" const char* T_JOINT_resName;
 
 /* 80454F18-80454F1C 003518 0002+02 1/0 0/0 0/0 .sdata2          T_JOINT_dylKeyTbl */
 extern "C" u16 T_JOINT_dylKeyTbl;
@@ -522,7 +522,7 @@ SECTION_DEAD static char const* const stringBase_8039A2DF = "T_JOINT";
 #pragma pop
 
 /* 80450760-80450764 -00001 0004+00 1/0 0/0 0/0 .sdata           T_JOINT_resName */
-SECTION_SDATA static char* T_JOINT_resName = "Always";
+SECTION_SDATA static const char* T_JOINT_resName = "Always";
 
 /* 80450764-80450768 -00001 0004+00 4/4 0/0 0/0 .sdata           None */
 SECTION_SDATA static s8 preLoadNo = 0xFF;

--- a/src/m_Do/m_Do_machine.cpp
+++ b/src/m_Do/m_Do_machine.cpp
@@ -148,7 +148,7 @@ static u32 heapErrors;
 
 /* 8000B1EC-8000B3EC 005B2C 0200+00 2/2 0/0 0/0 .text            myGetHeapTypeByString__FP7JKRHeap
  */
-static char* myGetHeapTypeByString(JKRHeap* p_heap) {
+static const char* myGetHeapTypeByString(JKRHeap* p_heap) {
     static char tmpString[5];
 
     if (p_heap == JKRHeap::getSystemHeap()) {
@@ -254,7 +254,7 @@ static void myMemoryErrorRoutine(void* p_heap, u32 size, int alignment) {
 /* 8000B5C8-8000B668 005F08 00A0+00 1/1 0/0 0/0 .text            myHeapCheckRecursive__FP7JKRHeap */
 void myHeapCheckRecursive(JKRHeap* p_heap) {
     if (!p_heap->check()) {
-        char* type = myGetHeapTypeByString(p_heap);
+        const char* type = myGetHeapTypeByString(p_heap);
         OSReport_Error("error in %08x(%s)\n", p_heap, type);
     }
 

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -217,11 +217,11 @@ static bool mCheckHeap;
 
 /* 80005AD8-80005D4C 000418 0274+00 1/1 0/0 0/0 .text            debugDisplay__Fv */
 void debugDisplay() {
-    static char* desc1[5] = {
+    static const char* desc1[5] = {
         "", "TotalFree", "MaxUsed  ", "Used     ", "RelUsed  ",
     };
 
-    static char* desc2[5] = {
+    static const char* desc2[5] = {
         "", "/ MaxFree", "/HeapSize", "Blk/Bytes", "Blk/Bytes",
     };
 

--- a/src/m_Do/m_Do_printf.cpp
+++ b/src/m_Do/m_Do_printf.cpp
@@ -41,12 +41,12 @@ void my_PutString(const char* string) {
 }
 
 /* 800067F4-80006814 001134 0020+00 3/3 0/0 0/0 .text OSVAttention__FPCcP16__va_list_struct */
-void OSVAttention(char* fmt, va_list args) {
+void OSVAttention(const char* fmt, va_list args) {
     mDoPrintf_vprintf(fmt, args);
 }
 
 /* 80006814-80006894 001154 0080+00 1/1 1/1 0/0 .text            OSAttention */
-void OSAttention(char* fmt, ...) {
+void OSAttention(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
     mDoPrintf_vprintf(fmt, args);
@@ -156,12 +156,12 @@ void mDoPrintf_VReport(const char* fmt, va_list args) {
 }
 
 /* 80006A9C-80006ABC 0013DC 0020+00 2/2 0/0 0/0 .text            OSVReport */
-void OSVReport(char* fmt, va_list args) {
+void OSVReport(const char* fmt, va_list args) {
     mDoPrintf_VReport(fmt, args);
 }
 
 /* 80006ABC-80006B3C 0013FC 0080+00 0/0 97/97 10/10 .text            OSReport */
-void OSReport(char* fmt, ...) {
+void OSReport(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
     OSVReport(fmt, args);
@@ -169,7 +169,7 @@ void OSReport(char* fmt, ...) {
 }
 
 /* 80006B3C-80006C0C 00147C 00D0+00 0/0 2/2 0/0 .text            OSReport_FatalError */
-void OSReport_FatalError(char* fmt, ...) {
+void OSReport_FatalError(const char* fmt, ...) {
     va_list args;
     va_start(args, fmt);
 
@@ -185,7 +185,7 @@ void OSReport_FatalError(char* fmt, ...) {
 }
 
 /* 80006C0C-80006CEC 00154C 00E0+00 0/0 31/31 10/10 .text            OSReport_Error */
-void OSReport_Error(char* fmt, ...) {
+void OSReport_Error(const char* fmt, ...) {
     print_errors++;
     if (!__OSReport_Error_disable) {
         va_list args;
@@ -201,7 +201,7 @@ void OSReport_Error(char* fmt, ...) {
 }
 
 /* 80006CEC-80006DCC 00162C 00E0+00 0/0 6/6 0/0 .text            OSReport_Warning */
-void OSReport_Warning(char* fmt, ...) {
+void OSReport_Warning(const char* fmt, ...) {
     print_warings++;
     if (!__OSReport_Warning_disable) {
         va_list args;
@@ -217,7 +217,7 @@ void OSReport_Warning(char* fmt, ...) {
 }
 
 /* 80006DCC-80006E7C 00170C 00B0+00 0/0 1/1 0/0 .text            OSReport_System */
-void OSReport_System(char* fmt, ...) {
+void OSReport_System(const char* fmt, ...) {
     print_systems++;
     if (!__OSReport_System_disable) {
         va_list args;
@@ -230,7 +230,7 @@ void OSReport_System(char* fmt, ...) {
 }
 
 /* 80006E7C-80006FB4 0017BC 0138+00 0/0 9/9 0/0 .text            OSPanic */
-void OSPanic(char* file, s32 line, char* fmt, ...) {
+void OSPanic(const char* file, s32 line, const char* fmt, ...) {
     va_list args;
     u32 i;
     u32* p;


### PR DESCRIPTION
Other compilers are less okay with assigning string literals to `char*` instead of `const char*`.