### PR TITLE
Fix tp.py module not found error report bug

### DIFF
--- a/tools/tp.py
+++ b/tools/tp.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 def _handle_import_error(ex: ImportError):
     MISSING_PREREQUISITES = (
-        f"Missing prerequisite python module {e}.\n"
+        f"Missing prerequisite python module {ex}.\n"
         f"Run `python3 -m pip install --user -r tools/requirements.txt` to install prerequisites."
     )
 


### PR DESCRIPTION
```
./root@madeline:/mnt/d/programs/tp# ./tp setup
Traceback (most recent call last):
  File "/mnt/d/programs/tp/tools/tp.py", line 41, in <module>
    from rich.logging import RichHandler
ModuleNotFoundError: No module named 'rich'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/mnt/d/programs/tp/tools/tp.py", line 47, in <module>
    _handle_import_error(ex)
  File "/mnt/d/programs/tp/tools/tp.py", line 28, in _handle_import_error
    f"Missing prerequisite python module {e}.\n"
NameError: name 'e' is not defined. Did you mean: 'ex'?
```