### PR TITLE
Fix Build Scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ $(DOL_SHIFT): $(ELF_SHIFT) | tools
 	
 shift: dirs $(DOL_SHIFT)
 
-shiftedrels: shift
+shiftedrels: shift $(RELS)
 	@echo generating shifted RELs from .plf
 	@echo $(RELS) > build/plf_files
 	$(PYTHON) $(MAKEREL) build --string-table $(BUILD_DIR)/frameworkF.str @build/plf_files $(ELF_SHIFT)

--- a/tools/package_game_assets.py
+++ b/tools/package_game_assets.py
@@ -342,10 +342,7 @@ def main(gamePath, buildPath, copyCode, yaz0Encoding):
 
     if not (gamePath / "files").exists() or not (gamePath / "sys").exists():
         print("ISO is not extracted; extracting...")
-        previousDir = os.getcwd()
-        os.chdir(str(gamePath.absolute()))
-        extract_game_assets.extract("../" + str(iso),yaz0Encoding)
-        os.chdir(previousDir)
+        extract_game_assets.extract(iso.absolute(),gamePath.absolute(),yaz0Encoding)
 
     print("Copying game files...")
     if os.path.exists(buildPath / "dolzel2") == False:


### PR DESCRIPTION
This is a simple change to the Makefile that will have it build rels when "make game" is used. This also fixes the extracting script when "make game" is used without having the assets already extracted.

## CC0 License Agreement
<!--
By submitting this pull request, I agree to comply with the terms of the Creative Commons Zero v1.0 Universal (CC0) Public Domain Dedication License for my contributions to this project.

I dedicate any and all copyright interest in this contribution to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

To the best of my knowledge and belief, my contribution is either originally created by me, or is derived from a source that also released its contents under CC0 or a compatible license.

I understand that this project and its maintainers are not responsible for enforcing the CC0 license, and I release them from any potential liability related to my contribution.
-->

- [x] I agree to the terms of the CC0 License.

<!--
Please check the checkbox above to indicate your agreement.
-->