### PR TITLE
setup dolphin VEC/MTX function defines

### DIFF
--- a/include/JSystem/J2DGraph/J2DPane.h
+++ b/include/JSystem/J2DGraph/J2DPane.h
@@ -129,7 +129,7 @@ public:
 
     MtxP getGlbMtx() { return mGlobalMtx; }
 
-    void setMtx(Mtx m) { PSMTXCopy(m, mPositionMtx); }
+    void setMtx(Mtx m) { MTXCopy(m, mPositionMtx); }
 
     void translate(f32 transX, f32 transY) {
         mTranslateX = transX;

--- a/include/JSystem/J3DGraphAnimator/J3DModel.h
+++ b/include/JSystem/J3DGraphAnimator/J3DModel.h
@@ -75,7 +75,7 @@ public:
     bool isCpuSkinningOn() const { return (mFlags & J3DMdlFlag_SkinPosCpu) && (mFlags & J3DMdlFlag_SkinNrmCpu); }
 
     Mtx& getBaseTRMtx() { return mBaseTransformMtx; }
-    void i_setBaseTRMtx(Mtx m) { PSMTXCopy(m, mBaseTransformMtx); }
+    void i_setBaseTRMtx(Mtx m) { MTXCopy(m, mBaseTransformMtx); }
     u32 getMtxCalcMode() const { return mFlags & 0x03; }
     J3DVertexBuffer* getVertexBuffer() const { return (J3DVertexBuffer*)&mVertexBuffer; }
     J3DMatPacket* getMatPacket(u16 idx) const { return &mMatPacket[idx]; }

--- a/include/JSystem/J3DGraphAnimator/J3DMtxBuffer.h
+++ b/include/JSystem/J3DGraphAnimator/J3DMtxBuffer.h
@@ -23,7 +23,7 @@ public:
     /* 80326EF0 */ void calcBBoardMtx();
 
     MtxP getAnmMtx(int idx) const { return mpAnmMtx[idx]; }
-    void setAnmMtx(int i, Mtx m) { PSMTXCopy(m, (MtxP)mpAnmMtx[i]); }
+    void setAnmMtx(int i, Mtx m) { MTXCopy(m, (MtxP)mpAnmMtx[i]); }
     MtxP getWeightAnmMtx(int idx) const { return mpWeightEvlpMtx[idx]; }
 
     void setScaleFlag(int idx, u8 flag) { mpScaleFlagArr[idx] = flag; }

--- a/include/JSystem/J3DGraphBase/J3DSys.h
+++ b/include/JSystem/J3DGraphBase/J3DSys.h
@@ -124,7 +124,7 @@ struct J3DSys {
     Mtx& getModelDrawMtx(u16 no) const { return mModelDrawMtx[no]; }
     J3DShapePacket* getShapePacket() const { return mShapePacket; }
 
-    void setViewMtx(Mtx m) { PSMTXCopy(m, mViewMtx); }
+    void setViewMtx(Mtx m) { MTXCopy(m, mViewMtx); }
 
     J3DModel* getModel() { return mModel; }
 

--- a/include/JSystem/JGeometry.h
+++ b/include/JSystem/JGeometry.h
@@ -181,7 +181,7 @@ struct TVec3<f32> {
     }
 
     f32 length() const {
-        return PSVECMag((Vec*)this);
+        return VECMag((Vec*)this);
     }
 
     void scale(register f32 sc) {
@@ -247,7 +247,7 @@ struct TVec3<f32> {
     }
 
     void cross(const TVec3<f32>& a, const TVec3<f32>& b) {
-        PSVECCrossProduct(a, b, *this);
+        VECCrossProduct(a, b, *this);
     }
     
     void setLength(f32 len) {

--- a/include/JSystem/JParticle/JPADrawInfo.h
+++ b/include/JSystem/JParticle/JPADrawInfo.h
@@ -6,20 +6,20 @@
 class JPADrawInfo {
 public:
     JPADrawInfo(Mtx param_0, f32 fovY, f32 aspect) {
-        PSMTXCopy(param_0, mCamMtx);
+        MTXCopy(param_0, mCamMtx);
         C_MTXLightPerspective(mPrjMtx, fovY, aspect, 0.5f, -0.5f, 0.5f, 0.5f);
     }
 
     JPADrawInfo(Mtx param_0, f32 top, f32 bottom, f32 left, f32 right) {
-        PSMTXCopy(param_0, mCamMtx);
+        MTXCopy(param_0, mCamMtx);
         C_MTXLightOrtho(mPrjMtx, top, bottom, left, right, 0.5f, 0.5f, 0.5f, 0.5f);
     }
 
     Mtx mCamMtx;
     Mtx mPrjMtx;
 
-    void getCamMtx(Mtx* dst) const { PSMTXCopy(mCamMtx, *dst); }
-    void getPrjMtx(Mtx* dst) const { PSMTXCopy(mPrjMtx, *dst); }
+    void getCamMtx(Mtx* dst) const { MTXCopy(mCamMtx, *dst); }
+    void getPrjMtx(Mtx* dst) const { MTXCopy(mPrjMtx, *dst); }
 };
 
 #endif

--- a/include/JSystem/TPosition3.hh
+++ b/include/JSystem/TPosition3.hh
@@ -15,7 +15,7 @@ template <>
 struct SMatrix34C<f32> {
     f32 data[3][4];
 
-    void identity() { PSMTXIdentity(data); }
+    void identity() { MTXIdentity(data); }
 
     typedef f32 ArrType[4];
     void set(const ArrType* src) { JMath::gekko_ps_copy12((f32*)data, (f32*)src); }

--- a/include/SSystem/SComponent/c_m3d_g_lin.h
+++ b/include/SSystem/SComponent/c_m3d_g_lin.h
@@ -18,7 +18,7 @@ public:
     void SetStartEnd(const cXyz&, const cXyz&);
     void SetStartEnd(const Vec&, const Vec&);
     void CalcPos(Vec*, f32) const;
-    void CalcVec(Vec* pOut) const { PSVECSubtract(&this->mEnd, &this->mStart, pOut); }
+    void CalcVec(Vec* pOut) const { VECSubtract(&this->mEnd, &this->mStart, pOut); }
     void SetEnd(const cXyz&);
     const cXyz& GetStartP(void) const { return mStart; }
     cXyz& GetStartP(void) { return mStart; }

--- a/include/SSystem/SComponent/c_m3d_g_pla.h
+++ b/include/SSystem/SComponent/c_m3d_g_pla.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~cM3dGPla() {}
 
-    f32 getPlaneFunc(const Vec* pPoint) const { return mD + PSVECDotProduct(&mNormal, pPoint); }
+    f32 getPlaneFunc(const Vec* pPoint) const { return mD + VECDotProduct(&mNormal, pPoint); }
     const cXyz& GetNP() const { return mNormal; }
     const cXyz* i_GetNP() const { return &mNormal; }
     f32 GetD() const { return mD; }

--- a/include/SSystem/SComponent/c_xyz.h
+++ b/include/SSystem/SComponent/c_xyz.h
@@ -52,9 +52,9 @@ struct cXyz : Vec {
         y -= f;
         z -= f;
     }
-    void operator-=(const Vec& other) { PSVECSubtract(this, &other, this); }
-    void operator+=(const Vec& other) { PSVECAdd(this, &other, this); }
-    void operator*=(f32 scale) { PSVECScale(this, this, scale); }
+    void operator-=(const Vec& other) { VECSubtract(this, &other, this); }
+    void operator+=(const Vec& other) { VECAdd(this, &other, this); }
+    void operator*=(f32 scale) { VECScale(this, this, scale); }
     /* 80266C6C */ cXyz getCrossProduct(Vec const&) const;
     /* 80266CBC */ cXyz outprod(Vec const&) const;
     /* 80266CE4 */ cXyz norm() const;
@@ -111,8 +111,8 @@ struct cXyz : Vec {
         }
     }
 
-    float getSquareMag() const { return PSVECSquareMag(this); }
-    f32 getSquareDistance(const Vec& other) const { return PSVECSquareDistance(this, &other); }
+    float getSquareMag() const { return VECSquareMag(this); }
+    f32 getSquareDistance(const Vec& other) const { return VECSquareDistance(this, &other); }
 
     static float getNearZeroValue() { return 8e-11f; }
 
@@ -134,7 +134,7 @@ struct cXyz : Vec {
     f32 absXZ(const Vec& other) const { return sqrtf(this->abs2XZ(other)); }
     f32 getMagXZ() const { return cXyz(this->x, 0, this->z).getSquareMag(); }
 
-    f32 getDotProduct(const Vec& other) const { return PSVECDotProduct(this, &other); }
+    f32 getDotProduct(const Vec& other) const { return VECDotProduct(this, &other); }
     f32 inprod(const Vec& other) const { return getDotProduct(other); }
 };
 

--- a/include/d/bg/d_bg_w.h
+++ b/include/d/bg/d_bg_w.h
@@ -216,7 +216,7 @@ public:
     /* 8007B0B0 */ virtual bool ChkShdwDrawThrough(int, cBgS_PolyPassChk*);
     /* 8007B0DC */ virtual bool ChkGrpThrough(int, cBgS_GrpPassChk*, int);
 
-    u32 GetOldInvMtx(Mtx m) { return PSMTXInverse(m_inv_mtx, m); }
+    u32 GetOldInvMtx(Mtx m) { return MTXInverse(m_inv_mtx, m); }
     MtxP GetBaseMtxP() { return pm_base; }
     bool ChkNoCalcVtx() { return mFlags & NO_CALC_VTX_e; }
     bool ChkFlush() { return field_0x91 & 8; }

--- a/include/dolphin/mtx/mtx.h
+++ b/include/dolphin/mtx/mtx.h
@@ -40,6 +40,35 @@ inline void C_MTXRotAxisRad(Mtx m, const Vec* axis, f32 rad) {
     PSMTXRotAxisRad(m, axis, rad);
 }
 
+/* When compiling in debug mode, use C implementations */
+#ifdef DEBUG
+#define MTXIdentity C_MTXIdentity
+#define MTXCopy C_MTXCopy
+#define MTXConcat C_MTXConcat
+#define MTXInverse C_MTXInverse
+#define MTXRotRad C_MTXRotRad
+#define MTXRotTrig C_MTXRotTrig
+#define MTXRotAxisRad C_MTXRotAxisRad
+#define MTXTrans C_MTXTrans
+#define MTXTransApply C_MTXTransApply
+#define MTXScale C_MTXScale
+#define MTXScaleApply C_MTXScaleApply
+#define MTXQuat C_MTXQuat
+#else
+#define MTXIdentity PSMTXIdentity
+#define MTXCopy PSMTXCopy
+#define MTXConcat PSMTXConcat
+#define MTXInverse PSMTXInverse
+#define MTXRotRad PSMTXRotRad
+#define MTXRotTrig PSMTXRotTrig
+#define MTXRotAxisRad PSMTXRotAxisRad
+#define MTXTrans PSMTXTrans
+#define MTXTransApply PSMTXTransApply
+#define MTXScale PSMTXScale
+#define MTXScaleApply PSMTXScaleApply
+#define MTXQuat PSMTXQuat
+#endif
+
 #ifdef __cplusplus
 };
 #endif

--- a/include/dolphin/mtx/mtxvec.h
+++ b/include/dolphin/mtx/mtxvec.h
@@ -12,6 +12,19 @@ void PSMTXMultVecSR(const Mtx m, const Vec* src, Vec* dst);
 void PSMTXMultVecArray(const Mtx m, const Vec* srcBase, Vec* dstBase, u32 count);
 void PSMTXMultVecArraySR(const Mtx m, const Vec* srcBase, Vec* dstBase, u32 count);
 
+/* When compiling in debug mode, use C implementations */
+#ifdef DEBUG
+#define MTXMultVec C_MTXMultVec
+#define MTXMultVecSR C_MTXMultVecSR
+#define MTXMultVecArray C_MTXMultVecArray
+#define MTXMultVecArraySR C_MTXMultVecArraySR
+#else
+#define MTXMultVec PSMTXMultVec
+#define MTXMultVecSR PSMTXMultVecSR
+#define MTXMultVecArray PSMTXMultVecArray
+#define MTXMultVecArraySR PSMTXMultVecArraySR
+#endif
+
 #ifdef __cplusplus
 };
 #endif

--- a/include/dolphin/mtx/quat.h
+++ b/include/dolphin/mtx/quat.h
@@ -15,6 +15,13 @@ void PSQUATMultiply(const Quaternion* a, const Quaternion* b, Quaternion* ab);
 void C_QUATRotAxisRad(Quaternion* q, const Vec* axis, f32 rad);
 void C_QUATSlerp(const Quaternion* p, const Quaternion* q, Quaternion* r, f32 t);
 
+/* When compiling in debug mode, use C implementations */
+#ifdef DEBUG
+#define QUATMultiply C_QUATMultiply
+#else
+#define QUATMultiply PSQUATMultiply
+#endif
+
 #ifdef __cplusplus
 };
 #endif

--- a/include/dolphin/mtx/vec.h
+++ b/include/dolphin/mtx/vec.h
@@ -80,9 +80,35 @@ inline f32 C_VECSquareMag(const Vec* v) {
         lfs     z,   8(src)
         ps_madd res, z, z, x_y
         ps_sum0 res, res, x_y, x_y
-    };
+    }
+    ;
     return res;
 }
+
+/* When compiling in debug mode, use C implementations */
+#ifdef DEBUG
+#define VECAdd C_VECAdd
+#define VECSubtract C_VECSubtract
+#define VECScale C_VECScale
+#define VECNormalize C_VECNormalize
+#define VECSquareMag C_VECSquareMag
+#define VECMag C_VECMag
+#define VECDotProduct C_VECDotProduct
+#define VECCrossProduct C_VECCrossProduct
+#define VECSquareDistance C_VECSquareDistance
+#define VECDistance C_VECDistance
+#else
+#define VECAdd PSVECAdd
+#define VECSubtract PSVECSubtract
+#define VECScale PSVECScale
+#define VECNormalize PSVECNormalize
+#define VECSquareMag PSVECSquareMag
+#define VECMag PSVECMag
+#define VECDotProduct PSVECDotProduct
+#define VECCrossProduct PSVECCrossProduct
+#define VECSquareDistance PSVECSquareDistance
+#define VECDistance PSVECDistance
+#endif
 
 #ifdef __cplusplus
 };

