### PR TITLE
extract_game_assets.py: fix 'make assets'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ tools: dirs $(ELF2DOL) $(YAZ0)
 
 assets:
 	@mkdir -p game
-	@cd game; $(PYTHON) ../tools/extract_game_assets.py ../$(IMAGENAME)
+	$(PYTHON) tools/extract_game_assets.py $(IMAGENAME) game
 
 docs:
 	$(DOXYGEN) Doxyfile

--- a/tools/extract_game_assets.py
+++ b/tools/extract_game_assets.py
@@ -231,7 +231,7 @@ def getDolInfo(disc):
     return dolOffset, dolSize
 
 
-def extract(path,yaz0Encoder):
+def extract(isoPath: Path, gamePath: Path, yaz0Encoder):
     if yaz0Encoder == "oead":
         try:
             from oead import yaz0
@@ -239,7 +239,10 @@ def extract(path,yaz0Encoder):
             yaz0DecompressFunction = yaz0.decompress
         except:
             print("Extract: oead isn't installed, falling back to native yaz0")
-    with open(path, "rb") as f:
+    isoPath = isoPath.absolute()
+    cwd = os.getcwd()
+    os.chdir(gamePath)
+    with open(isoPath, "rb") as f:
         # Seek to fst offset information and retrieve it
         f.seek(fstInfoPosition)
         fstOffset, fstSize = getFstInfo(f, fstInfoPosition)
@@ -272,10 +275,11 @@ def extract(path,yaz0Encoder):
 
         # Write assets to file
         writeAssets(parsedFstBin, f)
+    os.chdir(cwd)
 
 
 def main():
-    extract(sys.argv[1],"native")
+    extract(Path(sys.argv[1]), Path(sys.argv[2]), "native")
 
 
 if __name__ == "__main__":

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -337,10 +337,7 @@ def setup(debug: bool, game_path: Path, tools_path: Path, yaz0_encoder: str, for
 
         try:
             import extract_game_assets
-            previous_dir = os.getcwd()
-            os.chdir(str(game_path.absolute()))
-            extract_game_assets.extract("../" + str(iso),yaz0_encoder)
-            os.chdir(previous_dir)
+            extract_game_assets.extract(iso, game_path, yaz0_encoder)
         except ImportError as ex:
             _handle_import_error(ex)
         except Exception as e:


### PR DESCRIPTION
`make assets` always fails because it can't find yaz0.so. `./tp setup` works, so it hasn't been that big of an issue. This PR fixes `make assets`