--- a/include/m_Do/m_Do_mtx.h
+++ b/include/m_Do/m_Do_mtx.h
@@ -26,31 +26,31 @@ void mDoMtx_inverseTranspose(f32 const (*param_0)[4], f32 (*param_1)[4]);
 void mDoMtx_QuatConcat(Quaternion const* param_0, Quaternion const* param_1, Quaternion* param_2);
 
 inline void mDoMtx_multVecSR(Mtx m, const Vec* src, Vec* dst) {
-    PSMTXMultVecSR(m, src, dst);
+    MTXMultVecSR(m, src, dst);
 }
 
 inline void cMtx_concat(const Mtx a, const Mtx b, Mtx ab) {
-    PSMTXConcat(a, b, ab);
+    MTXConcat(a, b, ab);
 }
 
 inline void cMtx_scale(Mtx m, f32 x, f32 y, f32 z) {
-    PSMTXScale(m, x, y, z);
+    MTXScale(m, x, y, z);
 }
 
 inline void mDoMtx_multVec(Mtx m, const Vec* src, Vec* dst) {
-    PSMTXMultVec(m, src, dst);
+    MTXMultVec(m, src, dst);
 }
 
 inline void mDoMtx_multVecArray(Mtx m, const Vec* src, Vec* dst, u32 count) {
-    PSMTXMultVecArray(m, src, dst, count);
+    MTXMultVecArray(m, src, dst, count);
 }
 
 inline void mDoMtx_copy(const Mtx src, Mtx dst) {
-    PSMTXCopy(src, dst);
+    MTXCopy(src, dst);
 }
 
 inline void mDoMtx_trans(Mtx m, f32 x, f32 y, f32 z) {
-    PSMTXTrans(m, x, y, z);
+    MTXTrans(m, x, y, z);
 }
 
 inline void cMtx_XrotM(Mtx mtx, s16 x) {
@@ -92,7 +92,7 @@ inline void mDoMtx_multVecZero(MtxP param_0, Vec* param_1) {
 }
 
 inline void mDoMtx_quatMultiply(const Quaternion* a, const Quaternion* b, Quaternion* ab) {
-    PSQUATMultiply(a,b,ab);
+    QUATMultiply(a,b,ab);
 }
 
 inline void mDoMtx_quatSlerp(const Quaternion* a, const Quaternion* b, Quaternion* ab, f32 param_4) {
@@ -100,15 +100,15 @@ inline void mDoMtx_quatSlerp(const Quaternion* a, const Quaternion* b, Quaternio
 }
 
 inline void mDoMtx_identity(Mtx m) {
-    PSMTXIdentity(m);
+    MTXIdentity(m);
 }
 
 inline void mDoMtx_concat(const Mtx a, const Mtx b, Mtx c) {
-    PSMTXConcat(a, b, c);
+    MTXConcat(a, b, c);
 }
 
 inline void mDoMtx_inverse(const Mtx a, Mtx b) {
-    PSMTXInverse(a, b);
+    MTXInverse(a, b);
 }
 
 inline void cMtx_inverse(const Mtx a, Mtx b) {
@@ -191,7 +191,7 @@ public:
      * @param y The y-axis translation value
      * @param z The z-axis translation value
      */
-    static void transS(f32 x, f32 y, f32 z) { PSMTXTrans(now, x, y, z); }
+    static void transS(f32 x, f32 y, f32 z) { MTXTrans(now, x, y, z); }
 
     /**
      * Scales the `now` Matrix by the given X, Y, and Z values
@@ -199,21 +199,21 @@ public:
      * @param y The y-axis scale value
      * @param z The z-axis scale value
      */
-    static void scaleS(f32 x, f32 y, f32 z) { PSMTXScale(now, x, y, z); }
+    static void scaleS(f32 x, f32 y, f32 z) { MTXScale(now, x, y, z); }
     
     /**
      * Multiplies a given Vec `a` by the `now` Matrix and places the result into Vec `b`
      * @param a The source Vec
      * @param b The output Vec
      */
-    static void multVec(const Vec* a, Vec* b) { PSMTXMultVec(now, a, b); }
+    static void multVec(const Vec* a, Vec* b) { MTXMultVec(now, a, b); }
 
     /**
      * Multiplies a given Vec `a` by the `now` Matrix's "Scale-and-Rotate" component and places the result into Vec `b`
      * @param a The source Vec
      * @param b The output Vec
      */
-    static void multVecSR(const Vec* a, Vec* b) { PSMTXMultVecSR(now, a, b); }
+    static void multVecSR(const Vec* a, Vec* b) { MTXMultVecSR(now, a, b); }
 
     static void multVecZero(Vec* v) { mDoMtx_multVecZero(now, v); }
 
@@ -224,7 +224,7 @@ public:
      * @param count The size of the array
      */
     static void multVecArray(const Vec* src, Vec* dst, u32 count) {
-        PSMTXMultVecArray(now, src, dst, count);
+        MTXMultVecArray(now, src, dst, count);
     }
 
     static void XYZrotS(s16 x, s16 y, s16 z) { mDoMtx_XYZrotS(now, x, y, z); }
@@ -277,7 +277,7 @@ public:
      */
     static void ZrotM(s16 z) { mDoMtx_ZrotM(now, z); }
 
-    static void inverse() { PSMTXInverse(now, now); }
+    static void inverse() { MTXInverse(now, now); }
 
     static void inverseTranspose() { mDoMtx_inverseTranspose(now, now); }
 
@@ -285,15 +285,15 @@ public:
      * Concatenates the `now` matrix with the given Matrix `m`
      * @param m The matrix to concatenate with `now`
      */
-    static void concat(const Mtx m) { PSMTXConcat(now, m, now); }
+    static void concat(const Mtx m) { MTXConcat(now, m, now); }
 
-    static void revConcat(const Mtx m) { PSMTXConcat(m, now, now); }
+    static void revConcat(const Mtx m) { MTXConcat(m, now, now); }
 
     /**
      * Copies a given matrix `m` to the `now` matrix
      * @param m The source matrix to copy
      */
-    static void copy(const Mtx m) { PSMTXCopy(m, now); }
+    static void copy(const Mtx m) { MTXCopy(m, now); }
 
     static Mtx now;
     static Mtx buffer[16];

--- a/libs/JSystem/J2DGraph/J2DGrafContext.cpp
+++ b/libs/JSystem/J2DGraph/J2DGrafContext.cpp
@@ -56,7 +56,7 @@ void J2DGrafContext::setup2D() {
     GXSetCullMode(GX_CULL_NONE);
     GXLoadPosMtxImm(mPosMtx, 0);
     Mtx mtx;
-    PSMTXIdentity(mtx);
+    MTXIdentity(mtx);
     GXLoadTexMtxImm(mtx, GX_IDENTITY, GX_MTX3x4);
     GXSetChanCtrl(GX_COLOR0A0, GX_FALSE, GX_SRC_REG, GX_SRC_VTX, GX_LIGHT_NULL, GX_DF_NONE,
                   GX_AF_NONE);

--- a/libs/JSystem/J2DGraph/J2DOrthoGraph.cpp
+++ b/libs/JSystem/J2DGraph/J2DOrthoGraph.cpp
@@ -50,7 +50,7 @@ void J2DOrthoGraph::setOrtho(JGeometry::TBox2<f32> const& bounds, f32 far, f32 n
 
 /* 802E9840-802E987C 2E4180 003C+00 1/0 0/0 0/0 .text            setLookat__13J2DOrthoGraphFv */
 void J2DOrthoGraph::setLookat() {
-    PSMTXIdentity(mPosMtx);
+    MTXIdentity(mPosMtx);
     GXLoadPosMtxImm(mPosMtx, 0);
 }
 

--- a/libs/JSystem/J2DGraph/J2DPane.cpp
+++ b/libs/JSystem/J2DGraph/J2DPane.cpp
@@ -292,7 +292,7 @@ void J2DPane::draw(f32 x, f32 y, J2DGrafContext const* p_grafCtx, bool isOrthoGr
             f32 width = parent->mGlobalBounds.i.x - parent->mBounds.i.x;
             f32 height = parent->mGlobalBounds.i.y - parent->mBounds.i.y;
             mGlobalBounds.addPos(width, height);
-            PSMTXConcat(parent->mGlobalMtx, mPositionMtx, mGlobalMtx);
+            MTXConcat(parent->mGlobalMtx, mPositionMtx, mGlobalMtx);
 
             if (unkBool) {
                 if (isOrthoGraf) {
@@ -308,7 +308,7 @@ void J2DPane::draw(f32 x, f32 y, J2DGrafContext const* p_grafCtx, bool isOrthoGr
         } else {
             mGlobalBounds.addPos(x, y);
             makeMatrix(mTranslateX + x, mTranslateY + y);
-            PSMTXCopy(mPositionMtx, mGlobalMtx);
+            MTXCopy(mPositionMtx, mGlobalMtx);
             mClipRect = mGlobalBounds;
             mColorAlpha = mAlpha;
         }
@@ -528,15 +528,15 @@ void J2DPane::makeMatrix(f32 param_0, f32 param_1, f32 param_2, f32 param_3) {
     f32 tmpX = mRotateOffsetX - param_2;
     f32 tmpY = mRotateOffsetY - param_3;
     Mtx rotX, rotY, rotZ, rotMtx, mtx, tmp;
-    PSMTXTrans(mtx, -tmpX, -tmpY, 0);
-    PSMTXRotRad(rotX, 'x', DEG_TO_RAD(mRotateX));
-    PSMTXRotRad(rotY, 'y', DEG_TO_RAD(mRotateY));
-    PSMTXRotRad(rotZ, 'z', DEG_TO_RAD(-mRotateZ));
-    PSMTXConcat(rotZ, rotX, tmp);
-    PSMTXConcat(rotY, tmp, rotMtx);
-    PSMTXScaleApply(mtx, mPositionMtx, mScaleX, mScaleY, 1);
-    PSMTXConcat(rotMtx, mPositionMtx, tmp);
-    PSMTXTransApply(tmp, mPositionMtx, param_0 + tmpX, param_1 + tmpY, 0);
+    MTXTrans(mtx, -tmpX, -tmpY, 0);
+    MTXRotRad(rotX, 'x', DEG_TO_RAD(mRotateX));
+    MTXRotRad(rotY, 'y', DEG_TO_RAD(mRotateY));
+    MTXRotRad(rotZ, 'z', DEG_TO_RAD(-mRotateZ));
+    MTXConcat(rotZ, rotX, tmp);
+    MTXConcat(rotY, tmp, rotMtx);
+    MTXScaleApply(mtx, mPositionMtx, mScaleX, mScaleY, 1);
+    MTXConcat(rotMtx, mPositionMtx, tmp);
+    MTXTransApply(tmp, mPositionMtx, param_0 + tmpX, param_1 + tmpY, 0);
 }
 
 /* 802F7680-802F76F8 2F1FC0 0078+00 1/0 7/3 0/0 .text            setCullBack__7J2DPaneF11_GXCullMode

--- a/libs/JSystem/J2DGraph/J2DPicture.cpp
+++ b/libs/JSystem/J2DGraph/J2DPicture.cpp
@@ -662,7 +662,7 @@ void J2DPicture::changeTexture(char const* param_0, u8 param_1, JUTPalette* para
 /* 802FDB28-802FDB90 2F8468 0068+00 1/0 1/0 0/0 .text            drawSelf__10J2DPictureFff */
 void J2DPicture::drawSelf(f32 param_0, f32 param_1) {
     Mtx tmp;
-    PSMTXIdentity(tmp);
+    MTXIdentity(tmp);
 
     drawSelf(param_0, param_1, &tmp);
 }
@@ -732,7 +732,7 @@ void J2DPicture::drawTexCoord(f32 param_0, f32 param_1, f32 param_2, f32 param_3
 
         getNewColor(black);
         setTevMode();
-        PSMTXConcat((MtxP)param_12,mGlobalMtx,outputMtx);
+        MTXConcat((MtxP)param_12,mGlobalMtx,outputMtx);
 
         GXLoadPosMtxImm(outputMtx,0);
         GXClearVtxDesc();

--- a/libs/JSystem/J2DGraph/J2DTextBox.cpp
+++ b/libs/JSystem/J2DGraph/J2DTextBox.cpp
@@ -305,7 +305,7 @@ void J2DTextBox::draw(f32 posX, f32 posY) {
         if (mStringPtr != NULL) {
             print.print(0.0f, 0.0f, mAlpha, "%s", mStringPtr);
         }
-        PSMTXIdentity(m);
+        MTXIdentity(m);
         GXLoadPosMtxImm(m, 0);
     }
 }
@@ -334,7 +334,7 @@ void J2DTextBox::draw(f32 posX, f32 posY, f32 param_2, J2DTextBoxHBinding hBind)
             print.printReturn(mStringPtr, param_2, 0.0f, hBind, VBIND_TOP, 0.0f, -mFontSizeY,
                               mAlpha);
         }
-        PSMTXIdentity(m);
+        MTXIdentity(m);
         GXLoadPosMtxImm(m, 0);
     }
 }
@@ -421,7 +421,7 @@ bool J2DTextBox::setConnectParent(bool connected) {
 /* 803008E8-80300950 2FB228 0068+00 1/0 1/0 0/0 .text            drawSelf__10J2DTextBoxFff */
 void J2DTextBox::drawSelf(f32 param_0, f32 param_1) {
     Mtx identity;
-    PSMTXIdentity(identity);
+    MTXIdentity(identity);
 
     drawSelf(param_0, param_1, &identity);
 }
@@ -434,7 +434,7 @@ void J2DTextBox::drawSelf(f32 param_0, f32 param_1, Mtx* p_mtx) {
     J2DPrint print(mFont, mCharSpacing, mLineSpacing, mCharColor, mGradientColor, mBlackColor,
                    mWhiteColor);
     print.setFontSize(mFontSizeX, mFontSizeY);
-    PSMTXConcat(*p_mtx, mGlobalMtx, m);
+    MTXConcat(*p_mtx, mGlobalMtx, m);
 
     GXLoadPosMtxImm(m, GX_PNMTX0);
     GXSetNumIndStages(0);

--- a/libs/JSystem/J2DGraph/J2DTextBoxEx.cpp
+++ b/libs/JSystem/J2DGraph/J2DTextBoxEx.cpp
@@ -211,7 +211,7 @@ void J2DTextBoxEx::drawSelf(f32 param_0, f32 param_1, Mtx* p_mtx) {
 
     if (mMaterial != NULL) {
         mMaterial->setGX();
-        PSMTXConcat(*p_mtx, mGlobalMtx, m);
+        MTXConcat(*p_mtx, mGlobalMtx, m);
 
         GXLoadPosMtxImm(m, GX_PNMTX0);
         GXClearVtxDesc();
@@ -288,7 +288,7 @@ void J2DTextBoxEx::draw(f32 posX, f32 posY) {
                 GXSetTevDirect((GXTevStageID)i);
             }
 
-            PSMTXIdentity(m);
+            MTXIdentity(m);
             GXLoadPosMtxImm(m, 0);
         }
     }
@@ -346,7 +346,7 @@ void J2DTextBoxEx::draw(f32 posX, f32 posY, f32 param_2, J2DTextBoxHBinding hBin
                 GXSetTevDirect((GXTevStageID)i);
             }
 
-            PSMTXIdentity(m);
+            MTXIdentity(m);
             GXLoadPosMtxImm(m, 0);
         }
     }

--- a/libs/JSystem/J3DGraphAnimator/J3DJoint.cpp
+++ b/libs/JSystem/J3DGraphAnimator/J3DJoint.cpp
@@ -83,8 +83,8 @@ void J3DMtxCalcCalcTransformBasic::calcTransform(J3DTransformInfo const& transIn
         mtxBuf->setScaleFlag(jntNo, 1);
     }
 
-    PSMTXConcat(J3DSys::mCurrentMtx, anmMtx, J3DSys::mCurrentMtx);
-    PSMTXCopy(J3DSys::mCurrentMtx, anmMtx);
+    MTXConcat(J3DSys::mCurrentMtx, anmMtx, J3DSys::mCurrentMtx);
+    MTXCopy(J3DSys::mCurrentMtx, anmMtx);
 }
 
 /* 8032EE50-8032EFBC 329790 016C+00 0/0 1/1 0/0 .text
@@ -99,7 +99,7 @@ void J3DMtxCalcCalcTransformSoftimage::calcTransform(J3DTransformInfo const& tra
                              transInfo.mTranslate.x * J3DSys::mCurrentS.x,
                              transInfo.mTranslate.y * J3DSys::mCurrentS.y,
                              transInfo.mTranslate.z * J3DSys::mCurrentS.z, anmMtx);
-    PSMTXConcat(J3DSys::mCurrentMtx, anmMtx, J3DSys::mCurrentMtx);
+    MTXConcat(J3DSys::mCurrentMtx, anmMtx, J3DSys::mCurrentMtx);
 
     J3DSys::mCurrentS.x *= transInfo.mScale.x;
     J3DSys::mCurrentS.y *= transInfo.mScale.y;
@@ -114,7 +114,7 @@ void J3DMtxCalcCalcTransformSoftimage::calcTransform(J3DTransformInfo const& tra
         anmMtx[2][3] = J3DSys::mCurrentMtx[2][3];
     } else {
         mtxBuf->setScaleFlag(jntNo, 1);
-        PSMTXCopy(J3DSys::mCurrentMtx, anmMtx);
+        MTXCopy(J3DSys::mCurrentMtx, anmMtx);
     }
 }
 
@@ -154,8 +154,8 @@ void J3DMtxCalcCalcTransformMaya::calcTransform(J3DTransformInfo const& transInf
         anmMtx[2][2] *= invZ;
     }
 
-    PSMTXConcat(J3DSys::mCurrentMtx, anmMtx, J3DSys::mCurrentMtx);
-    PSMTXCopy(J3DSys::mCurrentMtx, anmMtx);
+    MTXConcat(J3DSys::mCurrentMtx, anmMtx, J3DSys::mCurrentMtx);
+    MTXCopy(J3DSys::mCurrentMtx, anmMtx);
 
     J3DSys::mParentS.x = transInfo.mScale.x;
     J3DSys::mParentS.y = transInfo.mScale.y;

--- a/libs/JSystem/J3DGraphAnimator/J3DModel.cpp
+++ b/libs/JSystem/J3DGraphAnimator/J3DModel.cpp
@@ -119,8 +119,8 @@ void J3DModel::initialize() {
     mBaseScale.y = 1.0f;
     mBaseScale.z = 1.0f;
 
-    PSMTXIdentity(mBaseTransformMtx);
-    PSMTXIdentity(mInternalView);
+    MTXIdentity(mBaseTransformMtx);
+    MTXIdentity(mInternalView);
 
     mMtxBuffer = NULL;
     mMatPacket = NULL;
@@ -406,7 +406,7 @@ void J3DModel::calcDiffTexMtx() {
             J3DTexMtx* texMtxNode = texGenBlock->getTexMtx(j);
             J3DTexMtxObj* texMtxObj = shapePacket->getTexMtxObj();
             if (texMtxNode != NULL && texMtxObj != NULL) {
-                PSMTXCopy(texMtxNode->getMtx(), texMtxObj->getMtx(j));
+                MTXCopy(texMtxNode->getMtx(), texMtxObj->getMtx(j));
             }
         }
     }

--- a/libs/JSystem/J3DGraphAnimator/J3DMtxBuffer.cpp
+++ b/libs/JSystem/J3DGraphAnimator/J3DMtxBuffer.cpp
@@ -317,5 +317,5 @@ void J3DCalcViewBaseMtx(Mtx view, Vec const& scale, const Mtx& base, Mtx dst) {
     m[2][2] = base[2][2] * scale.z;
     m[2][3] = base[2][3];
 
-    PSMTXConcat(view, m, dst);
+    MTXConcat(view, m, dst);
 }

--- a/libs/JSystem/J3DGraphAnimator/J3DSkinDeform.cpp
+++ b/libs/JSystem/J3DGraphAnimator/J3DSkinDeform.cpp
@@ -534,8 +534,8 @@ void J3DSkinDeform::transformVtxPosNrm(J3DModelData* param_0) {
                 u16 drawMtxIndex = param_0->getDrawMtxIndex(posIndex);
                 Vec* pos = ((Vec*)param_0->getVtxPosArray()) + i;
                 Mtx invMtx;
-                PSMTXInverse(param_0->getInvJointMtx(drawMtxIndex), invMtx);
-                PSMTXMultVec(invMtx, pos, pos);
+                MTXInverse(param_0->getInvJointMtx(drawMtxIndex), invMtx);
+                MTXMultVec(invMtx, pos, pos);
             }
         }
         for (int i = 0; i < nrmNum; i++) {
@@ -544,8 +544,8 @@ void J3DSkinDeform::transformVtxPosNrm(J3DModelData* param_0) {
                 u16 drawMtxIndex = param_0->getDrawMtxIndex(nrmIndex);
                 Vec* nrm = ((Vec*)param_0->getVtxNrmArray()) + i;
                 Mtx invMtx;
-                PSMTXInverse(param_0->getInvJointMtx(drawMtxIndex), invMtx);
-                PSMTXMultVecSR(invMtx, nrm, nrm);
+                MTXInverse(param_0->getInvJointMtx(drawMtxIndex), invMtx);
+                MTXMultVecSR(invMtx, nrm, nrm);
             }
         }
         field_0x19 = 1;
@@ -561,7 +561,7 @@ void J3DSkinDeform::calcAnmInvJointMtx(J3DMtxBuffer* param_0) {
         Mtx* invJointMtx = &param_0->getJointTree()->getInvJointMtx(0);
         Mtx* posMtx = mPosMtx;
         for (int i = 0; i < jointNum; i++) {
-            PSMTXConcat(anmMtx[i], invJointMtx[i], posMtx[i]);
+            MTXConcat(anmMtx[i], invJointMtx[i], posMtx[i]);
         }
     }
 }

--- a/libs/JSystem/J3DGraphBase/J3DShapeMtx.cpp
+++ b/libs/JSystem/J3DGraphBase/J3DShapeMtx.cpp
@@ -393,7 +393,7 @@ asm void J3DDifferedTexMtx::loadExecute(f32 const (*param_0)[4]) {
  * loadMtxConcatView_PNGP__21J3DShapeMtxConcatViewCFiUs         */
 void J3DShapeMtxConcatView::loadMtxConcatView_PNGP(int slot, u16 drw) const {
     Mtx m;
-    PSMTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
+    MTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
     J3DDifferedTexMtx::load(m);
     J3DFifoLoadPosMtxImm(m, slot * 3);
     loadNrmMtx(slot, drw, m);
@@ -403,7 +403,7 @@ void J3DShapeMtxConcatView::loadMtxConcatView_PNGP(int slot, u16 drw) const {
  * loadMtxConcatView_PCPU__21J3DShapeMtxConcatViewCFiUs         */
 void J3DShapeMtxConcatView::loadMtxConcatView_PCPU(int slot, u16 drw) const {
     Mtx m;
-    PSMTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
+    MTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
     J3DDifferedTexMtx::load(m);
     J3DFifoLoadPosMtxImm(*j3dSys.getShapePacket()->getBaseMtxPtr(), slot * 3);
     loadNrmMtx(slot, drw, m);
@@ -413,7 +413,7 @@ void J3DShapeMtxConcatView::loadMtxConcatView_PCPU(int slot, u16 drw) const {
  * loadMtxConcatView_NCPU__21J3DShapeMtxConcatViewCFiUs         */
 void J3DShapeMtxConcatView::loadMtxConcatView_NCPU(int slot, u16 drw) const {
     Mtx m;
-    PSMTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
+    MTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
     J3DDifferedTexMtx::load(m);
     J3DFifoLoadPosMtxImm(m, slot * 3);
     J3DFifoLoadNrmMtxImm(*j3dSys.getShapePacket()->getBaseMtxPtr(), slot * 3);
@@ -426,7 +426,7 @@ void J3DShapeMtxConcatView::loadMtxConcatView_NCPU(int slot, u16 drw) const {
 void J3DShapeMtxConcatView::loadMtxConcatView_PNCPU(int slot, u16 drw) const {
     Mtx m;
     if (J3DDifferedTexMtx::sTexGenBlock != NULL) {
-        PSMTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
+        MTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
         J3DDifferedTexMtx::loadExecute(m);
     }
     J3DFifoLoadPosMtxImm(*j3dSys.getShapePacket()->getBaseMtxPtr(), slot * 3);
@@ -439,8 +439,8 @@ void J3DShapeMtxConcatView::loadMtxConcatView_PNCPU(int slot, u16 drw) const {
  * loadMtxConcatView_PNGP_LOD__21J3DShapeMtxConcatViewCFiUs     */
 void J3DShapeMtxConcatView::loadMtxConcatView_PNGP_LOD(int slot, u16 drw) const {
     Mtx m;
-    PSMTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
-    PSMTXConcat(m, j3dSys.mModel->getModelData()->getInvJointMtx(drw), m);
+    MTXConcat(*j3dSys.getShapePacket()->getBaseMtxPtr(), j3dSys.getModelDrawMtx(drw), m);
+    MTXConcat(m, j3dSys.mModel->getModelData()->getInvJointMtx(drw), m);
     J3DDifferedTexMtx::load(m);
     J3DFifoLoadPosMtxImm(m, slot * 3);
     loadNrmMtx(slot, drw, m);

--- a/libs/JSystem/J3DGraphBase/J3DSys.cpp
+++ b/libs/JSystem/J3DGraphBase/J3DSys.cpp
@@ -61,7 +61,7 @@ J3DSys::J3DSys() {
     makeZModeTable();
 
     mFlags = 0;
-    PSMTXIdentity(mViewMtx);
+    MTXIdentity(mViewMtx);
     mDrawMode = 1;
     mMaterialMode = 0;
     mModel = NULL;

--- a/libs/JSystem/J3DU/J3DUClipper.cpp
+++ b/libs/JSystem/J3DU/J3DUClipper.cpp
@@ -49,7 +49,7 @@ void J3DUClipper::calcViewFrustum() {
 /* 802738FC-80273A44 26E23C 0148+00 0/0 3/3 2/2 .text            clip__11J3DUClipperCFPA4_Cf3Vecf */
 u32 J3DUClipper::clip(f32 const (*param_0)[4], Vec param_1, f32 param_2) const {
     Vec vec1;
-    PSMTXMultVec(param_0, &param_1, &vec1);
+    MTXMultVec(param_0, &param_1, &vec1);
     if (-vec1.z < mNear - param_2) {
         return 1;
     }
@@ -113,7 +113,7 @@ u32 J3DUClipper::clip(f32 const (*param_1)[4], Vec* param_2, Vec* param_3) const
 
     for (u32 i = 0; i < 8; i++) {
         Vec vec1;
-        PSMTXMultVec(param_1, local_80 + i, &vec1);
+        MTXMultVec(param_1, local_80 + i, &vec1);
         s32 r4 = 0;
         if (-vec1.z < mNear) {
             local_98[4]++;

--- a/libs/JSystem/J3DU/J3DUClipper.cpp
+++ b/libs/JSystem/J3DU/J3DUClipper.cpp
@@ -36,14 +36,14 @@ void J3DUClipper::calcViewFrustum() {
     Vec tmp2 = {-f5, f4, -mNear};
     Vec tmp3 = {f5, f4, -mNear};
     Vec tmp4 = {f5, -f4, -mNear};
-    PSVECCrossProduct(&tmp2, &tmp1, &_04);
-    PSVECCrossProduct(&tmp3, &tmp2, &_10);
-    PSVECCrossProduct(&tmp4, &tmp3, &_1C);
-    PSVECCrossProduct(&tmp1, &tmp4, &_28);
-    PSVECNormalize(&_04, &_04);
-    PSVECNormalize(&_10, &_10);
-    PSVECNormalize(&_1C, &_1C);
-    PSVECNormalize(&_28, &_28);
+    VECCrossProduct(&tmp2, &tmp1, &_04);
+    VECCrossProduct(&tmp3, &tmp2, &_10);
+    VECCrossProduct(&tmp4, &tmp3, &_1C);
+    VECCrossProduct(&tmp1, &tmp4, &_28);
+    VECNormalize(&_04, &_04);
+    VECNormalize(&_10, &_10);
+    VECNormalize(&_1C, &_1C);
+    VECNormalize(&_28, &_28);
 }
 
 /* 802738FC-80273A44 26E23C 0148+00 0/0 3/3 2/2 .text            clip__11J3DUClipperCFPA4_Cf3Vecf */

--- a/libs/JSystem/JParticle/JPABaseShape.cpp
+++ b/libs/JSystem/JParticle/JPABaseShape.cpp
@@ -658,7 +658,7 @@ static void noLoadPrj(JPAEmitterWorkData const* work, const Mtx srt) {
 /* 80277C90-80277CC8 2725D0 0038+00 1/0 0/0 0/0 .text loadPrj__FPC18JPAEmitterWorkDataPA4_Cf */
 void loadPrj(JPAEmitterWorkData const* work, const Mtx srt) {
     Mtx mtx;
-    PSMTXConcat(work->mPrjMtx, srt, mtx);
+    MTXConcat(work->mPrjMtx, srt, mtx);
     GXLoadTexMtxImm(mtx, GX_TEXMTX0, GX_MTX3x4);
 }
 
@@ -692,8 +692,8 @@ static void loadPrjAnm(JPAEmitterWorkData const* work, f32 const (*param_1)[4]) 
     local_108[2][1] = 0.0f;
     local_108[2][2] = 1.0f;
     local_108[2][3] = 0.0f;
-    PSMTXConcat(local_108, work->mPrjMtx, local_108);
-    PSMTXConcat(local_108, param_1, local_108);
+    MTXConcat(local_108, work->mPrjMtx, local_108);
+    MTXConcat(local_108, param_1, local_108);
     GXLoadTexMtxImm(local_108, 0x1e, GX_MTX3x4);
 }
 #else
@@ -736,7 +736,7 @@ static projectionFunc p_prj[3] = {
 void JPADrawBillboard(JPAEmitterWorkData* work, JPABaseParticle* param_1) {
     if (param_1->checkStatus(8) == 0) {
         JGeometry::TVec3<f32> local_48;
-        PSMTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
+        MTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
         Mtx local_38;
         local_38[0][0] = work->mGlobalPtclScl.x * param_1->mParticleScaleX;
         local_38[0][3] = local_48.x;
@@ -773,7 +773,7 @@ asm void JPADrawBillboard(JPAEmitterWorkData* param_0, JPABaseParticle* param_1)
 void JPADrawRotBillboard(JPAEmitterWorkData* work, JPABaseParticle* param_1) {
     if (param_1->checkStatus(8) == 0) {
         JGeometry::TVec3<f32> local_48;
-        PSMTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
+        MTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
         f32 sinRot = JMASSin(param_1->mRotateAngle);
         f32 cosRot = JMASCos(param_1->mRotateAngle);
         f32 particleX = work->mGlobalPtclScl.x * param_1->mParticleScaleX;
@@ -815,7 +815,7 @@ asm void JPADrawRotBillboard(JPAEmitterWorkData* param_0, JPABaseParticle* param
 void JPADrawYBillboard(JPAEmitterWorkData* work, JPABaseParticle* param_1) {
      if (param_1->checkStatus(8) == 0) {
         JGeometry::TVec3<f32> local_48;
-        PSMTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
+        MTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
         Mtx local_38;
         f32 particleY = work->mGlobalPtclScl.y * param_1->mParticleScaleY;
         local_38[0][0] = work->mGlobalPtclScl.x * param_1->mParticleScaleX;
@@ -853,7 +853,7 @@ asm void JPADrawYBillboard(JPAEmitterWorkData* param_0, JPABaseParticle* param_1
 void JPADrawRotYBillboard(JPAEmitterWorkData* work, JPABaseParticle* param_1) {
     if (param_1->checkStatus(8) == 0) {
         JGeometry::TVec3<f32> local_48;
-        PSMTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
+        MTXMultVec(work->mPosCamMtx, param_1->mPosition, local_48);
         f32 sinRot = JMASSin(param_1->mRotateAngle);
         f32 cosRot = JMASCos(param_1->mRotateAngle);
         Mtx local_38;
@@ -1168,7 +1168,7 @@ void JPADrawDirection(JPAEmitterWorkData* param_0, JPABaseParticle* param_1) {
                 local_60[2][2] = local_78.z;
                 local_60[2][3] = param_1->mPosition.z;
                 p_plane[param_0->mPlaneType](local_60, fVar1, fVar2);
-                PSMTXConcat(param_0->mPosCamMtx, local_60, local_60);
+                MTXConcat(param_0->mPosCamMtx, local_60, local_60);
                 GXLoadPosMtxImm(local_60, 0);
                 p_prj[param_0->mPrjType](param_0, local_60);
                 GXCallDisplayList(p_dl[param_0->mDLType], sizeof(jpa_dl));
@@ -1223,8 +1223,8 @@ void JPADrawRotDirection(JPAEmitterWorkData* param_0, JPABaseParticle* param_1) 
                 local_60[2][1] = local_6c.z;
                 local_60[2][2] = local_78.z;
                 local_60[2][3] = param_1->mPosition.z;
-                PSMTXConcat(local_60, auStack_80, auStack_80);
-                PSMTXConcat(param_0->mPosCamMtx, auStack_80, local_60);
+                MTXConcat(local_60, auStack_80, auStack_80);
+                MTXConcat(param_0->mPosCamMtx, auStack_80, local_60);
                 GXLoadPosMtxImm(local_60, 0);
                 p_prj[param_0->mPrjType](param_0, local_60);
                 GXCallDisplayList(p_dl[param_0->mDLType], sizeof(jpa_dl));
@@ -1257,9 +1257,9 @@ void JPADrawDBillboard(JPAEmitterWorkData* param_0, JPABaseParticle* param_1) {
         local_70.cross(local_70, aTStack_7c);
         if (!local_70.isZero()) {
             local_70.normalize();
-            PSMTXMultVecSR(param_0->mPosCamMtx, local_70, local_70);
+            MTXMultVecSR(param_0->mPosCamMtx, local_70, local_70);
             JGeometry::TVec3<f32> local_88;
-            PSMTXMultVec(param_0->mPosCamMtx, param_1->mPosition, local_88);
+            MTXMultVec(param_0->mPosCamMtx, param_1->mPosition, local_88);
             f32 particleX = param_0->mGlobalPtclScl.x * param_1->mParticleScaleX;
             f32 particleY = param_0->mGlobalPtclScl.y * param_1->mParticleScaleY;
             Mtx local_60;
@@ -1306,7 +1306,7 @@ void JPADrawRotation(JPAEmitterWorkData* param_0, JPABaseParticle* param_1) {
         auStack_88[0][3] = param_1->mPosition.x;
         auStack_88[1][3] = param_1->mPosition.y;
         auStack_88[2][3] = param_1->mPosition.z;
-        PSMTXConcat(param_0->mPosCamMtx, auStack_88, auStack_88);
+        MTXConcat(param_0->mPosCamMtx, auStack_88, auStack_88);
         GXLoadPosMtxImm(auStack_88, 0);
         p_prj[param_0->mPrjType](param_0, auStack_88);
         GXCallDisplayList(p_dl[param_0->mDLType], sizeof(jpa_dl));
@@ -1473,7 +1473,7 @@ void JPADrawStripe(JPAEmitterWorkData* param_0) {
         local_c8[2][1] = local_f8.z;
         local_c8[2][2] = pTVar7->mBaseAxis.z;
         local_c8[2][3] = 0.0f;
-        PSMTXMultVecArraySR(local_c8, local_e0, local_e0, 2);
+        MTXMultVecArraySR(local_c8, local_e0, local_e0, 2);
         GXPosition3f32(local_e0.x + local_ec.x, local_e0.y + local_ec.y,
                        local_e0.z + local_ec.z);
         GXTexCoord2f32(0.0f, dVar16);

--- a/libs/JSystem/JParticle/JPAEmitter.cpp
+++ b/libs/JSystem/JParticle/JPAEmitter.cpp
@@ -55,7 +55,7 @@ void JPABaseEmitter::init(JPAEmitterManager* param_0, JPAResource* param_1) {
     mRndmDirSpeed = mpRes->getDyn()->getInitVelRndm();
     mAirResist = mpRes->getDyn()->getAirRes();
     mRndm.set_seed(mpEmtrMgr->mpWorkData->mRndm.get_rndm_u());
-    PSMTXIdentity(mGlobalRot);
+    MTXIdentity(mGlobalRot);
     mGlobalScl.set(1.0f, 1.0f, 1.0f);
     mGlobalTrs.zero();
     mGlobalPScl.set(1.0f, 1.0f);
@@ -156,12 +156,12 @@ bool JPABaseEmitter::processTermination() {
  * calcEmitterGlobalPosition__14JPABaseEmitterCFPQ29JGeometry8TVec3<f> */
 void JPABaseEmitter::calcEmitterGlobalPosition(JGeometry::TVec3<f32>* dst) const {
     Mtx mtx;
-    PSMTXScale(mtx, mGlobalScl.x, mGlobalScl.y, mGlobalScl.z);
-    PSMTXConcat(mGlobalRot, mtx, mtx);
+    MTXScale(mtx, mGlobalScl.x, mGlobalScl.y, mGlobalScl.z);
+    MTXConcat(mGlobalRot, mtx, mtx);
     mtx[0][3] = mGlobalTrs.x;
     mtx[1][3] = mGlobalTrs.y;
     mtx[2][3] = mGlobalTrs.z;
-    PSMTXMultVec(mtx, mLocalTrs, *dst);
+    MTXMultVec(mtx, mLocalTrs, *dst);
 }
 
 /* 8027EF30-8027EF40 279870 0010+00 0/0 1/1 0/0 .text getCurrentCreateNumber__14JPABaseEmitterCFv

--- a/libs/JSystem/JParticle/JPAMath.cpp
+++ b/libs/JSystem/JParticle/JPAMath.cpp
@@ -139,7 +139,7 @@ void JPASetRMtxSTVecfromMtx(f32 const (*param_0)[4], f32 (*param_1)[4],
     param_2->y = aTStack_54.length();
     aTStack_54.set(param_0[0][2], param_0[1][2], param_0[2][2]);
     param_2->z = aTStack_54.length();
-    PSMTXIdentity(param_1);
+    MTXIdentity(param_1);
     if (param_2->x != 0.0f) {
         f32 fVar5 = 1.0f / param_2->x;
         param_1[0][0] = param_0[0][0] * fVar5;

--- a/libs/JSystem/JParticle/JPAResource.cpp
+++ b/libs/JSystem/JParticle/JPAResource.cpp
@@ -759,8 +759,8 @@ void JPAResource::calcWorkData_d(JPAEmitterWorkData* work) {
     Mtx mtx;
     JPAGetXYZRotateMtx(work->mpEmtr->mLocalRot.x * 0xB6, work->mpEmtr->mLocalRot.y * 0xB6,
                        work->mpEmtr->mLocalRot.z * 0xB6, mtx);
-    PSMTXConcat(work->mpEmtr->mGlobalRot, mtx, work->mGlobalRot);
-    PSMTXMultVecSR(work->mGlobalRot, (Vec*)&work->mpEmtr->mLocalDir, (Vec*)&work->mGlobalEmtrDir);
+    MTXConcat(work->mpEmtr->mGlobalRot, mtx, work->mGlobalRot);
+    MTXMultVecSR(work->mGlobalRot, (Vec*)&work->mpEmtr->mLocalDir, (Vec*)&work->mGlobalEmtrDir);
 }
 
 /* 80276A8C-80276A90 2713CC 0004+00 0/0 3/0 0/0 .text

--- a/libs/SSystem/SComponent/c_cc_d.cpp
+++ b/libs/SSystem/SComponent/c_cc_d.cpp
@@ -343,7 +343,7 @@ bool cCcD_TriAttr::GetNVec(cXyz const& param_0, cXyz* pOut) const {
         *pOut = mNormal;
     } else {
         *pOut = mNormal;
-        PSVECScale(pOut, pOut, -1.0f);
+        VECScale(pOut, pOut, -1.0f);
     }
     return true;
 }
@@ -436,32 +436,32 @@ void cCcD_CpsAttr::CalcAabBox() {
 bool cCcD_CpsAttr::GetNVec(cXyz const& param_0, cXyz* param_1) const {
     Vec diff;
     const cXyz& endP = GetEndP();
-    PSVECSubtract(&endP, &mStart, &diff);
+    VECSubtract(&endP, &mStart, &diff);
 
-    f32 diffLen = PSVECDotProduct(&diff, &diff);
+    f32 diffLen = VECDotProduct(&diff, &diff);
     if (cM3d_IsZero(diffLen)) {
         return false;
     } else {
         Vec vec1, vec2;
-        PSVECSubtract(&param_0, &mStart, &vec1);
-        f32 vec1Len = PSVECDotProduct(&vec1, &diff) / diffLen;
+        VECSubtract(&param_0, &mStart, &vec1);
+        f32 vec1Len = VECDotProduct(&vec1, &diff) / diffLen;
         if (vec1Len < 0.0f) {
             vec2 = mStart;
         } else {
             if (vec1Len > 1.0f) {
                 vec2 = endP;
             } else {
-                PSVECScale(&diff, &diff, vec1Len);
-                PSVECAdd(&diff, &mStart, &vec2);
+                VECScale(&diff, &diff, vec1Len);
+                VECAdd(&diff, &mStart, &vec2);
             }
         }
 
-        PSVECSubtract(&param_0, &vec2, param_1);
-        if (cM3d_IsZero(PSVECMag(param_1))) {
+        VECSubtract(&param_0, &vec2, param_1);
+        if (cM3d_IsZero(VECMag(param_1))) {
             param_1->set(0.0f, 0.0f, 0.0f);
             return false;
         } else {
-            PSVECNormalize(param_1, param_1);
+            VECNormalize(param_1, param_1);
             return true;
         }
     }
@@ -569,12 +569,12 @@ bool cCcD_CylAttr::GetNVec(cXyz const& param_0, cXyz* param_1) const {
         }
     }
 
-    PSVECSubtract(&param_0, &vec, param_1);
-    if (cM3d_IsZero(PSVECMag(param_1))) {
+    VECSubtract(&param_0, &vec, param_1);
+    if (cM3d_IsZero(VECMag(param_1))) {
         param_1->set(0.0f, 0.0f, 0.0f);
         return false;
     } else {
-        PSVECNormalize(param_1, param_1);
+        VECNormalize(param_1, param_1);
         return true;
     }
     return false;
@@ -692,13 +692,13 @@ bool cCcD_SphAttr::GetNVec(cXyz const& param_0, cXyz* param_1) const {
     param_1->y = param_0.y - mCenter.y;
     param_1->z = param_0.z - mCenter.z;
 
-    if (cM3d_IsZero(PSVECMag(param_1))) {
+    if (cM3d_IsZero(VECMag(param_1))) {
         param_1->x = 0.0f;
         param_1->y = 0.0f;
         param_1->z = 0.0f;
         return false;
     } else {
-        PSVECNormalize(param_1, param_1);
+        VECNormalize(param_1, param_1);
         return true;
     }
 }

--- a/libs/SSystem/SComponent/c_cc_s.cpp
+++ b/libs/SSystem/SComponent/c_cc_s.cpp
@@ -310,8 +310,8 @@ void cCcS::SetPosCorrect(cCcD_Obj* obj1, cXyz* xyz1, cCcD_Obj* obj2, cXyz* xyz2,
         Vec obj2Move;
         Vec objsDist;
         if (bothCoSph3DCrr) {
-            PSVECSubtract(xyz2, xyz1, &objsDist);
-            objDistLen = PSVECMag(&objsDist);
+            VECSubtract(xyz2, xyz1, &objsDist);
+            objDistLen = VECMag(&objsDist);
         } else {
             objsDist.x = xyz2->x - xyz1->x;
             objsDist.y = 0;
@@ -320,10 +320,10 @@ void cCcS::SetPosCorrect(cCcD_Obj* obj1, cXyz* xyz1, cCcD_Obj* obj2, cXyz* xyz2,
         }
         if (!cM3d_IsZero(objDistLen)) {
             if (bothCoSph3DCrr) {
-                PSVECScale(&objsDist, &objsDist, crossLen / objDistLen);
+                VECScale(&objsDist, &objsDist, crossLen / objDistLen);
                 obj2Weight *= -1;
-                PSVECScale(&objsDist, &obj1Move, obj2Weight);
-                PSVECScale(&objsDist, &obj2Move, obj1Weight);
+                VECScale(&objsDist, &obj1Move, obj2Weight);
+                VECScale(&objsDist, &obj2Move, obj1Weight);
             } else {
                 f32 pushFactor = crossLen / objDistLen;
                 objsDist.x *= pushFactor;
@@ -350,8 +350,8 @@ void cCcS::SetPosCorrect(cCcD_Obj* obj1, cXyz* xyz1, cCcD_Obj* obj2, cXyz* xyz2,
         }
         obj1->GetStts()->PlusCcMove(obj1Move.x, obj1Move.y, obj1Move.z);
         obj2->GetStts()->PlusCcMove(obj2Move.x, obj2Move.y, obj2Move.z);
-        PSVECAdd(xyz1, &obj1Move, xyz1);
-        PSVECAdd(xyz2, &obj2Move, xyz2);
+        VECAdd(xyz1, &obj1Move, xyz1);
+        VECAdd(xyz2, &obj2Move, xyz2);
     }
 }
 

--- a/libs/SSystem/SComponent/c_lib.cpp
+++ b/libs/SSystem/SComponent/c_lib.cpp
@@ -363,36 +363,36 @@ void MtxInit() {
 /* 80270E5C-80270EA4 26B79C 0048+00 0/0 0/0 43/43 .text            MtxTrans__FfffUc */
 void MtxTrans(f32 x_trans, f32 y_trans, f32 z_trans, u8 param_3) {
     if (param_3 == 0) {
-        PSMTXTrans(*calc_mtx, x_trans, y_trans, z_trans);
+        MTXTrans(*calc_mtx, x_trans, y_trans, z_trans);
     } else {
         Mtx mtx;
-        PSMTXTrans(mtx, x_trans, y_trans, z_trans);
-        PSMTXConcat(*calc_mtx, mtx, *calc_mtx);
+        MTXTrans(mtx, x_trans, y_trans, z_trans);
+        MTXConcat(*calc_mtx, mtx, *calc_mtx);
     }
 }
 
 /* 80270EA4-80270EEC 26B7E4 0048+00 0/0 0/0 46/46 .text            MtxScale__FfffUc */
 void MtxScale(f32 x_trans, f32 y_trans, f32 z_trans, u8 param_3) {
     if (param_3 == 0) {
-        PSMTXScale(*calc_mtx, x_trans, y_trans, z_trans);
+        MTXScale(*calc_mtx, x_trans, y_trans, z_trans);
     } else {
         Mtx mtx;
-        PSMTXScale(mtx, x_trans, y_trans, z_trans);
-        PSMTXConcat(*calc_mtx, mtx, *calc_mtx);
+        MTXScale(mtx, x_trans, y_trans, z_trans);
+        MTXConcat(*calc_mtx, mtx, *calc_mtx);
     }
 }
 
 /* 80270EEC-80270F1C 26B82C 0030+00 0/0 2/2 615/615 .text            MtxPosition__FP4cXyzP4cXyz */
 void MtxPosition(cXyz* src, cXyz* dest) {
-    PSMTXMultVec(*calc_mtx, src, dest);
+    MTXMultVec(*calc_mtx, src, dest);
 }
 
 /* 80270F1C-80270F58 26B85C 003C+00 0/0 0/0 20/20 .text            MtxPush__Fv */
 void MtxPush() {
     Mtx mtx;
-    PSMTXCopy(*calc_mtx, mtx);
+    MTXCopy(*calc_mtx, mtx);
     calc_mtx++;
-    PSMTXCopy(mtx, *calc_mtx);
+    MTXCopy(mtx, *calc_mtx);
 }
 
 /* 80270F58-80270F68 26B898 0010+00 0/0 0/0 20/20 .text            MtxPull__Fv */

--- a/libs/SSystem/SComponent/c_m3d.cpp
+++ b/libs/SSystem/SComponent/c_m3d.cpp
@@ -117,15 +117,15 @@ f32 G_CM3D_F_ABS_MIN = 32 * FLT_EPSILON;
  */
 void cM3d_InDivPos1(const Vec* pVecA, const Vec* pVecB, f32 pF, Vec* pOut) {
     Vec tmp;
-    PSVECScale(pVecB, &tmp, pF);
-    PSVECAdd(&tmp, pVecA, pOut);
+    VECScale(pVecB, &tmp, pF);
+    VECAdd(&tmp, pVecA, pOut);
 }
 
 /* 802685B0-80268614 262EF0 0064+00 2/2 1/1 2/2 .text            cM3d_InDivPos2__FPC3VecPC3VecfP3Vec
  */
 void cM3d_InDivPos2(const Vec* pVecA, const Vec* pVecB, f32 pF, Vec* pOut) {
     Vec tmp;
-    PSVECSubtract(pVecB, pVecA, &tmp);
+    VECSubtract(pVecB, pVecA, &tmp);
     cM3d_InDivPos1(pVecA, &tmp, pF, pOut);
 }
 
@@ -189,24 +189,24 @@ bool cM3d_Len2dSqPntAndSegLine(f32 param_1, f32 param_2, f32 param_3, f32 param_
 bool cM3d_Len3dSqPntAndSegLine(const cM3dGLin* pLine, const Vec* pVec, Vec* pOutVec, f32* pOutF) {
     bool retVal = false;
     Vec tmp;
-    PSVECSubtract(&pLine->GetEndP(), &pLine->GetStartP(), &tmp);
-    f32 seqLen = PSVECDotProduct(&tmp, &tmp);
+    VECSubtract(&pLine->GetEndP(), &pLine->GetStartP(), &tmp);
+    f32 seqLen = VECDotProduct(&tmp, &tmp);
     if (cM3d_IsZero(seqLen)) {
         *pOutF = /* 0.0 */ FLOAT_LABEL(lit_2256);
         return retVal;
     } else {
         Vec tmp2;
-        PSVECSubtract(pVec, &pLine->GetStartP(), &tmp2);
-        f32 tmpF = PSVECDotProduct(&tmp2, &tmp);
+        VECSubtract(pVec, &pLine->GetStartP(), &tmp2);
+        f32 tmpF = VECDotProduct(&tmp2, &tmp);
         tmpF /= seqLen;
         if (tmpF < /* 0.0 */ FLOAT_LABEL(lit_2256) || tmpF > /* 1.0 */ FLOAT_LABEL(lit_2273)) {
             retVal = false;
         } else {
             retVal = true;
         }
-        PSVECScale(&tmp, &tmp, tmpF);
-        PSVECAdd(&tmp, &pLine->GetStartP(), pOutVec);
-        *pOutF = PSVECSquareDistance(pOutVec, pVec);
+        VECScale(&tmp, &tmp, tmpF);
+        VECAdd(&tmp, &pLine->GetStartP(), pOutVec);
+        *pOutF = VECSquareDistance(pOutVec, pVec);
         return retVal;
     }
 }
@@ -214,11 +214,11 @@ bool cM3d_Len3dSqPntAndSegLine(const cM3dGLin* pLine, const Vec* pVec, Vec* pOut
 /* 80268814-80268894 263154 0080+00 1/1 3/3 0/0 .text cM3d_SignedLenPlaAndPos__FPC8cM3dGPlaPC3Vec
  */
 f32 cM3d_SignedLenPlaAndPos(const cM3dGPla* pPlane, const Vec* pPosition) {
-    f32 mag = PSVECMag(&pPlane->GetNP());
+    f32 mag = VECMag(&pPlane->GetNP());
     if (cM3d_IsZero(mag)) {
         return /* 0.0 */ FLOAT_LABEL(lit_2256);
     } else {
-        return (pPlane->mD + PSVECDotProduct(&pPlane->GetNP(), pPosition)) / mag;
+        return (pPlane->mD + VECDotProduct(&pPlane->GetNP(), pPosition)) / mag;
     }
 }
 
@@ -232,9 +232,9 @@ f32 cM3d_VectorProduct2d(f32 pX1, f32 pY1, f32 pX2, f32 pY2, f32 pX3, f32 pY3) {
 void cM3d_VectorProduct(const cXyz* pVecA, const cXyz* pVecB, const cXyz* pVecC, cXyz* pVecOut) {
     Vec tmp1;
     Vec tmp2;
-    PSVECSubtract(pVecB, pVecA, &tmp1);
-    PSVECSubtract(pVecC, pVecA, &tmp2);
-    PSVECCrossProduct(&tmp1, &tmp2, pVecOut);
+    VECSubtract(pVecB, pVecA, &tmp1);
+    VECSubtract(pVecC, pVecA, &tmp2);
+    VECCrossProduct(&tmp1, &tmp2, pVecOut);
 }
 
 /* ############################################################################################## */
@@ -245,13 +245,13 @@ SECTION_SDATA2 static f32 lit_2346 = 1.0f / 50.0f;
 void cM3d_CalcPla(const Vec* pVecA, const Vec* pVecB, const Vec* pVecC, Vec* pVecOut, f32* pD) {
     Vec tmp2;
     Vec tmp1;
-    PSVECSubtract(pVecB, pVecA, &tmp1);
-    PSVECSubtract(pVecC, pVecA, &tmp2);
-    PSVECCrossProduct(&tmp1, &tmp2, pVecOut);
-    f32 mag = PSVECMag(pVecOut);
+    VECSubtract(pVecB, pVecA, &tmp1);
+    VECSubtract(pVecC, pVecA, &tmp2);
+    VECCrossProduct(&tmp1, &tmp2, pVecOut);
+    f32 mag = VECMag(pVecOut);
     if (fabsf(mag) >= /* 0.02 */ FLOAT_LABEL(lit_2346)) {
-        PSVECScale(pVecOut, pVecOut, /* 1.0 */ FLOAT_LABEL(lit_2273) / mag);
-        *pD = -PSVECDotProduct(pVecOut, pVecA);
+        VECScale(pVecOut, pVecOut, /* 1.0 */ FLOAT_LABEL(lit_2273) / mag);
+        *pD = -VECDotProduct(pVecOut, pVecA);
     } else {
         f32 zero = /* 0.0 */ FLOAT_LABEL(lit_2256);
         pVecOut->y = zero;
@@ -346,23 +346,23 @@ int cM3d_Check_LinLin(const cM3dGLin* pLinA, const cM3dGLin* pLinB, f32* pFloatA
     Vec linBVec;
     pLinA->CalcVec(&linAVec);
     pLinB->CalcVec(&linBVec);
-    f32 linALen = PSVECMag(&linAVec);
-    f32 linBLen = PSVECMag(&linBVec);
+    f32 linALen = VECMag(&linAVec);
+    f32 linBLen = VECMag(&linBVec);
     if (cM3d_IsZero(linALen) || cM3d_IsZero(linBLen)) {
         return 1;
     } else {
         f32 invLinALen = /* 1.0 */ FLOAT_LABEL(lit_2273) / linALen;
         f32 invLinBLen = /* 1.0 */ FLOAT_LABEL(lit_2273) / linBLen;
-        PSVECScale(&linAVec, &linAVec, invLinALen);
-        PSVECScale(&linBVec, &linBVec, invLinBLen);
+        VECScale(&linAVec, &linAVec, invLinALen);
+        VECScale(&linBVec, &linBVec, invLinBLen);
         Vec tmp;
-        PSVECSubtract(&pLinA->GetStartP(), &pLinB->GetStartP(), &tmp);
-        f32 tmpF = -PSVECDotProduct(&linAVec, &linBVec);
-        f32 tmpF2 = PSVECDotProduct(&tmp, &linAVec);
-        PSVECSquareMag(&tmp);  // result not used
+        VECSubtract(&pLinA->GetStartP(), &pLinB->GetStartP(), &tmp);
+        f32 tmpF = -VECDotProduct(&linAVec, &linBVec);
+        f32 tmpF2 = VECDotProduct(&tmp, &linAVec);
+        VECSquareMag(&tmp);  // result not used
         f32 tmpF3 = fabsf(/* 1.0 */ FLOAT_LABEL(lit_2273) - (tmpF * tmpF));
         if (!cM3d_IsZero(tmpF3)) {
-            f32 tmpF4 = -PSVECDotProduct(&tmp, &linBVec);
+            f32 tmpF4 = -VECDotProduct(&tmp, &linBVec);
             f32 tmpF7 = /* 1.0 */ FLOAT_LABEL(lit_2273) / tmpF3;
             f32 outFloatAtmp = ((tmpF * tmpF4) - tmpF2) * tmpF7;
             *pFloatA = outFloatAtmp * invLinALen;
@@ -377,7 +377,7 @@ int cM3d_Check_LinLin(const cM3dGLin* pLinA, const cM3dGLin* pLinB, f32* pFloatA
                 tmpF6 = linBLen;
                 tmpF5 = (tmpF6 * tmpF) - tmpF2;
             }
-            f32 tmpF7 = PSVECDotProduct(&tmp, &linBVec);
+            f32 tmpF7 = VECDotProduct(&tmp, &linBVec);
             if (tmpF5 < /* 0.0 */ FLOAT_LABEL(lit_2256) || tmpF5 > linALen) {
                 tmpF5 = /* 0.0 */ FLOAT_LABEL(lit_2256);
                 tmpF6 = tmpF7;
@@ -897,9 +897,9 @@ bool cM3d_Cross_SphSph(const cM3dGSph* pSphereA, const cM3dGSph* pSphereB, Vec* 
             // could be an inlined function
             f32 tmpF = pSphereB->GetR() / centerDist;
             Vec tmp;
-            PSVECSubtract(&pSphereA->GetC(), &pSphereB->GetC(), &tmp);
-            PSVECScale(&tmp, &tmp, tmpF);
-            PSVECAdd(&tmp, &pSphereB->GetC(), pVecOut);
+            VECSubtract(&pSphereA->GetC(), &pSphereB->GetC(), &tmp);
+            VECScale(&tmp, &tmp, tmpF);
+            VECAdd(&tmp, &pSphereB->GetC(), pVecOut);
         } else {
             *pVecOut = pSphereA->GetC();
         }
@@ -918,9 +918,9 @@ SECTION_SDATA2 static f32 lit_3892 = 0.5f;
 void cM3d_CalcSphVsTriCrossPoint(const cM3dGSph* pSphere, const cM3dGTri* pTriangle, Vec* pVecOut) {
     Vec tmp2;
     Vec tmp;
-    PSVECAdd(&pTriangle->mA, &pTriangle->mB, &tmp);
-    PSVECScale(&tmp, &tmp2, /* 0.5 */ FLOAT_LABEL(lit_3892));
-    f32 sqDist = PSVECSquareDistance(&tmp2, &pSphere->GetC());
+    VECAdd(&pTriangle->mA, &pTriangle->mB, &tmp);
+    VECScale(&tmp, &tmp2, /* 0.5 */ FLOAT_LABEL(lit_3892));
+    f32 sqDist = VECSquareDistance(&tmp2, &pSphere->GetC());
     if (cM3d_IsZero(sqDist)) {
         *pVecOut = pSphere->GetC();
     } else {
@@ -1071,8 +1071,8 @@ inline void cM3d_2LinCenter(cM3dGLin const pLinA, f32 pLinAF, cM3dGLin const& pL
     Vec tmp, tmp2;
     pLinA.CalcPos(&tmp, pLinAF);
     pLinB.CalcPos(&tmp2, pLinBF);
-    PSVECAdd(&tmp, &tmp2, pVecOut);
-    PSVECScale(pVecOut, pVecOut, /* 0.5 */ FLOAT_LABEL(lit_3892));
+    VECAdd(&tmp, &tmp2, pVecOut);
+    VECScale(pVecOut, pVecOut, /* 0.5 */ FLOAT_LABEL(lit_3892));
 }
 
 /* 8026E12C-8026E4FC 268A6C 03D0+00 0/0 2/2 0/0 .text
@@ -1115,7 +1115,7 @@ void cM3d_PlaneCrossLineProcWork(f32 f1, f32 f2, f32 f3, f32 f4, f32 f5, f32 f6,
 static int cM3d_2PlaneCrossLine(const cM3dGPla& pPlaneA, const cM3dGPla& pPlaneB,
                                 cM3dGLin* pLinOut) {
     Vec tmp;
-    PSVECCrossProduct(&pPlaneA.GetNP(), &pPlaneB.GetNP(), &tmp);
+    VECCrossProduct(&pPlaneA.GetNP(), &pPlaneB.GetNP(), &tmp);
     if (cM3d_IsZero(tmp.x) && cM3d_IsZero(tmp.y) && cM3d_IsZero(tmp.z)) {
         return 0;
     } else {
@@ -1138,12 +1138,12 @@ static int cM3d_2PlaneCrossLine(const cM3dGPla& pPlaneA, const cM3dGPla& pPlaneB
                                         &pLinOut->GetStartP().x, &pLinOut->GetStartP().y);
             pLinOut->GetStartP().z = /* 0.0 */ FLOAT_LABEL(lit_2256);
         }
-        f32 scale = PSVECMag(&pLinOut->GetStartP());
+        f32 scale = VECMag(&pLinOut->GetStartP());
         if (cM3d_IsZero(scale)) {
             scale = /* 1.0 */ FLOAT_LABEL(lit_2273);
         }
-        PSVECScale(&tmp, &tmp, scale);
-        PSVECAdd(&pLinOut->GetStartP(), &tmp, &pLinOut->GetEndP());
+        VECScale(&tmp, &tmp, scale);
+        VECAdd(&pLinOut->GetStartP(), &tmp, &pLinOut->GetEndP());
         return 1;
     }
 }
@@ -1174,15 +1174,15 @@ f32 cM3d_lineVsPosSuisenCross(const cM3dGLin* pLine, const Vec* pPoint, Vec* pVe
     Vec tmp2;
     Vec tmp3;
     pLine->CalcVec(&tmp1);
-    f32 diffLen = PSVECSquareMag(&tmp1);
+    f32 diffLen = VECSquareMag(&tmp1);
     if (cM3d_IsZero(diffLen)) {
         *pVecOut = *pPoint;
         return /* 0.0 */ FLOAT_LABEL(lit_2256);
     } else {
-        PSVECSubtract(pPoint, &pLine->GetStartP(), &tmp2);
-        f32 retVal = PSVECDotProduct(&tmp2, &tmp1) / diffLen;
-        PSVECScale(&tmp1, &tmp3, retVal);
-        PSVECAdd(&tmp3, &pLine->GetStartP(), pVecOut);
+        VECSubtract(pPoint, &pLine->GetStartP(), &tmp2);
+        f32 retVal = VECDotProduct(&tmp2, &tmp1) / diffLen;
+        VECScale(&tmp1, &tmp3, retVal);
+        VECAdd(&tmp3, &pLine->GetStartP(), pVecOut);
         return retVal;
     }
 }
@@ -1194,17 +1194,17 @@ f32 cM3d_lineVsPosSuisenCross(const Vec& pLinePointA, const Vec& pLinePointB, co
     Vec tmp1;
     Vec tmp2;
     Vec tmp3;
-    PSVECSubtract(&pLinePointB, &pLinePointA, &tmp1);
-    f32 diffLen = PSVECSquareMag(&tmp1);
+    VECSubtract(&pLinePointB, &pLinePointA, &tmp1);
+    f32 diffLen = VECSquareMag(&tmp1);
     if (cM3d_IsZero(diffLen)) {
         *pVecOut = pPoint;
         return /* 0.0 */ FLOAT_LABEL(lit_2256);
     } else {
-        PSVECSubtract(&pPoint, &pLinePointA, &tmp2);
-        f32 dotProd = PSVECDotProduct(&tmp2, &tmp1);
+        VECSubtract(&pPoint, &pLinePointA, &tmp2);
+        f32 dotProd = VECDotProduct(&tmp2, &tmp1);
         f32 retVal = dotProd / diffLen;
-        PSVECScale(&tmp1, &tmp3, retVal);
-        PSVECAdd(&tmp3, &pLinePointA, pVecOut);
+        VECScale(&tmp1, &tmp3, retVal);
+        VECAdd(&tmp3, &pLinePointA, pVecOut);
         return retVal;
     }
 }
@@ -1225,6 +1225,6 @@ int cM3d_2PlaneLinePosNearPos(const cM3dGPla& pPlaneA, const cM3dGPla& pPlaneB, 
 /* 8026EBBC-8026EC3C 2694FC 0080+00 0/0 1/1 0/0 .text            cM3d_CrawVec__FRC3VecRC3VecP3Vec */
 void cM3d_CrawVec(const Vec& pVecA, const Vec& pVecB, Vec* pVecOut) {
     Vec tmp;
-    PSVECScale(&pVecA, &tmp, fabsf(pVecB.x * pVecA.x + pVecB.y * pVecA.y + pVecB.z * pVecA.z));
-    PSVECAdd(&tmp, &pVecB, pVecOut);
+    VECScale(&pVecA, &tmp, fabsf(pVecB.x * pVecA.x + pVecB.y * pVecA.y + pVecB.z * pVecA.z));
+    VECAdd(&tmp, &pVecB, pVecOut);
 }

--- a/libs/SSystem/SComponent/c_m3d_g_aab.cpp
+++ b/libs/SSystem/SComponent/c_m3d_g_aab.cpp
@@ -68,8 +68,8 @@ void cM3dGAab::SetMax(const cXyz& pMax) {
 }
 /* 8026EE24-8026EE68 0044+00 s=0 e=1 z=0  None .text      CalcCenter__8cM3dGAabCFP4cXyz */
 void cM3dGAab::CalcCenter(cXyz* pOut) const {
-    PSVECAdd(&mMin, &mMax, pOut);
-    PSVECScale(pOut, pOut, 0.5f);
+    VECAdd(&mMin, &mMax, pOut);
+    VECScale(pOut, pOut, 0.5f);
 }
 
 /* 8026EE68-8026EEB4 004C+00 s=0 e=1 z=0  None .text      PlusR__8cM3dGAabFf */

--- a/libs/SSystem/SComponent/c_m3d_g_lin.cpp
+++ b/libs/SSystem/SComponent/c_m3d_g_lin.cpp
@@ -28,9 +28,9 @@ void cM3dGLin::SetStartEnd(const Vec& pStart, const Vec& pEnd) {
 /* 8026F350-8026F3C0 0070+00 s=0 e=3 z=0  None .text      CalcPos__8cM3dGLinCFP3Vecf */
 void cM3dGLin::CalcPos(Vec* pOut, f32 pScale) const {
     Vec tmp;
-    PSVECSubtract(&mEnd, &mStart, &tmp);
-    PSVECScale(&tmp, &tmp, pScale);
-    PSVECAdd(&tmp, &mStart, pOut);
+    VECSubtract(&mEnd, &mStart, &tmp);
+    VECScale(&tmp, &tmp, pScale);
+    VECAdd(&tmp, &mStart, pOut);
 }
 
 /* 8026F3C0-8026F3DC 001C+00 s=0 e=1 z=0  None .text      SetEnd__8cM3dGLinFRC4cXyz */

--- a/libs/SSystem/SComponent/c_m3d_g_pla.cpp
+++ b/libs/SSystem/SComponent/c_m3d_g_pla.cpp
@@ -17,8 +17,8 @@ cM3dGPla::cM3dGPla(const cXyz* pNormal, f32 pD) : mNormal(*pNormal), mD(pD) {}
 /* 8026F408-8026F4C4 269D48 00BC+00 0/0 3/3 0/0 .text crossInfLin__8cM3dGPlaCFRC4cXyzRC4cXyzR4cXyz
  */
 bool cM3dGPla::crossInfLin(const cXyz& pStart, const cXyz& pEnd, cXyz& out) const {
-    f32 tmp1 = (mD + PSVECDotProduct(&mNormal, &pStart));
-    f32 tmp2 = tmp1 - (mD + PSVECDotProduct(&mNormal, &pEnd));
+    f32 tmp1 = (mD + VECDotProduct(&mNormal, &pStart));
+    f32 tmp2 = tmp1 - (mD + VECDotProduct(&mNormal, &pEnd));
     if (fabsf(tmp2) < G_CM3D_F_ABS_MIN) {
         out = pEnd;
         return false;
@@ -31,14 +31,14 @@ bool cM3dGPla::crossInfLin(const cXyz& pStart, const cXyz& pEnd, cXyz& out) cons
 /* 8026F4C4-8026F52C 269E04 0068+00 0/0 1/1 0/0 .text            SetupNP0__8cM3dGPlaFRC3VecRC3Vec */
 void cM3dGPla::SetupNP0(const Vec& pNormal, const Vec& pPoint) {
     mNormal = pNormal;
-    PSVECNormalize(&mNormal, &mNormal);
-    mD = -PSVECDotProduct(&mNormal, &pPoint);
+    VECNormalize(&mNormal, &mNormal);
+    mD = -VECDotProduct(&mNormal, &pPoint);
 }
 
 /* 8026F52C-8026F57C 269E6C 0050+00 0/0 2/2 0/0 .text            SetupNP__8cM3dGPlaFRC3VecRC3Vec */
 void cM3dGPla::SetupNP(const Vec& pNormal, const Vec& pPoint) {
     mNormal = pNormal;
-    mD = -PSVECDotProduct(&mNormal, &pPoint);
+    mD = -VECDotProduct(&mNormal, &pPoint);
 }
 
 /* 8026F57C-8026F5D4 269EBC 0058+00 0/0 2/2 0/0 .text            getCrossY__8cM3dGPlaCFRC4cXyzPf */

--- a/libs/SSystem/SComponent/c_xyz.cpp
+++ b/libs/SSystem/SComponent/c_xyz.cpp
@@ -14,21 +14,21 @@
 /* 80266AE4-80266B34 0050+00 s=0 e=103 z=300  None .text      __pl__4cXyzCFRC3Vec */
 cXyz cXyz::operator+(const Vec& vec) const {
     Vec ret;
-    PSVECAdd(this, &vec, &ret);
+    VECAdd(this, &vec, &ret);
     return cXyz(ret);
 }
 
 /* 80266B34-80266B84 0050+00 s=0 e=196 z=1082  None .text      __mi__4cXyzCFRC3Vec */
 cXyz cXyz::operator-(const Vec& vec) const {
     Vec ret;
-    PSVECSubtract(this, &vec, &ret);
+    VECSubtract(this, &vec, &ret);
     return cXyz(ret);
 }
 
 /* 80266B84-80266BD0 004C+00 s=1 e=99 z=158  None .text      __ml__4cXyzCFf */
 cXyz cXyz::operator*(f32 scale) const {
     Vec ret;
-    PSVECScale(this, &ret, scale);
+    VECScale(this, &ret, scale);
     return cXyz(ret);
 }
 
@@ -48,14 +48,14 @@ cXyz cXyz::operator*(const Vec& vec) const {
 /* 80266C18-80266C6C 0054+00 s=0 e=3 z=12  None .text      __dv__4cXyzCFf */
 cXyz cXyz::operator/(f32 scale) const {
     Vec ret;
-    PSVECScale(this, &ret, 1.0f / scale);
+    VECScale(this, &ret, 1.0f / scale);
     return cXyz(ret);
 }
 
 /* 80266C6C-80266CBC 0050+00 s=1 e=0 z=0  None .text      getCrossProduct__4cXyzCFRC3Vec */
 cXyz cXyz::getCrossProduct(const Vec& vec) const {
     Vec ret;
-    PSVECCrossProduct(this, &vec, &ret);
+    VECCrossProduct(this, &vec, &ret);
     return cXyz(ret);
 }
 
@@ -67,7 +67,7 @@ cXyz cXyz::outprod(const Vec& vec) const {
 /* 80266CE4-80266D30 004C+00 s=0 e=10 z=1  None .text      norm__4cXyzCFv */
 cXyz cXyz::norm(void) const {
     Vec ret;
-    PSVECNormalize(this, &ret);
+    VECNormalize(this, &ret);
     return cXyz(ret);
 }
 
@@ -75,7 +75,7 @@ cXyz cXyz::norm(void) const {
 cXyz cXyz::normZP(void) const {
     Vec vec;
     if (this->isNearZeroSquare() == false) {
-        PSVECNormalize(this, &vec);
+        VECNormalize(this, &vec);
     } else {
         vec = cXyz::Zero;
     }
@@ -96,7 +96,7 @@ inline void normToUpZIfNearZero(Vec& vec) {
 cXyz cXyz::normZC(void) const {
     Vec outVec;
     if (this->isNearZeroSquare() == false) {
-        PSVECNormalize(this, &outVec);
+        VECNormalize(this, &outVec);
     } else {
         outVec = (*this * 1.25f * 1000000.0f).normZP();
         normToUpZIfNearZero(outVec);
@@ -106,14 +106,14 @@ cXyz cXyz::normZC(void) const {
 
 /* 80266EF4-80266F48 0054+00 s=0 e=13 z=17  None .text      normalize__4cXyzFv */
 cXyz cXyz::normalize(void) {
-    PSVECNormalize(this, this);
+    VECNormalize(this, this);
     return *this;
 }
 
 /* 80266F48-80266FDC 0094+00 s=0 e=19 z=59  None .text      normalizeZP__4cXyzFv */
 cXyz cXyz::normalizeZP(void) {
     if (this->isNearZeroSquare() == false) {
-        PSVECNormalize(this, this);
+        VECNormalize(this, this);
     } else {
         *this = cXyz::Zero;
     }
@@ -125,7 +125,7 @@ bool cXyz::normalizeRS(void) {
     if (this->isNearZeroSquare()) {
         return false;
     } else {
-        PSVECNormalize(this, this);
+        VECNormalize(this, this);
         return true;
     }
 }

--- a/libs/Z2AudioLib/Z2Audience.cpp
+++ b/libs/Z2AudioLib/Z2Audience.cpp
@@ -728,9 +728,9 @@ void Z2AudioCamera::setCameraState(f32 (*param_0)[4], Vec& param_1, Vec& param_2
         aTStack_cc.y = param_0[0][1];
         aTStack_cc.z = param_0[0][2];
         Mtx rotMtx;
-        PSMTXRotAxisRad(rotMtx, aTStack_cc, 0.01745329238474369f * (-1.0f * dVar10));
+        MTXRotAxisRad(rotMtx, aTStack_cc, 0.01745329238474369f * (-1.0f * dVar10));
         JGeometry::TVec3<f32> aTStack_d8;
-        PSMTXMultVec(rotMtx, aTStack_c0, aTStack_d8);
+        MTXMultVec(rotMtx, aTStack_c0, aTStack_d8);
         aTStack_d8.scale(aTStack_c0.y / aTStack_d8.y);
         mDolbyCenterZ = fVar8 * aTStack_d8.length();
         if (mSetMainCamera) {
@@ -759,7 +759,7 @@ void Z2AudioCamera::convertAbsToRel(Z2Audible* param_0, int param_1) {
         return;
     }
     Z2AudibleRelPos* relPos = &iVar2->field_0x14;
-    PSMTXMultVec(field_0x0, param_0->mPos, relPos->field_0x00);
+    MTXMultVec(field_0x0, param_0->mPos, relPos->field_0x00);
     relPos->field_0xC = relPos->field_0x00.length();
     JGeometry::TVec3<f32> aTStack_38;
     JGeometry::setTVec3f(*(Vec*)&relPos->field_0x00, *(Vec*)&aTStack_38);
@@ -770,7 +770,7 @@ void Z2AudioCamera::convertAbsToRel(Z2Audible* param_0, int param_1) {
 /* 802BCC7C-802BCCC0 2B75BC 0044+00 2/2 0/0 0/0 .text convertAbsToRel__13Z2AudioCameraCFR3VecP3Vec
  */
 bool Z2AudioCamera::convertAbsToRel(Vec& param_0, Vec* param_1) const {
-    PSMTXMultVec(field_0x0, &param_0, param_1);
+    MTXMultVec(field_0x0, &param_0, param_1);
     return isInSight(*param_1);
 }
 

--- a/libs/Z2AudioLib/Z2Audience.cpp
+++ b/libs/Z2AudioLib/Z2Audience.cpp
@@ -688,7 +688,7 @@ SECTION_SDATA2 static f32 lit_1273 = 0.01745329238474369f;
 void Z2AudioCamera::setCameraState(f32 (*param_0)[4], Vec& param_1, Vec& param_2, f32 param_3,
                                        f32 param_4, bool param_5, bool param_6) {
     JGeometry::TVec3<f32> aTStack_c0;
-    PSVECSubtract(&param_2, &param_1, aTStack_c0);
+    VECSubtract(&param_2, &param_1, aTStack_c0);
     mCamDist = aTStack_c0.length();
     f32 dVar10 = 0.5f * param_3;
     mFovySin = JMASinDegree(dVar10);
@@ -1308,7 +1308,7 @@ asm f32 Z2Audience::calcRelPosVolume(Vec const& param_0, f32 param_1, int param_
 f32 Z2Audience::calcRelPosPan(Vec const& param_0, int param_1) {
     Vec local_54 = param_0;
     local_54.y = 0.0f;
-    f32 dVar6 = PSVECMag(&local_54);
+    f32 dVar6 = VECMag(&local_54);
     if (dVar6 < 0.1f) {
         return 0.5f;
     }

--- a/libs/Z2AudioLib/Z2WolfHowlMgr.cpp
+++ b/libs/Z2AudioLib/Z2WolfHowlMgr.cpp
@@ -486,7 +486,7 @@ void Z2WolfHowlMgr::startWindStoneSound(s8 param_0, Vec* param_1) {
         return; 
     }
     JGeometry::TVec3<f32> local_60 = Z2GetAudience()->getAudioCamPos();
-    f32 dVar13 = sqrtf(PSVECSquareDistance(param_1, local_60));
+    f32 dVar13 = sqrtf(VECSquareDistance(param_1, local_60));
     if (dVar13 > 2100.0f && field_0x04) {
         field_0x04->stop();
     } else if (dVar13 < 2100.0f && !field_0x04) {
@@ -496,7 +496,7 @@ void Z2WolfHowlMgr::startWindStoneSound(s8 param_0, Vec* param_1) {
         field_0x04->fadeIn(0);
         field_0x04->stop(0x1e);
         if (Z2GetLink()->getLinkState() == 1) {
-            f32 fVar14 = sqrtf(PSVECSquareDistance(param_1, Z2GetLink()->getCurrentPos()));
+            f32 fVar14 = sqrtf(VECSquareDistance(param_1, Z2GetLink()->getCurrentPos()));
             f32 dVar13 = 1.0f;
             if (fVar14 < 150.0f) {
                 dVar13 = 0.0f;

--- a/rel/d/a/b/d_a_b_go/d_a_b_go.cpp
+++ b/rel/d/a/b/d_a_b_go/d_a_b_go.cpp
@@ -541,7 +541,7 @@ static void action(b_go_class* b_go) {
     b_go->speed.x = newSpeed.x;
     b_go->speed.z = newSpeed.z;
 
-    PSVECAdd(&b_go->current.pos, &b_go->speed, &b_go->current.pos);
+    VECAdd(&b_go->current.pos, &b_go->speed, &b_go->current.pos);
     b_go->speed.y += b_go->mGravity;
 
     b_go->mAcch.CrrPos(dComIfG_Bgsp());

--- a/rel/d/a/b/d_a_b_oh/d_a_b_oh.cpp
+++ b/rel/d/a/b/d_a_b_oh/d_a_b_oh.cpp
@@ -262,11 +262,11 @@ static int nodeCallBack(J3DJoint* param_0, int param_1) {
         b_oh_class* this_ = (b_oh_class*)model_p->getUserArea();
 
         if (this_ != NULL && jnt_no >= this_->field_0xca8 && jnt_no <= 29) {
-            PSMTXCopy(model_p->i_getAnmMtx(jnt_no), *calc_mtx);
+            MTXCopy(model_p->i_getAnmMtx(jnt_no), *calc_mtx);
             mDoMtx_YrotM(*calc_mtx, this_->field_0x61c[jnt_no].y + this_->field_0x784[jnt_no].y);
             mDoMtx_ZrotM(*calc_mtx, this_->field_0x61c[jnt_no].x + this_->field_0x784[jnt_no].x);
             MtxTrans(this_->mTentacleLength + -100.0f, 1.0f, 1.0f, 1);
-            PSMTXCopy(*calc_mtx, J3DSys::mCurrentMtx);
+            MTXCopy(*calc_mtx, J3DSys::mCurrentMtx);
             MtxScale(1.0f, this_->field_0x8ec[jnt_no] + this_->field_0x9dc[jnt_no],
                      this_->field_0x8ec[jnt_no] + this_->field_0x9dc[jnt_no], 1);
             model_p->i_setAnmMtx(jnt_no, *calc_mtx);
@@ -473,7 +473,7 @@ static void start(b_oh_class* i_this) {
     case 1:
         if (i_this->field_0xcac < -100.0f) {
             for (int i = 0; i < 28; i++) {
-                PSMTXCopy(i_this->mpMorf->getModel()->i_getAnmMtx(i), mDoMtx_stack_c::get());
+                MTXCopy(i_this->mpMorf->getModel()->i_getAnmMtx(i), mDoMtx_stack_c::get());
                 mDoMtx_stack_c::multVecZero(&sp28);
 
                 if (sp28.y > boss->field_0x47a0) {
@@ -1071,7 +1071,7 @@ static void action(b_oh_class* i_this) {
         cLib_addCalc2(&i_this->mTentacleLength, l_HIO.mLength, 0.1f, 0.5f);
     }
 
-    PSMTXCopy(i_this->mpMorf->getModel()->i_getAnmMtx(i_this->field_0x5c8 + 8),
+    MTXCopy(i_this->mpMorf->getModel()->i_getAnmMtx(i_this->field_0x5c8 + 8),
               mDoMtx_stack_c::get());
     mDoMtx_stack_c::multVecZero(&i_this->current.pos);
 
@@ -1194,7 +1194,7 @@ static void damage_check(b_oh_class* i_this) {
                 i_this->mHealth = 1000;
                 cc_at_check(i_this, &i_this->mAtInfo);
 
-                PSMTXCopy(i_this->mpMorf->getModel()->i_getAnmMtx(i * 2 + 1),
+                MTXCopy(i_this->mpMorf->getModel()->i_getAnmMtx(i * 2 + 1),
                           mDoMtx_stack_c::get());
                 mDoMtx_stack_c::multVecZero(&i_this->mEyePos);
                 i_dComIfGp_setHitMark(1, i_this, &i_this->mEyePos, NULL, NULL, 0);
@@ -1310,7 +1310,7 @@ static int daB_OH_Execute(b_oh_class* i_this) {
     }
 
     for (int i = 0; i < 15; i++) {
-        PSMTXCopy(model_p->i_getAnmMtx(tmp + i * 2), mDoMtx_stack_c::get());
+        MTXCopy(model_p->i_getAnmMtx(tmp + i * 2), mDoMtx_stack_c::get());
         mDoMtx_stack_c::multVecZero(&collider_center);
 
         if (i_this->mAction >= ACTION_END) {

--- a/rel/d/a/b/d_a_b_oh2/d_a_b_oh2.cpp
+++ b/rel/d/a/b/d_a_b_oh2/d_a_b_oh2.cpp
@@ -141,10 +141,10 @@ static void action(b_oh2_class* i_this) {
         break;
     }
 
-    PSMTXCopy(boss->mParts[0].field_0x0->getModel()->i_getAnmMtx(i_this->field_0x5c8 + 8),
+    MTXCopy(boss->mParts[0].field_0x0->getModel()->i_getAnmMtx(i_this->field_0x5c8 + 8),
               mDoMtx_stack_c::get());
     mDoMtx_stack_c::multVecZero(&i_this->current.pos);
-    PSMTXCopy(boss->mParts[0].field_0x0->getModel()->i_getAnmMtx(0), mDoMtx_stack_c::get());
+    MTXCopy(boss->mParts[0].field_0x0->getModel()->i_getAnmMtx(0), mDoMtx_stack_c::get());
 
     local_20.set(0.0f, 0.0f, i_this->field_0x5c8 * 20.0f + 650.0f);
     mDoMtx_stack_c::multVec(&local_20, &vstack_2C);

--- a/rel/d/a/d_a_bg_obj/d_a_bg_obj.cpp
+++ b/rel/d/a/d_a_bg_obj/d_a_bg_obj.cpp
@@ -508,7 +508,7 @@ asm void daBgObj_c::setAttentionInfo(fopAc_ac_c* param_0) {
 void daBgObj_c::initBaseMtx() {
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::YrotM(shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
     setBaseMtx();
 }
 

--- a/rel/d/a/d_a_boomerang/d_a_boomerang.cpp
+++ b/rel/d/a/d_a_boomerang/d_a_boomerang.cpp
@@ -859,13 +859,13 @@ void daBoomerang_c::windModelCallBack() {
     mDoMtx_XrotM((MtxP)mDoMtx_stack_c::get(), -shape_angle.x);
     mDoMtx_YrotM((MtxP)mDoMtx_stack_c::get(), -shape_angle.y);
 
-    PSMTXConcat(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx, mDoMtx_stack_c::get());
+    MTXConcat(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx, mDoMtx_stack_c::get());
 
     mDoMtx_stack_c::get()[0][3] = J3DSys::mCurrentMtx[0][3];
     mDoMtx_stack_c::get()[1][3] = J3DSys::mCurrentMtx[1][3];
     mDoMtx_stack_c::get()[2][3] = J3DSys::mCurrentMtx[2][3];
 
-    PSMTXCopy(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx);
+    MTXCopy(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx);
     field_0x56c->setAnmMtx(4, mDoMtx_stack_c::get());
 
     return;
@@ -1092,14 +1092,14 @@ void daBoomerang_c::setRoomInfo() {
 /* 8049FAA4-8049FBAC 001A64 0108+00 2/2 0/0 0/0 .text            setKeepMatrix__13daBoomerang_cFv */
 void daBoomerang_c::setKeepMatrix() {
     daAlink_c* link = daAlink_getAlinkActorClass();
-    PSMTXCopy(link->getLeftItemMatrix(), mDoMtx_stack_c::now);
+    MTXCopy(link->getLeftItemMatrix(), mDoMtx_stack_c::now);
     mDoMtx_stack_c::transM(32.0f, -5.0f, -6.0f);
     mDoMtx_stack_c::XYZrotM(0xfd28, 0x1bbb, 0xf99a);
-    PSMTXCopy(mDoMtx_stack_c::now, field_0x568->mBaseTransformMtx);
-    PSMTXCopy(link->getLeftItemMatrix(), field_0x56c->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, field_0x568->mBaseTransformMtx);
+    MTXCopy(link->getLeftItemMatrix(), field_0x56c->mBaseTransformMtx);
     mDoMtx_stack_c::multVecZero(&current.pos);
     daAlink_c::simpleAnmPlay(m_waitEffBtk);
-    PSMTXCopy(link->getLeftItemMatrix(), field_0x590->mBaseTransformMtx);
+    MTXCopy(link->getLeftItemMatrix(), field_0x590->mBaseTransformMtx);
 }
 
 /* ############################################################################################## */
@@ -1113,7 +1113,7 @@ COMPILER_STRIP_GATE(0x804A2910, &lit_4945);
 void daBoomerang_c::setMoveMatrix() {
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::ZXYrotM(shape_angle);
-    PSMTXCopy(mDoMtx_stack_c::now, field_0x56c->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, field_0x56c->mBaseTransformMtx);
     daAlink_c::simpleAnmPlay(m_windBtk);
     field_0x98c += 1.0f;
     s32 maxFrame = mBck.getBckAnm()->getFrameMax();
@@ -1126,7 +1126,7 @@ void daBoomerang_c::setMoveMatrix() {
     mDoMtx_stack_c::ZXYrotM(shape_angle);
     mDoMtx_stack_c::YrotM(field_0x95a);
     mDoMtx_stack_c::XrotM(0x7fff);
-    PSMTXCopy(mDoMtx_stack_c::now, field_0x568->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, field_0x568->mBaseTransformMtx);
 }
 #else
 #pragma push

--- a/rel/d/a/d_a_do/d_a_do.cpp
+++ b/rel/d/a/d_a_do/d_a_do.cpp
@@ -442,7 +442,7 @@ static int nodeCallBack(J3DJoint* i_jntP, int param_1) {
         do_class* user_area = (do_class*)model->getUserArea();
 
         if (user_area) {
-            PSMTXCopy(model->i_getAnmMtx(joint_num), *calc_mtx);
+            MTXCopy(model->i_getAnmMtx(joint_num), *calc_mtx);
 
             if (joint_num == 9 || joint_num == 10) {
                 cMtx_YrotM(*calc_mtx, user_area->field_0x60e.y + user_area->field_0x626.y);
@@ -457,7 +457,7 @@ static int nodeCallBack(J3DJoint* i_jntP, int param_1) {
             }
 
             model->setAnmMtx(joint_num, *calc_mtx);
-            PSMTXCopy(*calc_mtx, j3dSys.mCurrentMtx);
+            MTXCopy(*calc_mtx, j3dSys.mCurrentMtx);
         }
     }
     return 1;

--- a/rel/d/a/d_a_dshutter/d_a_dshutter.cpp
+++ b/rel/d/a/d_a_dshutter/d_a_dshutter.cpp
@@ -190,7 +190,7 @@ void daDsh_c::setMtx() {
     mDoMtx_stack_c::YrotM(shape_angle.y);
 
     mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
 }
 
 /* 80467708-8046772C 0002E8 0024+00 5/5 0/0 0/0 .text setAction__7daDsh_cFPQ27daDsh_c8action_c */

--- a/rel/d/a/d_a_izumi_gate/d_a_izumi_gate.cpp
+++ b/rel/d/a/d_a_izumi_gate/d_a_izumi_gate.cpp
@@ -15,8 +15,8 @@ void daIzumiGate_c::initBaseMtx() {
 /* 808490B8-8084910C 000098 0054+00 2/2 0/0 0/0 .text            setBaseMtx__13daIzumiGate_cFv */
 void daIzumiGate_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos);
-    PSMTXCopy(mDoMtx_stack_c::now, mBgMtx);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mBgMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
 }
 
 /* 8084910C-80849138 0000EC 002C+00 1/0 0/0 0/0 .text            daIzumiGate_Draw__FP13daIzumiGate_c

--- a/rel/d/a/d_a_scene_exit/d_a_scene_exit.cpp
+++ b/rel/d/a/d_a_scene_exit/d_a_scene_exit.cpp
@@ -82,7 +82,7 @@ static int daScex_Create(fopAc_ac_c* i_this) {
 
     mDoMtx_stack_c::transS(scex->current.pos.x, scex->current.pos.y, scex->current.pos.z);
     mDoMtx_stack_c::YrotM(scex->shape_angle.y);
-    PSMTXInverse(mDoMtx_stack_c::get(), scex->mMatrix);
+    MTXInverse(mDoMtx_stack_c::get(), scex->mMatrix);
     scex->mScale.x *= 75.0f;
     scex->mScale.z *= 75.0f;
     scex->mScale.y *= 150.0f;

--- a/rel/d/a/d_a_spinner/d_a_spinner.cpp
+++ b/rel/d/a/d_a_spinner/d_a_spinner.cpp
@@ -531,7 +531,7 @@ void daSpinner_c::setMatrix() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y + field_0xa84 + 90.0f, current.pos.z);
     mDoMtx_stack_c::ZXYrotM(shape_angle);
     mDoMtx_stack_c::YrotM(field_0xa7e);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
     mBck.entry(mpModel->getModelData());
     mpModel->calc();
 }

--- a/rel/d/a/d_a_title/d_a_title_nonmatching.cpp
+++ b/rel/d/a/d_a_title/d_a_title_nonmatching.cpp
@@ -511,7 +511,7 @@ asm int daTitle_c::getDemoPrm() {
 /* 80D67768-80D6786C 000D48 0104+00 1/1 0/0 0/0 .text            Draw__9daTitle_cFv */
 int daTitle_c::Draw() {
     J3DModelData* modelData = mpModel->getModelData();
-    PSMTXTrans(mpModel->getBaseTRMtx(), 0.0f, 0.0f, -430.0f);
+    MTXTrans(mpModel->getBaseTRMtx(), 0.0f, 0.0f, -430.0f);
     mpModel->getBaseScale()->x = -1.0f;
 
     mBck.entry(modelData);

--- a/rel/d/a/e/d_a_e_yk/d_a_e_yk.cpp
+++ b/rel/d/a/e/d_a_e_yk/d_a_e_yk.cpp
@@ -1731,7 +1731,7 @@ static int daE_YK_Execute(e_yk_class* i_this) {
             i_this->mAttentionInfo.mFlags = 0;
 
             // need to define inline here
-            PSMTXCopy(daPy_getLinkPlayerActorClass()->getWolfMouthMatrix(),mDoMtx_stack_c::now);
+            MTXCopy(daPy_getLinkPlayerActorClass()->getWolfMouthMatrix(),mDoMtx_stack_c::now);
             model->i_setBaseTRMtx(mDoMtx_stack_c::get());
             mDoMtx_stack_c::multVecZero(&i_this->current.pos);
         } else {
@@ -1782,7 +1782,7 @@ static int daE_YK_Execute(e_yk_class* i_this) {
 
         
 
-        PSMTXCopy(model->i_getAnmMtx(2),(MtxP)calc_mtx);
+        MTXCopy(model->i_getAnmMtx(2),(MtxP)calc_mtx);
         pos.set(0.0f,0.0f,0.0f);
 
         MtxPosition(&pos,&i_this->mEyePos);

--- a/rel/d/a/npc/d_a_npc_tr/d_a_npc_tr.cpp
+++ b/rel/d/a/npc/d_a_npc_tr/d_a_npc_tr.cpp
@@ -195,7 +195,7 @@ static int nodeCallBack(J3DJoint* p_joint, int param_1) {
         J3DModel* sysModel = j3dSys.mModel;
         npc_tr_class* npc_tr = (npc_tr_class*)sysModel->mUserArea;
 
-        PSMTXCopy(sysModel->i_getAnmMtx(jointNo), *calc_mtx);
+        MTXCopy(sysModel->i_getAnmMtx(jointNo), *calc_mtx);
 
         if (jointNo == 1) {
             mDoMtx_YrotM(*calc_mtx, npc_tr->field_0x5f2[0] + (s16)(npc_tr->field_0x5f8 * 0.3f));
@@ -203,7 +203,7 @@ static int nodeCallBack(J3DJoint* p_joint, int param_1) {
             mDoMtx_YrotM(*calc_mtx, npc_tr->field_0x5f2[jointNo - 1] + (s16)(npc_tr->field_0x5f8));
         }
         sysModel->setAnmMtx(jointNo, *calc_mtx);
-        PSMTXCopy(*calc_mtx, j3dSys.mCurrentMtx);
+        MTXCopy(*calc_mtx, j3dSys.mCurrentMtx);
     }
 
     return 1;
@@ -523,7 +523,7 @@ static int daNPC_TR_Execute(npc_tr_class* npc_tr) {
 
     f32 scale = npc_tr->mScale.x * l_HIO.field_0x8;
     mDoMtx_stack_c::scaleM(scale, scale, scale);
-    PSMTXCopy(mDoMtx_stack_c::get(), npc_tr->field_0x5b8->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::get(), npc_tr->field_0x5b8->mBaseTransformMtx);
 
     return 1;
 }

--- a/rel/d/a/obj/d_a_obj_bombf/d_a_obj_bombf.cpp
+++ b/rel/d/a/obj/d_a_obj_bombf/d_a_obj_bombf.cpp
@@ -65,7 +65,7 @@ static int daObjBombf_Delete(daObjBombf_c* i_this) {
 void daObjBombf_c::setMatrix() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y + field_0x584, current.pos.z);
     mDoMtx_stack_c::ZXYrotM(shape_angle.x, shape_angle.y, shape_angle.z);
-    PSMTXCopy(mDoMtx_stack_c::now, field_0x570->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, field_0x570->mBaseTransformMtx);
 }
 
 /* 80BBAE9C-80BBAEA8 000018 000C+00 1/1 0/0 0/0 .rodata          bombOffset$3727 */

--- a/rel/d/a/obj/d_a_obj_catdoor/d_a_obj_catdoor.cpp
+++ b/rel/d/a/obj/d_a_obj_catdoor/d_a_obj_catdoor.cpp
@@ -208,7 +208,7 @@ void daObjCatDoor_c::initBaseMtx() {
     mCullMtx = mMtx;
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_YrotM(mDoMtx_stack_c::get(), shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::get(), mMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mMtx);
     setBaseMtx();
 }
 

--- a/rel/d/a/obj/d_a_obj_cboard/d_a_obj_cboard.cpp
+++ b/rel/d/a/obj/d_a_obj_cboard/d_a_obj_cboard.cpp
@@ -18,7 +18,7 @@ void daObjBoard_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::ZXYrotM(shape_angle);
     mDoMtx_stack_c::scaleM(mScale);
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
 }
 
 /* 8057BE20-8057BE24 -00001 0004+00 2/2 0/0 0/0 .data            l_arcName */

--- a/rel/d/a/obj/d_a_obj_cowdoor/d_a_obj_cowdoor.cpp
+++ b/rel/d/a/obj/d_a_obj_cowdoor/d_a_obj_cowdoor.cpp
@@ -9,10 +9,10 @@
 
 /* 80BCC7F8-80BCC86C 000078 0074+00 2/2 0/0 0/0 .text            setBaseMtx__11daCowdoor_cFv */
 void daCowdoor_c::setBaseMtx() {
-    PSMTXTrans(mDoMtx_stack_c::now, current.pos.x, current.pos.y, current.pos.z);
+    MTXTrans(mDoMtx_stack_c::now, current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_stack_c::YrotM(shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::now, field_0x5a8->mBaseTransformMtx);
-    PSMTXCopy(mDoMtx_stack_c::now, mBgMtx);
+    MTXCopy(mDoMtx_stack_c::now, field_0x5a8->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mBgMtx);
 }
 
 /* 80BCC86C-80BCC8C4 0000EC 0058+00 1/0 0/0 0/0 .text            Create__11daCowdoor_cFv */

--- a/rel/d/a/obj/d_a_obj_fmobj/d_a_obj_fmobj.cpp
+++ b/rel/d/a/obj/d_a_obj_fmobj/d_a_obj_fmobj.cpp
@@ -170,7 +170,7 @@ static int daObj_Fmobj_Create(fopAc_ac_c* i_this) {
         a_this->mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
 
         mDoMtx_stack_c::transM(0.0f, -30.0f, 0.0f);
-        PSMTXCopy(mDoMtx_stack_c::get(), a_this->mDzbMtx);
+        MTXCopy(mDoMtx_stack_c::get(), a_this->mDzbMtx);
 
         a_this->mpBgW->Move();
     }

--- a/rel/d/a/obj/d_a_obj_hbombkoya/d_a_obj_hbombkoya.cpp
+++ b/rel/d/a/obj/d_a_obj_hbombkoya/d_a_obj_hbombkoya.cpp
@@ -113,7 +113,7 @@ int daObjHBombkoya_c::create1st() {
 
     int phase = dComIfG_resLoad(actor_phase, l_arcName);
     if (phase == cPhs_COMPLEATE_e) {
-        PSMTXIdentity(mBgMtx);
+        MTXIdentity(mBgMtx);
 
         phase = MoveBGCreate(l_arcName, 7, NULL, 0x2860, &mBgMtx);
         if (phase == cPhs_ERROR_e) {
@@ -133,7 +133,7 @@ int daObjHBombkoya_c::CreateHeap() {
     }
 
     Mtx m;
-    PSMTXIdentity(m);
+    MTXIdentity(m);
     mpModel->i_setBaseTRMtx(m);
     return 1;
 }
@@ -173,7 +173,7 @@ int daObjHBombkoya_c::Create() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_stack_c::YrotM(current.angle.y);
     mDoMtx_stack_c::scaleM(mScale.x, mScale.y, mScale.z);
-    PSMTXCopy(mDoMtx_stack_c::get(), mMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mMtx);
 
     for (int i = 0; i < 9; i++) {
         mEmitterKeys[i] = 0;
@@ -220,7 +220,7 @@ bool daObjHBombkoya_c::setParticle(u16* i_particleIDs, int i_particleMax,
             cXyz base_pos;
 
             base_pos = i_setTbl[i].m_position;
-            PSMTXMultVec(mMtx, &base_pos, &position);
+            MTXMultVec(mMtx, &base_pos, &position);
 
             cXyz scale;
             scale.z = i_setTbl[i].m_scale;
@@ -298,7 +298,7 @@ int daObjHBombkoya_c::Execute(Mtx** param_0) {
                 base_pos.y = 0.0f;
                 base_pos.z = -500.0f;
 
-                PSMTXMultVec(mMtx, &base_pos, &cyl_pos);
+                MTXMultVec(mMtx, &base_pos, &cyl_pos);
                 mCyl.SetC(cyl_pos);
                 dComIfG_Ccsp()->Set(&mCyl);
             }
@@ -333,7 +333,7 @@ int daObjHBombkoya_c::Execute(Mtx** param_0) {
                     cXyz base_pos;
 
                     base_pos = ptable[i].set_info.m_position;
-                    PSMTXMultVec(mMtx, &base_pos, &pos);
+                    MTXMultVec(mMtx, &base_pos, &pos);
 
                     cXyz scale;
                     scale.z = ptable[i].set_info.m_scale;

--- a/rel/d/a/obj/d_a_obj_kjgjs/d_a_obj_kjgjs.cpp
+++ b/rel/d/a/obj/d_a_obj_kjgjs/d_a_obj_kjgjs.cpp
@@ -41,8 +41,8 @@ int daObjKJgjs_c::create1st() {
 void daObjKJgjs_c::setMtx() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_stack_c::XYZrotM(current.angle.x, current.angle.y, current.angle.z);
-    PSMTXCopy(mDoMtx_stack_c::now, mMtx[1]);
-    PSMTXCopy(mDoMtx_stack_c::now, mMtx[0]);
+    MTXCopy(mDoMtx_stack_c::now, mMtx[1]);
+    MTXCopy(mDoMtx_stack_c::now, mMtx[0]);
 }
 
 /* 80C4654C-80C46554 000008 0008+00 1/1 0/0 0/0 .rodata          l_bmdidx */
@@ -65,7 +65,7 @@ static const Vec l_cull_box[4] = {
 /* 80C46264-80C46310 000244 00AC+00 1/0 0/0 0/0 .text            Create__12daObjKJgjs_cFv */
 int daObjKJgjs_c::Create() {
     fopAcM_SetMtx(this, mMtx[1]);
-    PSMTXCopy(mMtx[1], mpModel->mBaseTransformMtx);
+    MTXCopy(mMtx[1], mpModel->mBaseTransformMtx);
     dBgW* bgw_p = mpBgW;
     bgw_p->field_0x91 |= 4;
     if (!field_0x60c) {

--- a/rel/d/a/obj/d_a_obj_lv4floor/d_a_obj_lv4floor.cpp
+++ b/rel/d/a/obj/d_a_obj_lv4floor/d_a_obj_lv4floor.cpp
@@ -20,7 +20,7 @@ void daObjLv4Floor_c::setBaseMtx() {
     mDoMtx_stack_c::YrotM(shape_angle.y);
 
     mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
 }
 
 /* 80C678B0-80C678D4 000130 0024+00 1/0 0/0 0/0 .text            Create__15daObjLv4Floor_cFv */

--- a/rel/d/a/obj/d_a_obj_magLiftRot/d_a_obj_magLiftRot.cpp
+++ b/rel/d/a/obj/d_a_obj_magLiftRot/d_a_obj_magLiftRot.cpp
@@ -424,7 +424,7 @@ void daMagLiftRot_c::setBaseMtx() {
     mpModel->setBaseScale(cXyz(1.0f, 1.0f, 1.0f));
 
     mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
 }
 #else
 #pragma push

--- a/rel/d/a/obj/d_a_obj_mgate/d_a_obj_mgate.cpp
+++ b/rel/d/a/obj/d_a_obj_mgate/d_a_obj_mgate.cpp
@@ -58,7 +58,7 @@ void daObjMGate_c::setBaseMtx() {
     mDoMtx_stack_c::YrotM(shape_angle.y);
     mDoMtx_stack_c::ZXYrotM(mGateAngle.x, mGateAngle.y, mGateAngle.z);
     mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
 
     if (mpKeyModel != NULL) {
         cXyz key_offset(l_key_offset[mKind]);

--- a/rel/d/a/obj/d_a_obj_myogan/d_a_obj_myogan.cpp
+++ b/rel/d/a/obj/d_a_obj_myogan/d_a_obj_myogan.cpp
@@ -52,7 +52,7 @@ static void action(obj_myogan_class* i_this) {
     mDoMtx_stack_c::scaleM(l_HIO.mSize, l_HIO.mSize, l_HIO.mSize);
 
     i_this->mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), i_this->mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), i_this->mBgMtx);
 
     i_this->mpBgW->Move();
     i_this->mpBrk->play();

--- a/rel/d/a/obj/d_a_obj_onsen/d_a_obj_onsen.cpp
+++ b/rel/d/a/obj/d_a_obj_onsen/d_a_obj_onsen.cpp
@@ -18,9 +18,9 @@ void daObjOnsen_c::initBaseMtx() {
 void daObjOnsen_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::YrotM(shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel[0]->mBaseTransformMtx);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel[1]->mBaseTransformMtx);
-    PSMTXCopy(mDoMtx_stack_c::now, mBgMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel[0]->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel[1]->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mBgMtx);
 }
 
 /* 80CA7C28-80CA7C74 000148 004C+00 1/0 0/0 0/0 .text            Create__12daObjOnsen_cFv */

--- a/rel/d/a/obj/d_a_obj_prop/d_a_obj_prop.cpp
+++ b/rel/d/a/obj/d_a_obj_prop/d_a_obj_prop.cpp
@@ -95,7 +95,7 @@ void daObjProp_c::init() {
 void daObjProp_c::setModelMtx() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_stack_c::YrotM(shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
 }
 
 /* 80CB5558-80CB55AC 0003F8 0054+00 1/0 0/0 0/0 .text            daObjProp_create__FP11daObjProp_c */

--- a/rel/d/a/obj/d_a_obj_rcircle/d_a_obj_rcircle.cpp
+++ b/rel/d/a/obj/d_a_obj_rcircle/d_a_obj_rcircle.cpp
@@ -114,7 +114,7 @@ void daObjRCircle_c::init() {
 /* 80CB8BF0-80CB8C44 000610 0054+00 1/1 0/0 0/0 .text            setModelMtx__14daObjRCircle_cFv */
 void daObjRCircle_c::setModelMtx() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
 }
 
 /* 80CB8C44-80CB8C98 000664 0054+00 1/0 0/0 0/0 .text daObjRCircle_create__FP14daObjRCircle_c */

--- a/rel/d/a/obj/d_a_obj_stoneMark/d_a_obj_stoneMark.cpp
+++ b/rel/d/a/obj/d_a_obj_stoneMark/d_a_obj_stoneMark.cpp
@@ -72,7 +72,7 @@ void daObjSMark_c::initBaseMtx() {
 void daObjSMark_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::ZXYrotM(shape_angle);
-    PSMTXCopy((MtxP)&mDoMtx_stack_c::now,(MtxP)&mCullMtx);
+    MTXCopy((MtxP)&mDoMtx_stack_c::now,(MtxP)&mCullMtx);
 }
 /* ############################################################################################## */
 /* 8059A3E8-8059A3EC 000000 0004+00 2/2 0/0 0/0 .rodata          @3642 */

--- a/rel/d/a/obj/d_a_obj_tgake/d_a_obj_tgake.cpp
+++ b/rel/d/a/obj/d_a_obj_tgake/d_a_obj_tgake.cpp
@@ -21,7 +21,7 @@ void daObjGake_c::setBaseMtx() {
     mDoMtx_stack_c::YrotM(shape_angle.y);
 
     mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
 }
 
 /* 80D0BCB8-80D0BD30 000118 0078+00 1/0 0/0 0/0 .text            Create__11daObjGake_cFv */

--- a/rel/d/a/obj/d_a_obj_tmoon/d_a_obj_tmoon.cpp
+++ b/rel/d/a/obj/d_a_obj_tmoon/d_a_obj_tmoon.cpp
@@ -23,7 +23,7 @@ void daObjTMoon_c::initBaseMtx() {
 void daObjTMoon_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::YrotM(shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::now, field_0x570->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, field_0x570->mBaseTransformMtx);
 }
 
 /* 80D12C48-80D12C9C 000128 0054+00 1/1 0/0 0/0 .text            Create__12daObjTMoon_cFv */

--- a/rel/d/a/obj/d_a_obj_usaku/d_a_obj_usaku.cpp
+++ b/rel/d/a/obj/d_a_obj_usaku/d_a_obj_usaku.cpp
@@ -25,7 +25,7 @@ static int daObj_Usaku_Execute(obj_usaku_class* i_this) {
 
     i_this->mpModel->i_setBaseTRMtx(mDoMtx_stack_c::get());
     if (i_this->mpBgW != NULL) {
-        PSMTXCopy(mDoMtx_stack_c::get(), i_this->mBgMtx);
+        MTXCopy(mDoMtx_stack_c::get(), i_this->mBgMtx);
         i_this->mpBgW->Move();
     }
 

--- a/rel/d/a/obj/d_a_obj_vground/d_a_obj_vground.cpp
+++ b/rel/d/a/obj/d_a_obj_vground/d_a_obj_vground.cpp
@@ -23,7 +23,7 @@ void daObjVGnd_c::initBaseMtx() {
 void daObjVGnd_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_stack_c::YrotM(shape_angle.y);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
 }
 
 /* 80D214AC-80D21500 00014C 0054+00 1/1 0/0 0/0 .text            Create__11daObjVGnd_cFv */

--- a/rel/d/a/obj/d_a_obj_volcball/d_a_obj_volcball.cpp
+++ b/rel/d/a/obj/d_a_obj_volcball/d_a_obj_volcball.cpp
@@ -396,7 +396,7 @@ void daObjVolcBall_c::setBaseMtx() {
     }
 
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
-    PSMTXCopy(mDoMtx_stack_c::get(), field_0x28ec);
+    MTXCopy(mDoMtx_stack_c::get(), field_0x28ec);
 }
 
 /* ############################################################################################## */

--- a/rel/d/a/obj/d_a_obj_web0/d_a_obj_web0.cpp
+++ b/rel/d/a/obj/d_a_obj_web0/d_a_obj_web0.cpp
@@ -263,7 +263,7 @@ static int daObj_Web0_Execute(obj_web0_class* i_this) {
     if (tmp < 0) {
         mDoMtx_stack_c::YrotM(-0x8000);
     }
-    PSMTXCopy(mDoMtx_stack_c::get(), i_this->mMtx);
+    MTXCopy(mDoMtx_stack_c::get(), i_this->mMtx);
 
     i_this->mpBgW->Move();
 

--- a/rel/d/a/obj/d_a_obj_web1/d_a_obj_web1.cpp
+++ b/rel/d/a/obj/d_a_obj_web1/d_a_obj_web1.cpp
@@ -175,7 +175,7 @@ static int daObj_Web1_Execute(obj_web1_class* i_this) {
     mDoMtx_stack_c::transS(i_this->current.pos.x, i_this->current.pos.y, i_this->current.pos.z);
     mDoMtx_stack_c::scaleM(i_this->mScale.x * 1.2f, i_this->mScale.x, i_this->mScale.x * 1.2f);
     mDoMtx_stack_c::transM(0.0f, i_this->mScale.x * i_this->mScale.y * -15.0f + 9.0f, 0.0f);
-    PSMTXCopy(mDoMtx_stack_c::get(), i_this->mMtx);
+    MTXCopy(mDoMtx_stack_c::get(), i_this->mMtx);
 
     i_this->mpBgW->Move();
     i_this->mCylCc.SetC(i_this->current.pos);

--- a/rel/d/a/obj/d_a_obj_zcloth/d_a_obj_zcloth.cpp
+++ b/rel/d/a/obj/d_a_obj_zcloth/d_a_obj_zcloth.cpp
@@ -108,7 +108,7 @@ void daObjZCloth_c::initBaseMtx() {
 void daObjZCloth_c::setBaseMtx() {
     mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_stack_c::ZXYrotM(shape_angle.x, shape_angle.y, shape_angle.z);
-    PSMTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
+    MTXCopy(mDoMtx_stack_c::now, mpModel->mBaseTransformMtx);
 }
 
 /* 80D3EEC0-80D3EF0C 000120 004C+00 1/1 0/0 0/0 .text            Create__13daObjZCloth_cFv */

--- a/rel/d/a/tag/d_a_tag_spinner/d_a_tag_spinner.cpp
+++ b/rel/d/a/tag/d_a_tag_spinner/d_a_tag_spinner.cpp
@@ -33,7 +33,7 @@ void daTagSpinner_c::initBaseMtx() {
 
 /* 80D618C4-80D6191C 000244 0058+00 1/1 0/0 0/0 .text            setBaseMtx__14daTagSpinner_cFv */
 void daTagSpinner_c::setBaseMtx() {
-    PSMTXTrans(mDoMtx_stack_c::now, current.pos.x, current.pos.y, current.pos.z);
+    MTXTrans(mDoMtx_stack_c::now, current.pos.x, current.pos.y, current.pos.z);
     mDoMtx_ZXYrotM(mDoMtx_stack_c::now, shape_angle.x, shape_angle.y, shape_angle.z);
 }
 

--- a/src/d/a/d_a_alink.cpp
+++ b/src/d/a/d_a_alink.cpp
@@ -3296,10 +3296,10 @@ void daAlink_c::setMatrixWorldAxisRot(MtxP param_0, s16 param_1, s16 param_2, s1
     mDoMtx_stack_c::YrotM(-shape_angle.y);
     concatMagneBootInvMtx();
     mDoMtx_stack_c::transM(-tmp.x, -tmp.y, -tmp.z);
-    PSMTXConcat(mDoMtx_stack_c::get(), param_0, mDoMtx_stack_c::get());
-    PSMTXCopy(mDoMtx_stack_c::get(), param_0);
+    MTXConcat(mDoMtx_stack_c::get(), param_0, mDoMtx_stack_c::get());
+    MTXCopy(mDoMtx_stack_c::get(), param_0);
     if (param_4 != 0) {
-        PSMTXCopy(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx);
+        MTXCopy(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx);
     }
 }
 
@@ -3335,7 +3335,7 @@ asm void daAlink_c::changeBlendRate(int param_0) {
 
 /* 8009EB18-8009EB58 099458 0040+00 1/1 0/0 0/0 .text            resetRootMtx__9daAlink_cFv */
 void daAlink_c::resetRootMtx() {
-    PSMTXCopy(mRootMtx, J3DSys::mCurrentMtx);
+    MTXCopy(mRootMtx, J3DSys::mCurrentMtx);
     field_0x2f90 = 0;
 }
 

--- a/src/d/a/d_a_alink_link.inc
+++ b/src/d/a/d_a_alink_link.inc
@@ -3440,7 +3440,7 @@ MtxP J3DModel::getAnmMtx(int i) {
 
 /* 800CFFF4-800D0020 0CA934 002C+00 1/1 0/0 0/0 .text            setBaseTRMtx__8J3DModelFPA4_f */
 void J3DModel::setBaseTRMtx(MtxP matrix) {
-    PSMTXCopy(matrix, mBaseTransformMtx);
+    MTXCopy(matrix, mBaseTransformMtx);
 }
 
 /* 800D0020-800D0048 0CA960 0028+00 1/1 0/0 0/0 .text checkFmChainGrabAnime__9daAlink_cCFv */

--- a/src/d/a/d_a_npc.cpp
+++ b/src/d/a/d_a_npc.cpp
@@ -1040,7 +1040,7 @@ int daNpcT_Path_c::chkPassed1(cXyz param_0, int param_1) {
 
         s16 angle = cLib_targetAngleY(&l_pos1,&l_pos2);
         mDoMtx_YrotS((MtxP)&mDoMtx_stack_c::now,angle);
-        PSMTXMultVec((MtxP)&mDoMtx_stack_c::now,&l_vec,&l_vec);
+        MTXMultVec((MtxP)&mDoMtx_stack_c::now,&l_vec,&l_vec);
         l_pos4 = (cXyz)l_vec + l_pos2;
         l_pos3 = l_pos4;
     }
@@ -1052,7 +1052,7 @@ int daNpcT_Path_c::chkPassed1(cXyz param_0, int param_1) {
 
         s16 angle = cLib_targetAngleY(&l_pos3,&l_pos2);
         mDoMtx_YrotS((MtxP)&mDoMtx_stack_c::now,angle);
-        PSMTXMultVec((MtxP)&mDoMtx_stack_c::now,&l_vec,&l_vec);
+        MTXMultVec((MtxP)&mDoMtx_stack_c::now,&l_vec,&l_vec);
         l_pos5 = (cXyz)l_vec + l_pos2;
         l_pos1 = l_pos5;
     }
@@ -5705,7 +5705,7 @@ BOOL daNpcF_chkPointInArea(cXyz param_0, cXyz param_1, cXyz param_2, s16 param_3
 
     mDoMtx_YrotS((MtxP)&mDoMtx_stack_c::now,-param_3);
     mDoMtx_stack_c::transM(-param_1.x,-param_1.y,-param_1.z);
-    PSMTXMultVec((MtxP)&mDoMtx_stack_c::now,(Vec*)&param_0,&l_vec);
+    MTXMultVec((MtxP)&mDoMtx_stack_c::now,(Vec*)&param_0,&l_vec);
 
     l_float1 = fabsf(param_2.x);
     l_float2 = fabsf(param_2.z);

--- a/src/d/bg/d_bg_s.cpp
+++ b/src/d/bg/d_bg_s.cpp
@@ -835,7 +835,7 @@ void dBgS_MoveBGProc_Trans(dBgW* i_bgw, void* i_actor_ptr, cBgS_PolyInfo const& 
     cXyz trans;
     i_bgw->GetTrans(&trans);
 
-    PSVECAdd(i_pos, &trans, i_pos);
+    VECAdd(i_pos, &trans, i_pos);
 }
 
 /* 80075B84-80075BF4 0704C4 0070+00 0/0 1/1 2/2 .text

--- a/src/d/bg/d_bg_s.cpp
+++ b/src/d/bg/d_bg_s.cpp
@@ -793,10 +793,10 @@ void dBgS_MoveBGProc_Typical(dBgW* i_bgw, void* i_actor_ptr, cBgS_PolyInfo const
     Mtx m;
     if (i_bgw->GetOldInvMtx(m) != NULL) {
         cXyz move_old;
-        PSMTXMultVec(m, i_pos, &move_old);
+        MTXMultVec(m, i_pos, &move_old);
 
         cXyz move_pos;
-        PSMTXMultVec(i_bgw->GetBaseMtxP(), &move_old, &move_pos);
+        MTXMultVec(i_bgw->GetBaseMtxP(), &move_old, &move_pos);
         i_pos->x = move_pos.x;
         i_pos->y = move_pos.y;
         i_pos->z = move_pos.z;

--- a/src/d/bg/d_bg_s_movebg_actor.cpp
+++ b/src/d/bg/d_bg_s_movebg_actor.cpp
@@ -108,9 +108,9 @@ int dBgS_MoveBgActor::MoveBGCreate(char const* i_arcName, int i_dzb_id,
         mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
         mDoMtx_stack_c::YrotM(shape_angle.y);
         mDoMtx_stack_c::scaleM(mScale.x, mScale.y, mScale.z);
-        PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+        MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
     } else {
-        PSMTXCopy(*i_bgMtx, mBgMtx);
+        MTXCopy(*i_bgMtx, mBgMtx);
     }
 
     m_name = i_arcName;
@@ -148,9 +148,9 @@ int dBgS_MoveBgActor::MoveBGExecute() {
         mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
         mDoMtx_stack_c::YrotM(shape_angle.y);
         mDoMtx_stack_c::scaleM(mScale.x, mScale.y, mScale.z);
-        PSMTXCopy(mDoMtx_stack_c::get(), mBgMtx);
+        MTXCopy(mDoMtx_stack_c::get(), mBgMtx);
     } else {
-        PSMTXCopy(*new_mtx, mBgMtx);
+        MTXCopy(*new_mtx, mBgMtx);
     }
 
     if (mpBgW != NULL) {

--- a/src/d/bg/d_bg_w.cpp
+++ b/src/d/bg/d_bg_w.cpp
@@ -284,7 +284,7 @@ void cBgW::GlobalVtx() {
         if (!mNeedsFullTransform) {
             for (int i = 0; i < pm_bgd->m_v_num; i++) {
                 Vec* vtx = &pm_vtx_tbl[i];
-                PSVECAdd(vtx, &mTransVel, vtx);
+                VECAdd(vtx, &mTransVel, vtx);
             }
         } else {
             for (int i = 0; i < pm_bgd->m_v_num; i++) {
@@ -340,7 +340,7 @@ void cBgW::CalcPlane() {
     if (pm_vtx_tbl != NULL) {
         if (!mNeedsFullTransform) {
             for (int i = 0; i < pm_bgd->m_t_num; i++) {
-                pm_tri[i].m_plane.mD -= PSVECDotProduct(&pm_tri[i].m_plane.mNormal, &mTransVel);
+                pm_tri[i].m_plane.mD -= VECDotProduct(&pm_tri[i].m_plane.mNormal, &mTransVel);
             }
         } else {
             for (int i = 0; i < pm_bgd->m_t_num; i++) {
@@ -443,8 +443,8 @@ asm void cBgW::ClassifyPlane() {
 
 /* 8007998C-800799E0 0742CC 0054+00 1/1 0/0 0/0 .text MakeBlckTransMinMax__4cBgWFP4cXyzP4cXyz */
 void cBgW::MakeBlckTransMinMax(cXyz* i_min, cXyz* i_max) {
-    PSVECAdd(i_min, &mTransVel, i_min);
-    PSVECAdd(i_max, &mTransVel, i_max);
+    VECAdd(i_min, &mTransVel, i_min);
+    VECAdd(i_max, &mTransVel, i_max);
 }
 
 /* 800799E0-80079A68 074320 0088+00 1/1 0/0 0/0 .text            MakeBlckMinMax__4cBgWFiP4cXyzP4cXyz

--- a/src/d/bg/d_bg_w.cpp
+++ b/src/d/bg/d_bg_w.cpp
@@ -257,8 +257,8 @@ cBgW::cBgW() {
     pm_vtx_tbl = NULL;
     pm_base = NULL;
 
-    PSMTXIdentity(m_inv_mtx);
-    PSMTXIdentity(m_mtx);
+    MTXIdentity(m_inv_mtx);
+    MTXIdentity(m_mtx);
     m_rootGrpIdx = 0xFFFF;
     field_0x91 = 0;
 }
@@ -288,7 +288,7 @@ void cBgW::GlobalVtx() {
             }
         } else {
             for (int i = 0; i < pm_bgd->m_v_num; i++) {
-                PSMTXMultVec(pm_base, &pm_bgd->m_v_tbl[i], &pm_vtx_tbl[i]);
+                MTXMultVec(pm_base, &pm_bgd->m_v_tbl[i], &pm_vtx_tbl[i]);
             }
         }
     }
@@ -637,12 +637,12 @@ bool cBgW::Set(cBgD_t* pbgd, u32 flags, Mtx* pbase_mtx) {
     mFlags = flags;
     if (mFlags & GLOBAL_e) {
         pm_base = NULL;
-        PSMTXIdentity(m_inv_mtx);
-        PSMTXIdentity(m_mtx);
+        MTXIdentity(m_inv_mtx);
+        MTXIdentity(m_mtx);
     } else {
         pm_base = *pbase_mtx;
-        PSMTXCopy(pm_base, m_inv_mtx);
-        PSMTXCopy(pm_base, m_mtx);
+        MTXCopy(pm_base, m_inv_mtx);
+        MTXCopy(pm_base, m_mtx);
     }
 
     pm_bgd = pbgd;
@@ -933,8 +933,8 @@ bool cBgW::GroundCross(cBgS_GndChk* pchk) {
 /* 8007ABC4-8007AC10 075504 004C+00 1/1 0/0 0/0 .text            CopyOldMtx__4cBgWFv */
 void cBgW::CopyOldMtx() {
     if (pm_base != NULL) {
-        PSMTXCopy(m_mtx, m_inv_mtx);
-        PSMTXCopy(pm_base, m_mtx);
+        MTXCopy(m_mtx, m_inv_mtx);
+        MTXCopy(pm_base, m_mtx);
     }
 }
 
@@ -952,7 +952,7 @@ void cBgW::Move() {
             } else if (m_mtx[0][3] == pm_base[0][3] && m_mtx[1][3] == pm_base[1][3] &&
                        m_mtx[2][3] == pm_base[2][3])
             {
-                PSMTXCopy(pm_base, m_inv_mtx);
+                MTXCopy(pm_base, m_inv_mtx);
                 if (!ChkFlush()) {
                     return;
                 }

--- a/src/d/bg/d_bg_w_kcol.cpp
+++ b/src/d/bg/d_bg_w_kcol.cpp
@@ -279,7 +279,7 @@ cM3dGPla dBgWKCol::GetTriPla(int poly_index) const {
 
     Vec* tri_pos;
     getTri1Pos(pd, &tri_pos);
-    PSVECDotProduct(tri_nrm, tri_pos);
+    VECDotProduct(tri_nrm, tri_pos);
 
     cM3dGPla plane;
     plane.SetupNP(*tri_nrm, *tri_pos);

--- a/src/d/cc/d_cc_mass_s.cpp
+++ b/src/d/cc/d_cc_mass_s.cpp
@@ -171,13 +171,13 @@ u32 dCcMassS_Mng::Chk(cXyz* p_xyz, fopAc_ac_c** p_actor, dCcMassS_HitInf* p_hitI
 
                 if (field_0x200 & 0x10) {
                     Vec vec;
-                    PSVECSubtract(&(*p_actor)->current.pos, p_xyz, &vec);
+                    VECSubtract(&(*p_actor)->current.pos, p_xyz, &vec);
                     vec.y = 0;
-                    f32 vecMag = PSVECMag(&vec);
+                    f32 vecMag = VECMag(&vec);
                     if (cM3d_IsZero(vecMag)) {
                         vec.x = 1;
                     } else {
-                        PSVECScale(&vec, &vec, f / vecMag);
+                        VECScale(&vec, &vec, f / vecMag);
                     }
                     obj->GetStts()->PlusCcMove(vec.x, vec.y, vec.z);
                 }
@@ -203,7 +203,7 @@ u32 dCcMassS_Mng::Chk(cXyz* p_xyz, fopAc_ac_c** p_actor, dCcMassS_HitInf* p_hitI
             tmpVec.z = p_xyz->z;
 
             if (mCamTopPos.y < (20.0f + plusH)) {
-                f32 newCamTopDist = PSVECSquareDistance(&tmpVec, &mCpsAttr.GetStartP());
+                f32 newCamTopDist = VECSquareDistance(&tmpVec, &mCpsAttr.GetStartP());
                 if (mCamTopDist > newCamTopDist) {
                     mCamTopDist = newCamTopDist;
                     mCamTopPos = tmpVec;
@@ -211,7 +211,7 @@ u32 dCcMassS_Mng::Chk(cXyz* p_xyz, fopAc_ac_c** p_actor, dCcMassS_HitInf* p_hitI
             }
 
             if (mCamBottomPos.y < (20.0f + plusH)) {
-                f32 newCamBottomDist = PSVECSquareDistance(&tmpVec, &mCpsAttr.GetEndP());
+                f32 newCamBottomDist = VECSquareDistance(&tmpVec, &mCpsAttr.GetEndP());
                 if (mCamBottomDist > newCamBottomDist) {
                     mCamBottomDist = newCamBottomDist;
                     mCamBottomPos = tmpVec;

--- a/src/d/cc/d_cc_s.cpp
+++ b/src/d/cc/d_cc_s.cpp
@@ -403,8 +403,8 @@ void dCcS::SetPosCorrect(cCcD_Obj* param_0, cXyz* param_1, cCcD_Obj* param_2, cX
 
     f32 fvar14;
     if (bvar2) {
-        PSVECSubtract(param_3, param_1, &local_c8);
-        fvar14 = PSVECMag(&local_c8);
+        VECSubtract(param_3, param_1, &local_c8);
+        fvar14 = VECMag(&local_c8);
     } else {
         local_c8.x = param_3->x - param_1->x;
         local_c8.y = 0.0f;
@@ -414,10 +414,10 @@ void dCcS::SetPosCorrect(cCcD_Obj* param_0, cXyz* param_1, cCcD_Obj* param_2, cX
 
     if (!cM3d_IsZero(fvar14)) {
         if (bvar2) {
-            PSVECScale(&local_c8, &local_c8, param_4 / fvar14);
+            VECScale(&local_c8, &local_c8, param_4 / fvar14);
             fvar1 *= -1.0f;
-            PSVECScale(&local_c8, &local_b0, fvar1);
-            PSVECScale(&local_c8, &local_bc, fvar2);
+            VECScale(&local_c8, &local_b0, fvar1);
+            VECScale(&local_c8, &local_bc, fvar2);
         } else {
             fvar14 = param_4 / fvar14;
             local_c8.x *= fvar14;
@@ -458,7 +458,7 @@ void dCcS::CalcParticleAngle(dCcD_GObjInf* i_atObjInf, cCcD_Stts* i_atStts, cCcD
                              csXyz* o_angle) {
     cXyz vec(*i_atObjInf->GetAtVecP());
 
-    if (cM3d_IsZero(PSVECMag(&vec))) {
+    if (cM3d_IsZero(VECMag(&vec))) {
         fopAc_ac_c* atActor = i_atStts->GetActor();
         fopAc_ac_c* tgActor = i_tgStts->GetActor();
 
@@ -467,18 +467,18 @@ void dCcS::CalcParticleAngle(dCcD_GObjInf* i_atObjInf, cCcD_Stts* i_atStts, cCcD
             vec.x = 0.0f;
             vec.y = -1.0f;
         } else {
-            PSVECSubtract(&tgActor->current.pos, &atActor->current.pos, &vec);
+            VECSubtract(&tgActor->current.pos, &atActor->current.pos, &vec);
 
-            if (cM3d_IsZero(PSVECMag(&vec))) {
+            if (cM3d_IsZero(VECMag(&vec))) {
                 vec.z = 0.0f;
                 vec.x = 0.0f;
                 vec.y = -1.0f;
             } else {
-                PSVECNormalize(&vec, &vec);
+                VECNormalize(&vec, &vec);
             }
         }
     } else {
-        PSVECNormalize(&vec, &vec);
+        VECNormalize(&vec, &vec);
     }
 
     cM3d_CalcVecZAngle(vec, o_angle);

--- a/src/d/d_attention.cpp
+++ b/src/d/d_attention.cpp
@@ -1640,7 +1640,7 @@ void dAttention_c::Draw() {
     }
 
     Mtx tmp;
-    PSMTXInverse(dComIfGd_getViewRotMtx(), tmp);
+    MTXInverse(dComIfGd_getViewRotMtx(), tmp);
     fopAc_ac_c* target = LockonTarget(0);
 
     if (!i_dComIfGp_event_runCheck()) {
@@ -1775,7 +1775,7 @@ void dAttDraw_c::draw(cXyz& param_0, Mtx param_1) {
     f32 temp_f30 = (-100.0f - g_AttDwHIO.mCursorDistance) / temp_f31;
 
     cXyz tmp;
-    PSMTXMultVec(dComIfGd_getViewMtx(), &param_0, &tmp);
+    MTXMultVec(dComIfGd_getViewMtx(), &param_0, &tmp);
 
     f32 var_f2 = 1.0f;
     if (tmp.z < temp_f30) {

--- a/src/d/d_cam_param.cpp
+++ b/src/d/d_cam_param.cpp
@@ -88,7 +88,7 @@ cXyz dCamMath::xyzRotateX(cXyz& i_xyz, cSAngle i_angle) {
 
     s16 angle = i_angle.Val();
     mDoMtx_XrotS(m, angle);
-    PSMTXMultVec(m, &i_xyz, &rot_xyz);
+    MTXMultVec(m, &i_xyz, &rot_xyz);
     return rot_xyz;
 }
 
@@ -99,7 +99,7 @@ cXyz dCamMath::xyzRotateY(cXyz& i_xyz, cSAngle i_angle) {
 
     s16 angle = i_angle.Val();
     mDoMtx_YrotS(m, angle);
-    PSMTXMultVec(m, &i_xyz, &rot_xyz);
+    MTXMultVec(m, &i_xyz, &rot_xyz);
     return rot_xyz;
 }
 

--- a/src/d/d_demo.cpp
+++ b/src/d/d_demo.cpp
@@ -1671,7 +1671,7 @@ s32 dDemo_actor_c::JSGFindNodeID(char const* param_0) const {
 /* 8003A088-8003A0C8 0349C8 0040+00 1/0 0/0 0/0 .text
  * JSGGetNodeTransformation__13dDemo_actor_cCFUlPA4_f           */
 int dDemo_actor_c::JSGGetNodeTransformation(u32 param_0, Mtx param_1) const {
-    PSMTXCopy(mModel->i_getAnmMtx((u16)param_0), param_1);
+    MTXCopy(mModel->i_getAnmMtx((u16)param_0), param_1);
     return 1;
 }
 

--- a/src/d/d_drawlist.cpp
+++ b/src/d/d_drawlist.cpp
@@ -1673,9 +1673,9 @@ int dDlst_shadowPoly_c::set(cBgD_Vtx_t* i_vtx, u16 param_1, u16 param_2, u16 par
     b.z *= temp_f3;
     b *= 2.0f;
 
-    PSVECAdd(&i_vtx[param_1], &b, &dst->mPos[0]);
-    PSVECAdd(&i_vtx[param_2], &b, &dst->mPos[1]);
-    PSVECAdd(&i_vtx[param_3], &b, &dst->mPos[2]);
+    VECAdd(&i_vtx[param_1], &b, &dst->mPos[0]);
+    VECAdd(&i_vtx[param_2], &b, &dst->mPos[1]);
+    VECAdd(&i_vtx[param_3], &b, &dst->mPos[2]);
     mCount++;
     return 1;
 }

--- a/src/d/d_ky_thunder.cpp
+++ b/src/d/d_ky_thunder.cpp
@@ -52,7 +52,7 @@ int dThunder_c::draw() {
     mDoMtx_stack_c::XrotM(field_0x15c);
 
     Mtx m;
-    PSMTXCopy(mDoMtx_stack_c::get(), m);
+    MTXCopy(mDoMtx_stack_c::get(), m);
 
     mModelInfo.mpModel->setBaseScale(field_0x138);
     mModelInfo.mpModel->i_setBaseTRMtx(m);

--- a/src/d/d_model.cpp
+++ b/src/d/d_model.cpp
@@ -42,7 +42,7 @@ void dMdl_c::draw() {
 
     Mtx m;
     for (dMdl_obj_c* obj = mpModelObj; obj != NULL; obj = obj->mpObj) {
-        PSMTXConcat(j3dSys.getViewMtx(), obj->getMtx(), m);
+        MTXConcat(j3dSys.getViewMtx(), obj->getMtx(), m);
         GXLoadPosMtxImm(m, GX_PNMTX0);
         GXLoadNrmMtxImm(m, GX_PNMTX0);
         shape->simpleDrawCache();

--- a/src/d/file/d_file_sel_info.cpp
+++ b/src/d/file/d_file_sel_info.cpp
@@ -349,9 +349,9 @@ void dDlst_FileInfo_c::draw() {
         MtxP glbMtx2 = mBasePane->getGlbMtx();
         // Fake match
         MtxP glbMtx = (MtxP)&glbMtx2[0][0];
-        PSMTXScale(m, mBasePane->getWidth() / field_0x10->getWidth(),
+        MTXScale(m, mBasePane->getWidth() / field_0x10->getWidth(),
                    mBasePane->getHeight() / field_0x10->getHeight(), 1.0f);
-        PSMTXConcat(glbMtx, m, glbMtx);
+        MTXConcat(glbMtx, m, glbMtx);
         Scr->search('Nm_02')->setMtx(glbMtx);
     }
     Scr->draw(0.0f, 0.0f, ctx);

--- a/src/d/pane/d_pane_class.cpp
+++ b/src/d/pane/d_pane_class.cpp
@@ -394,11 +394,11 @@ Vec CPaneMgr::getGlobalVtx(J2DPane* p_pane, Mtx* param_1, u8 param_2, bool param
 
     if (parent != NULL) {
         getGlobalVtx(parent, param_1, param_2, param_3, param_4);
-        PSMTXCopy(*param_1, m);
-        PSMTXConcat(m, *p_pane->getMtx(), *param_1);
+        MTXCopy(*param_1, m);
+        MTXConcat(m, *p_pane->getMtx(), *param_1);
     } else {
         p_pane->calcMtx();
-        PSMTXCopy(*p_pane->getMtx(), *param_1);
+        MTXCopy(*p_pane->getMtx(), *param_1);
     }
 
     Vec outVec;

--- a/src/d/particle/d_particle.cpp
+++ b/src/d/particle/d_particle.cpp
@@ -981,7 +981,7 @@ static void static_light8EcallBack(JPABaseEmitter* param_0) {
 static void static_gen_b_light8EcallBack(JPABaseEmitter* param_0) {
     GXFlush();
     Mtx identity;
-    PSMTXIdentity(identity);
+    MTXIdentity(identity);
     GXLoadPosMtxImm(identity, 0);
     GXLoadNrmMtxImm(identity, 0);
     GXInvalidateVtxCache();
@@ -1093,27 +1093,27 @@ SECTION_SDATA2 static f64 lit_4093 = 4503599627370496.0 /* cast u32 to float */;
 void dPa_modelPcallBack::draw(JPABaseEmitter* param_0, JPABaseParticle* param_1) {
     Mtx local_74;
     Mtx local_44;
-    PSMTXIdentity(local_74);
-    PSMTXIdentity(local_44);
+    MTXIdentity(local_74);
+    MTXIdentity(local_44);
     f32 f31 = -90.0f / 16384.0f * param_1->getRotateAngle();
     if (f31) {
         switch(dPa_modelEcallBack::getRotAxis(param_0)) {
         case 0:
-            PSMTXRotRad(local_44, 0x79, DEG_TO_RAD(f31));
+            MTXRotRad(local_44, 0x79, DEG_TO_RAD(f31));
             break;
         case 1:
-            PSMTXRotRad(local_44, 0x78, DEG_TO_RAD(f31));
+            MTXRotRad(local_44, 0x78, DEG_TO_RAD(f31));
             break;
         case 2:
-            PSMTXRotRad(local_44, 0x7a, DEG_TO_RAD(f31));
+            MTXRotRad(local_44, 0x7a, DEG_TO_RAD(f31));
             break;
         case 3:
             Vec vec = {1.0f, 1.0f, 1.0f};
-            PSMTXRotAxisRad(local_44, &vec, DEG_TO_RAD(f31));
+            MTXRotAxisRad(local_44, &vec, DEG_TO_RAD(f31));
             break;
         }
 
-        PSMTXConcat(local_74, local_44, local_74);
+        MTXConcat(local_74, local_44, local_74);
     }
     JGeometry::TVec3<f32> local_cc;
     param_1->getGlobalPosition(local_cc);
@@ -1125,8 +1125,8 @@ void dPa_modelPcallBack::draw(JPABaseEmitter* param_0, JPABaseParticle* param_1)
     local_fc.x *= param_1->getParticleScaleX();
     local_fc.y *= param_1->getParticleScaleY();
     Mtx auStack_c0;
-    PSMTXScale(auStack_c0, local_fc.x, local_fc.y, local_fc.x);
-    PSMTXConcat(local_74, auStack_c0, local_74);
+    MTXScale(auStack_c0, local_fc.x, local_fc.y, local_fc.x);
+    MTXConcat(local_74, auStack_c0, local_74);
     dPa_modelEcallBack::drawModel(param_0, local_74);
     param_1->setInvisibleParticleFlag();
 }
@@ -1264,7 +1264,7 @@ void dPa_modelEcallBack::model_c::draw(f32 (*param_0)[4]) {
         dKy_Global_amb_set(&field_0x8);
         dKy_GxFog_tevstr_set(&field_0x8);
         Mtx auStack_48;
-        PSMTXConcat(j3dSys.getViewMtx(), param_0, auStack_48);
+        MTXConcat(j3dSys.getViewMtx(), param_0, auStack_48);
         GXLoadPosMtxImm(auStack_48, 0);
         GXLoadNrmMtxImm(auStack_48, 0);
         material->getShape()->simpleDrawCache();
@@ -1919,7 +1919,7 @@ dPa_control_c::dPa_control_c() {
     mSceneResMng = NULL;
     m_sceneRes = NULL;
 
-    PSMTXIdentity(mWindViewMatrix);
+    MTXIdentity(mWindViewMatrix);
 }
 
 /* 8004BB70-8004BB78 0464B0 0008+00 4/4 0/0 0/0 .text            getRM_ID__13dPa_control_cFUs */

--- a/src/d/s/d_s_name.cpp
+++ b/src/d/s/d_s_name.cpp
@@ -217,12 +217,12 @@ void dScnName_c::setView() {
                      mCamera.mFar);
     mDoMtx_lookAt(mCamera.mViewMtx, &mCamera.mLookat.mEye, &mCamera.mLookat.mCenter,
                   mCamera.mBank);
-    PSMTXInverse(mCamera.mViewMtx, mCamera.mInvViewMtx);
-    PSMTXCopy(mCamera.mViewMtx, mCamera.mViewMtxNoTrans);
+    MTXInverse(mCamera.mViewMtx, mCamera.mInvViewMtx);
+    MTXCopy(mCamera.mViewMtx, mCamera.mViewMtxNoTrans);
     mCamera.mViewMtxNoTrans[0][3] = 0.0f;
     mCamera.mViewMtxNoTrans[1][3] = 0.0f;
     mCamera.mViewMtxNoTrans[2][3] = 0.0f;
-    PSMTXCopy(mCamera.mViewMtx, j3dSys.mViewMtx);
+    MTXCopy(mCamera.mViewMtx, j3dSys.mViewMtx);
     mDoMtx_concatProjView(mCamera.mProjMtx, mCamera.mViewMtx, mCamera.mProjViewMtx);
 }
 

--- a/src/f_op/f_op_actor_mng.cpp
+++ b/src/f_op/f_op_actor_mng.cpp
@@ -2043,7 +2043,7 @@ s32 fopAcM_wayBgCheck(fopAc_ac_c const* param_0, f32 param_1, f32 param_2) {
     tmp1.z = param_1;
 
     MtxPosition(&tmp1, &tmp2);
-    PSVECAdd(&tmp2, &param_0->current.pos, &tmp2);
+    VECAdd(&tmp2, &param_0->current.pos, &tmp2);
 
     linChk.Set(&tmp0, &tmp2, param_0);
 
@@ -2193,7 +2193,7 @@ s32 fopAcM_carryOffRevise(fopAc_ac_c* param_0) {
     tmp1.z = 150.0f;
 
     MtxPosition(&tmp1, &tmp2);
-    PSVECAdd(&tmp2, &player->current.pos, &tmp2);
+    VECAdd(&tmp2, &player->current.pos, &tmp2);
 
     linChk.Set(&tmp0, &tmp2, param_0);
 

--- a/src/f_op/f_op_actor_mng.cpp
+++ b/src/f_op/f_op_actor_mng.cpp
@@ -942,7 +942,7 @@ s32 fopAcM_checkCullingBox(Mtx pMtx, f32 x1, f32 y1, f32 z1, f32 x2, f32 y2, f32
     Vec tmp1 = {x1, y1, z1};
     Vec tmp2 = {x2, y2, z2};
     Mtx tmpMtx;
-    PSMTXConcat(j3dSys.mViewMtx, pMtx, tmpMtx);
+    MTXConcat(j3dSys.mViewMtx, pMtx, tmpMtx);
     return mDoLib_clipper::mClipper.clip(tmpMtx, &tmp2, &tmp1) != 0;
 }
 
@@ -1052,7 +1052,7 @@ s32 fopAcM_cullingCheck(fopAc_ac_c const* i_actor) {
         mtx_p = j3dSys.getViewMtx();
     } else {
         Mtx concat_mtx;
-        PSMTXConcat(j3dSys.getViewMtx(), fopAcM_GetMtx(i_actor), concat_mtx);
+        MTXConcat(j3dSys.getViewMtx(), fopAcM_GetMtx(i_actor), concat_mtx);
         mtx_p = concat_mtx;
     }
 

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -327,7 +327,7 @@ Mtx mDoGph_gInf_c::mBlureMtx;
 /* 800080A0-800080D0 0029E0 0030+00 1/1 1/1 0/0 .text            onBlure__13mDoGph_gInf_cFPA4_Cf */
 void mDoGph_gInf_c::onBlure(const Mtx m) {
     mBlureFlag = true;
-    PSMTXCopy(m, mBlureMtx);
+    MTXCopy(m, mBlureMtx);
 }
 
 /* 800080D0-800080F4 002A10 0024+00 0/0 3/3 7/7 .text            fadeOut__13mDoGph_gInf_cFf */
@@ -1478,7 +1478,7 @@ int mDoGph_Painter() {
                 ortho.setPort();
 
                 Mtx m3;
-                PSMTXTrans(m3, 304.0f, 224.0f, 0.0f);
+                MTXTrans(m3, 304.0f, 224.0f, 0.0f);
                 JPADrawInfo draw_info2(m3, 0.0f, 448.0f, 0.0f, 608.0f);
                 dComIfGp_particle_draw2Dgame(&draw_info2);
 
@@ -1501,10 +1501,10 @@ int mDoGph_Painter() {
     ortho.setPort();
 
     Mtx m4;
-    PSMTXCopy(j3dSys.getViewMtx(), m4);
+    MTXCopy(j3dSys.getViewMtx(), m4);
 
     Mtx m5;
-    PSMTXTrans(m5, 304.0f, 224.0f, 0.0f);
+    MTXTrans(m5, 304.0f, 224.0f, 0.0f);
 
     JPADrawInfo draw_info3(m5, 0.0f, 448.0f, 0.0f, 608.0f);
 

--- a/src/m_Do/m_Do_mtx.cpp
+++ b/src/m_Do/m_Do_mtx.cpp
@@ -77,17 +77,17 @@ void mDoMtx_XYZrotS(Mtx mtx, s16 x, s16 y, s16 z) {
     if (z != 0) {
         mDoMtx_ZrotS(mtx, z);
     } else {
-        PSMTXIdentity(mtx);
+        MTXIdentity(mtx);
     }
 
     if (y != 0) {
         mDoMtx_YrotS(tmp, y);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 
     if (x != 0) {
         mDoMtx_XrotS(tmp, x);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 }
 
@@ -96,17 +96,17 @@ void mDoMtx_XYZrotM(Mtx mtx, s16 x, s16 y, s16 z) {
     Mtx tmp;
     if (z != 0) {
         mDoMtx_ZrotS(tmp, z);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 
     if (y != 0) {
         mDoMtx_YrotS(tmp, y);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 
     if (x != 0) {
         mDoMtx_XrotS(tmp, x);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 }
 
@@ -116,17 +116,17 @@ void mDoMtx_ZXYrotS(Mtx mtx, s16 x, s16 y, s16 z) {
     if (y != 0) {
         mDoMtx_YrotS(mtx, y);
     } else {
-        PSMTXIdentity(mtx);
+        MTXIdentity(mtx);
     }
 
     if (x != 0) {
         mDoMtx_XrotS(tmp, x);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 
     if (z != 0) {
         mDoMtx_ZrotS(tmp, z);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 }
 
@@ -135,17 +135,17 @@ void mDoMtx_ZXYrotM(Mtx mtx, s16 x, s16 y, s16 z) {
     Mtx tmp;
     if (y != 0) {
         mDoMtx_YrotS(tmp, y);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 
     if (x != 0) {
         mDoMtx_XrotS(tmp, x);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 
     if (z != 0) {
         mDoMtx_ZrotS(tmp, z);
-        PSMTXConcat(mtx, tmp, mtx);
+        MTXConcat(mtx, tmp, mtx);
     }
 }
 
@@ -198,7 +198,7 @@ asm void mDoMtx_XrotS(f32 (*param_0)[4], s16 param_1) {
 void mDoMtx_XrotM(Mtx mtx, s16 x) {
     Mtx tmp;
     mDoMtx_XrotS(tmp, x);
-    PSMTXConcat(mtx, tmp, mtx);
+    MTXConcat(mtx, tmp, mtx);
 }
 
 /* 8000C3DC-8000C434 006D1C 0058+00 5/5 24/24 809/809 .text            mDoMtx_YrotS__FPA4_fs */
@@ -238,7 +238,7 @@ asm void mDoMtx_YrotS(f32 (*param_0)[4], s16 param_1) {
 void mDoMtx_YrotM(Mtx mtx, s16 y) {
     Mtx tmp;
     mDoMtx_YrotS(tmp, y);
-    PSMTXConcat(mtx, tmp, mtx);
+    MTXConcat(mtx, tmp, mtx);
 }
 
 /* 8000C474-8000C4CC 006DB4 0058+00 7/7 1/1 6/6 .text            mDoMtx_ZrotS__FPA4_fs */
@@ -278,7 +278,7 @@ asm void mDoMtx_ZrotS(f32 (*param_0)[4], s16 param_1) {
 void mDoMtx_ZrotM(Mtx mtx, s16 z) {
     Mtx tmp;
     mDoMtx_ZrotS(tmp, z);
-    PSMTXConcat(mtx, tmp, mtx);
+    MTXConcat(mtx, tmp, mtx);
 }
 
 /* 8000C50C-8000C710 006E4C 0204+00 0/0 3/3 0/0 .text            mDoMtx_lookAt__FPA4_fPC3VecPC3Vecs
@@ -435,7 +435,7 @@ bool mDoMtx_stack_c::push() {
         return false;
     }
     Mtx* old = next++;
-    PSMTXCopy(now, *old);
+    MTXCopy(now, *old);
     return true;
 }
 
@@ -445,7 +445,7 @@ bool mDoMtx_stack_c::pop() {
         return false;
     }
     next--;
-    PSMTXCopy(*next, now);
+    MTXCopy(*next, now);
     return true;
 }
 
@@ -458,8 +458,8 @@ void mDoMtx_stack_c::transS(cXyz const& param_0) {
  */
 void mDoMtx_stack_c::transM(f32 x, f32 y, f32 z) {
     Mtx tmp;
-    PSMTXTrans(tmp, x, y, z);
-    PSMTXConcat(now, tmp, now);
+    MTXTrans(tmp, x, y, z);
+    MTXConcat(now, tmp, now);
 }
 
 /* 8000CDD4-8000CE00 007714 002C+00 0/0 3/3 40/40 .text            transM__14mDoMtx_stack_cFRC4cXyz
@@ -477,8 +477,8 @@ void mDoMtx_stack_c::scaleS(cXyz const& param_0) {
  */
 void mDoMtx_stack_c::scaleM(f32 x, f32 y, f32 z) {
     Mtx tmp;
-    PSMTXScale(tmp, x, y, z);
-    PSMTXConcat(now, tmp, now);
+    MTXScale(tmp, x, y, z);
+    MTXConcat(now, tmp, now);
 }
 
 /* 8000CE70-8000CE9C 0077B0 002C+00 0/0 7/7 79/79 .text            scaleM__14mDoMtx_stack_cFRC4cXyz
@@ -512,8 +512,8 @@ void mDoMtx_stack_c::ZXYrotM(csXyz const& param_0) {
 /* 8000CF7C-8000CFB8 0078BC 003C+00 0/0 1/1 6/6 .text quatM__14mDoMtx_stack_cFPC10Quaternion */
 void mDoMtx_stack_c::quatM(Quaternion const* param_0) {
     Mtx tmp;
-    PSMTXQuat(tmp, param_0);
-    PSMTXConcat(now, tmp, now);
+    MTXQuat(tmp, param_0);
+    MTXConcat(now, tmp, now);
 }
 
 /* ############################################################################################## */


### PR DESCRIPTION
this makes it so that the VEC/MTX functions choose PS versions by default for release builds as they're faster, while C implemented versions are chosen when building a debug build. this is probably how they were used originally. some functions still manually call C or PS versions instead of using the macro, so those are left alone

## CC0 License Agreement
<!--
By submitting this pull request, I agree to comply with the terms of the Creative Commons Zero v1.0 Universal (CC0) Public Domain Dedication License for my contributions to this project.

I dedicate any and all copyright interest in this contribution to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

To the best of my knowledge and belief, my contribution is either originally created by me, or is derived from a source that also released its contents under CC0 or a compatible license.

I understand that this project and its maintainers are not responsible for enforcing the CC0 license, and I release them from any potential liability related to my contribution.
-->

- [X] I agree to the terms of the CC0 License.

<!--
Please check the checkbox above to indicate your agreement.
-->