### PR TITLE
fix/simplify assert macros

### DIFF
--- a/include/JSystem/JAudio2/JAISeqMgr.h
+++ b/include/JSystem/JAudio2/JAISeqMgr.h
@@ -29,13 +29,13 @@ public:
     void setAudience(JAIAudience* param_0) { mAudience = param_0; }
     JAISeqDataMgr* getSeqDataMgr() { return seqDataMgr_; }
     void setSeqDataMgr(JAISeqDataMgr* param_0) {
-        JUT_ASSERT("JAISeqMgr.h", 0x7c, !isActive());
+        JUT_ASSERT(124, !isActive());
         resetSeqDataMgr();
         seqDataMgr_ = param_0;
         seqDataMgr_->setSeqDataUser(this);
     }
     void resetSeqDataMgr() {
-        JUT_ASSERT("JAISeqMgr.h", 0x83, !isActive());
+        JUT_ASSERT(131, !isActive());
         if (seqDataMgr_) {
             seqDataMgr_->setSeqDataUser(NULL);
             seqDataMgr_ = NULL;

--- a/include/JSystem/JAudio2/JAISoundHandles.h
+++ b/include/JSystem/JAudio2/JAISoundHandles.h
@@ -15,7 +15,7 @@ public:
     bool isSoundAttached() const { return sound_ != NULL; }
 
     JAISound* operator->() const {
-        JUT_ASSERT("JAISound.h", 58, sound_ != 0);
+        JUT_ASSERT(58, sound_ != 0);
         return sound_;
     }
 

--- a/include/JSystem/JAudio2/JAIStreamMgr.h
+++ b/include/JSystem/JAudio2/JAIStreamMgr.h
@@ -34,11 +34,11 @@ public:
 
     JAISoundParamsMove* getParams() { return &mParams; }
     void setStreamDataMgr(JAIStreamDataMgr* param_0) {
-        JUT_ASSERT("JAIStreamMgr.h", 0x8b, !isActive());
+        JUT_ASSERT(139, !isActive());
         mStreamDataMgr = param_0;
     }
     void setStreamAramMgr(JAIStreamAramMgr* param_0) {
-        JUT_ASSERT("JAIStreamMgr.h", 0x9d, !isActive());
+        JUT_ASSERT(157, !isActive());
         mStreamAramMgr = param_0;
     }
 

--- a/include/JSystem/JAudio2/JASGadget.h
+++ b/include/JSystem/JAudio2/JASGadget.h
@@ -13,7 +13,7 @@ public:
 
     JASGlobalInstance(bool param_1) {
         if (param_1) {
-            JUT_ASSERT("JASGadget.h", 0xba, sInstance == 0);
+            JUT_ASSERT(186, sInstance == 0);
             sInstance = (T*)this;
         }
     }
@@ -50,7 +50,7 @@ public:
         return mTable[index];
     }
     void set(u32 index, T* value) {
-        JUT_ASSERT("JASGadget.h", 0xe5, index < mSize);
+        JUT_ASSERT(229, index < mSize);
         mTable[index] = value;
     }
 

--- a/include/JSystem/JAudio2/JAUStreamAramMgr.h
+++ b/include/JSystem/JAudio2/JAUStreamAramMgr.h
@@ -18,13 +18,13 @@ public:
     ~JAUStreamAramMgrBase_() { releaseAram_JAUStreamAramMgrBase_(); }
     bool isStreamUsingAram() { return field_0x4.any(); }
     void releaseAram_JAUStreamAramMgrBase_() {
-        JUT_ASSERT("JAUStreamAramMgr.h", 0x26, ! isStreamUsingAram());
+        JUT_ASSERT(38, ! isStreamUsingAram());
         for (int i = 0; i >= 0; i--) {
             if (mHeaps[i].isAllocated()) {
                 JASHeap* heap = mHeaps[i];
                 heap.free();
                 if (!heap) {
-                    JUT_ASSERT("JAUStreamAramMgr.h", 0x2f, 0);
+                    JUT_ASSERT(47, 0);
                 }
             }
         }
@@ -65,15 +65,15 @@ public:
     }
     bool isAramReserved() const { return field_0x4c; }
     void reserveAram(JASHeap* heap, int numReserve, u32 param_2) {
-        JUT_ASSERT("JAUStreamAramMgr.h", 0x48, ! isAramReserved());
-        JUT_ASSERT("JAUStreamAramMgr.h", 0x49, ! JAUStreamAramMgrBase_ < MAX_CHUNKS_ >::isStreamUsingAram());
+        JUT_ASSERT(72, ! isAramReserved());
+        JUT_ASSERT(73, ! JAUStreamAramMgrBase_ < MAX_CHUNKS_ >::isStreamUsingAram());
         if (!heap) {
             heap = JASKernel::getAramHeap();
         }
         if (numReserve < 1) {
             numReserve = 1;
         }
-        JUT_ASSERT("JAUStreamAramMgr.h", 0x53, numReserve <= MAX_CHUNKS);
+        JUT_ASSERT(83, numReserve <= MAX_CHUNKS);
         int r27 = param_2 * JASAramStream::getBlockSize();
         for (int i = 0; i < numReserve; i++) {
             if (!this->mHeaps[i].alloc(heap, r27)) {

--- a/include/JSystem/JUtility/JUTAssert.h
+++ b/include/JSystem/JUtility/JUTAssert.h
@@ -4,18 +4,18 @@
 #include "dolphin/types.h"
 
 #if DEBUG
-#define JUT_ASSERT(FILE, LINE, COND)                                                               \
-    if (!COND) {                                                                                   \
-        JUTAssertion::showAssert(JUTAssertion::getSDevice(), FILE, LINE, #COND);                   \
-        OSPanic(FILE, LINE, "Halt");                                                               \
+#define JUT_ASSERT(LINE, COND)                                                                     \
+    if ((COND) == 0) {                                                                             \
+        JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, LINE, #COND);               \
+        OSPanic(__FILE__, LINE, "Halt");                                                           \
     }
 
-#define JUT_PANIC(FILE, LINE, TEXT)                                                                \
-    JUTAssertion::showAssert(JUTAssertion::getSDevice(), FILE, LINE, TEXT);                        \
-    OSPanic(FILE, LINE, "Halt");
+#define JUT_PANIC(LINE, TEXT)                                                                      \
+    JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, LINE, TEXT);                    \
+    OSPanic(__FILE__, LINE, "Halt");
 
-#define JUT_WARN(FILE, LINE, ...)                                                                  \
-    JUTAssertion::setWarningMessage_f(JUTAssertion::getSDevice(), FILE, LINE, __VA_ARGS__)
+#define JUT_WARN(LINE, ...)                                                                        \
+    JUTAssertion::setWarningMessage_f(JUTAssertion::getSDevice(), __FILE__, LINE, __VA_ARGS__);    \
 
 #define JUT_LOG(LINE, ...)                                                                         \
     JUTAssertion::setLogMessage_f(JUTAssertion::getSDevice(), __FILE__, LINE, __VA_ARGS__)

--- a/libs/JSystem/JAudio2/JASBasicWaveBank.cpp
+++ b/libs/JSystem/JAudio2/JASBasicWaveBank.cpp
@@ -182,7 +182,7 @@ void JASBasicWaveBank::setGroupCount(u32 param_0, JKRHeap* param_1) {
     delete[] mWaveGroupArray;
     mGroupCount = param_0;
     mWaveGroupArray = new(param_1, 0) TWaveGroup[param_0];
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0x3e, mWaveGroupArray != 0);
+    JUT_ASSERT(62, mWaveGroupArray != 0);
     for (int i = 0; i < mGroupCount; i++) {
         mWaveGroupArray[i].mBank = this;
     }
@@ -193,7 +193,7 @@ void JASBasicWaveBank::setGroupCount(u32 param_0, JKRHeap* param_1) {
 void JASBasicWaveBank::setWaveTableSize(u32 param_0, JKRHeap* param_1) {
     delete[] mWaveTable;
     mWaveTable = new(param_1, 0) TWaveHandle[param_0];
-    JUT_ASSERT("JASBasicWaveBank.cpp",0x5c, mWaveTable != 0);
+    JUT_ASSERT(92, mWaveTable != 0);
     mHandleCount = param_0;
 }
 
@@ -256,9 +256,9 @@ JASWaveHandle* JASBasicWaveBank::getWaveHandle(u32 param_0) const {
  * setWaveInfo__16JASBasicWaveBankFPQ216JASBasicWaveBank10TWaveGroupiUsRC11JASWaveInfo */
 void JASBasicWaveBank::setWaveInfo(JASBasicWaveBank::TWaveGroup* wgrp, int index,
                                    u16 param_2, JASWaveInfo const& param_3) {
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0xcc, wgrp);
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0xcd, index < wgrp->mWaveCount);
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0xce, index >= 0);
+    JUT_ASSERT(204, wgrp);
+    JUT_ASSERT(205, index < wgrp->mWaveCount);
+    JUT_ASSERT(206, index >= 0);
     mWaveTable[param_2].field_0x4 = param_3;
     mWaveTable[param_2].field_0x4.field_0x20 = mNoLoad;
     mWaveTable[param_2].field_0x4.field_0x08 = -1;
@@ -308,20 +308,20 @@ void JASBasicWaveBank::TWaveGroup::setWaveCount(u32 param_0, JKRHeap* param_1) {
     delete[] mCtrlWaveArray;
     mWaveCount = param_0;
     mCtrlWaveArray = new(param_1, 0) TGroupWaveInfo[param_0];
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0xff, mCtrlWaveArray != 0);
+    JUT_ASSERT(255, mCtrlWaveArray != 0);
 }
 
 /* 80298B04-80298B2C 293444 0028+00 1/0 0/0 0/0 .text
  * onLoadDone__Q216JASBasicWaveBank10TWaveGroupFv               */
 void JASBasicWaveBank::TWaveGroup::onLoadDone() {
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0x11e, mBank);
+    JUT_ASSERT(286, mBank);
     mBank->incWaveTable(this);
 }
 
 /* 80298B2C-80298B54 29346C 0028+00 1/0 0/0 0/0 .text
  * onEraseDone__Q216JASBasicWaveBank10TWaveGroupFv              */
 void JASBasicWaveBank::TWaveGroup::onEraseDone() {
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0x124, mBank);
+    JUT_ASSERT(292, mBank);
     mBank->decWaveTable(this);
 }
 
@@ -329,15 +329,15 @@ void JASBasicWaveBank::TWaveGroup::onEraseDone() {
 /* 80298B54-80298B64 293494 0010+00 2/2 0/0 0/0 .text
  * getWaveID__Q216JASBasicWaveBank10TWaveGroupCFi               */
 u32 JASBasicWaveBank::TWaveGroup::getWaveID(int index) const {
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0x12a, index < mWaveCount);
-    JUT_ASSERT("JASBasicWaveBank.cpp", 299, index >= 0);
+    JUT_ASSERT(298, index < mWaveCount);
+    JUT_ASSERT(299, index >= 0);
     return mCtrlWaveArray[index].field_0x0;
 }
 
 /* 80298B64-80298B88 2934A4 0024+00 1/0 0/0 0/0 .text
  * getWavePtr__Q216JASBasicWaveBank11TWaveHandleCFv             */
 int JASBasicWaveBank::TWaveHandle::getWavePtr() const {
-    JUT_ASSERT("JASBasicWaveBank.cpp", 0x139, mHeap);
+    JUT_ASSERT(313, mHeap);
     void* base = mHeap->getBase();
     if (base == 0) {
         return 0;

--- a/libs/JSystem/JAudio2/JAUAudioArcInterpreter.cpp
+++ b/libs/JSystem/JAudio2/JAUAudioArcInterpreter.cpp
@@ -125,7 +125,7 @@ bool JAUAudioArcInterpreter::readCommand_() {
     }
     default:
         if (!readCommandMore(cmd)) {
-            JUT_ASSERT("JAUAudioArcInterpreter.cpp", 0x91, false);
+            JUT_ASSERT(145, false);
         }
         break;
     }

--- a/libs/JSystem/JAudio2/JAUAudioArcLoader.cpp
+++ b/libs/JSystem/JAudio2/JAUAudioArcLoader.cpp
@@ -14,8 +14,8 @@
 
 /* 802A4740-802A478C 29F080 004C+00 0/0 1/1 0/0 .text __ct__17JAUAudioArcLoaderFP10JAUSection */
 JAUAudioArcLoader::JAUAudioArcLoader(JAUSection* section) {
-    //JUT_ASSERT("JAUAudioArcLoader.cpp",0xd, section->isOpen());
-    //JUT_ASSERT("JAUAudioArcLoader.cpp",0xe, section->isBuilding());
+    //JUT_ASSERT(13, section->isOpen());
+    //JUT_ASSERT(14, section->isBuilding());
     mSection = section;
 }
 
@@ -77,7 +77,7 @@ void JAUAudioArcLoader::newVoiceBank(u32 param_0, u32 param_1) {
  */
 void JAUAudioArcLoader::newDynamicSeqBlock(u32 param_0) {
     JAUSectionHeap* sectionHeap = mSection->asSectionHeap();
-    JUT_ASSERT("JAUAudioArcLoader.cpp", 0x48, sectionHeap);
+    JUT_ASSERT(72, sectionHeap);
     sectionHeap->newDynamicSeqBlock(param_0);
 }
 

--- a/libs/JSystem/JAudio2/JAUSectionHeap.cpp
+++ b/libs/JSystem/JAudio2/JAUSectionHeap.cpp
@@ -334,8 +334,8 @@ asm JAUSection::JAUSection(JAUSectionHeap* param_0, u32 param_1, s32 param_2) {
 
 /* 802A50F8-802A5160 29FA38 0068+00 0/0 1/1 0/0 .text            finishBuild__10JAUSectionFv */
 void JAUSection::finishBuild() {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x8f, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x90, isBuilding());
+    JUT_ASSERT(143, isOpen());
+    JUT_ASSERT(144, isBuilding());
     {
         TPushCurrentHeap push(getHeap_());
     }
@@ -346,8 +346,8 @@ void JAUSection::finishBuild() {
 
 /* 802A5160-802A51E4 29FAA0 0084+00 2/0 0/0 0/0 .text            dispose__10JAUSectionFv */
 void JAUSection::dispose() {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x10b, ! data_.registeredBankTables.any());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x10c, ! data_.registeredWaveBankTables.any());
+    JUT_ASSERT(267, ! data_.registeredBankTables.any());
+    JUT_ASSERT(268, ! data_.registeredWaveBankTables.any());
     if (data_.mBstDst) {
         sectionHeap_->sectionHeapData_.soundTable->~JAUSoundTable();
         sectionHeap_->sectionHeapData_.soundTable = NULL;
@@ -363,20 +363,20 @@ void JAUSection::dispose() {
 // regalloc, stackalloc
 #ifdef NONMATCHING
 JAUSoundTable* JAUSection::newSoundTable(void const* bst, u32 param_1, bool param_2) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x11d, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x11e, isBuilding());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x11f, bst);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x120, asSectionHeap() == this);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x121, sectionHeap_->sectionHeapData_.soundTable == 0);
+    JUT_ASSERT(285, isOpen());
+    JUT_ASSERT(286, isBuilding());
+    JUT_ASSERT(287, bst);
+    JUT_ASSERT(288, asSectionHeap() == this);
+    JUT_ASSERT(289, sectionHeap_->sectionHeapData_.soundTable == 0);
     {
         TPushCurrentHeap push(getHeap_());
         void* bstDst;
         if (param_1) {
             bstDst = newCopy(bst, param_1, 4);
-            JUT_ASSERT("JAUSectionHeap.cpp", 0x128, bstDst);
+            JUT_ASSERT(296, bstDst);
         }
         JAUSoundTable* soundTable = new JAUSoundTable(param_2);
-        JUT_ASSERT("JAUSectionHeap.cpp", 299, soundTable);
+        JUT_ASSERT(299, soundTable);
         soundTable->init(bst);
         sectionHeap_->sectionHeapData_.soundTable = soundTable;
         data_.mBstDst = bstDst;
@@ -398,20 +398,20 @@ asm JAUSoundTable* JAUSection::newSoundTable(void const* param_0, u32 param_1, b
 // regalloc, stackalloc
 #ifdef NONMATCHING
 JAUSoundNameTable* JAUSection::newSoundNameTable(void const* bstn, u32 param_1, bool param_2) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x13b, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x13c, isBuilding());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x13d, bstn);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x13e, asSectionHeap() == this);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x13f, sectionHeap_->sectionHeapData_.soundNameTable == 0);
+    JUT_ASSERT(315, isOpen());
+    JUT_ASSERT(316, isBuilding());
+    JUT_ASSERT(317, bstn);
+    JUT_ASSERT(318, asSectionHeap() == this);
+    JUT_ASSERT(319, sectionHeap_->sectionHeapData_.soundNameTable == 0);
     {
         TPushCurrentHeap push(getHeap_());
         void* bstnDst;
         if (param_1) {
             bstnDst = newCopy(bstn, param_1, 4);
-            JUT_ASSERT("JAUSectionHeap.cpp", 0x146, bstnDst);
+            JUT_ASSERT(326, bstnDst);
         }
         JAUSoundNameTable* soundNameTable = new JAUSoundNameTable(param_2);
-        JUT_ASSERT("JAUSectionHeap.cpp", 0x149, soundNameTable);
+        JUT_ASSERT(329, soundNameTable);
         soundNameTable->init(bstnDst);
         sectionHeap_->sectionHeapData_.soundNameTable = soundNameTable;
         data_.mBstnDst = bstnDst;
@@ -433,10 +433,10 @@ asm JAUSoundNameTable* JAUSection::newSoundNameTable(void const* param_0, u32 pa
 // JAUStreamFileTable::isValid() signed
 #ifdef NONMATCHING
 JAIStreamDataMgr* JAUSection::newStreamFileTable(void const* param_0, bool param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x159, asSectionHeap() == this);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x15a, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x15b, isBuilding());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x15c, sectionHeap_->sectionHeapData_.streamDataMgr_ == 0);
+    JUT_ASSERT(345, asSectionHeap() == this);
+    JUT_ASSERT(346, isOpen());
+    JUT_ASSERT(347, isBuilding());
+    JUT_ASSERT(348, sectionHeap_->sectionHeapData_.streamDataMgr_ == 0);
     {
         TPushCurrentHeap push(getHeap_());
         JAIStreamDataMgr* r28 = NULL;
@@ -469,16 +469,16 @@ asm JAIStreamDataMgr* JAUSection::newStreamFileTable(void const* param_0, bool p
 
 /* 802A5500-802A5598 29FE40 0098+00 0/0 1/1 0/0 .text newSeSeqCollection__10JAUSectionFPCvUl */
 JAISeqDataMgr* JAUSection::newSeSeqCollection(void const* bsc, u32 param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x18e, asSectionHeap() == this);
-    JUT_ASSERT("JAUSectionHeap.cpp", 399, sectionHeap_->sectionHeapData_.seSeqDataMgr_ == 0);
+    JUT_ASSERT(398, asSectionHeap() == this);
+    JUT_ASSERT(399, sectionHeap_->sectionHeapData_.seSeqDataMgr_ == 0);
     if (param_1) {
         bsc = newCopy(bsc, param_1, 4);
     }
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x195, "bsc");
+    JUT_ASSERT(405, bsc);
     {
         TPushCurrentHeap push(getHeap_());
         JAUSeqDataMgr_SeqCollection* seSeqDataMgr = new JAUSeqDataMgr_SeqCollection();
-        JUT_ASSERT("JAUSectionHeap.cpp", 0x199, seSeqDataMgr);
+        JUT_ASSERT(409, seSeqDataMgr);
         seSeqDataMgr->init(bsc);
         sectionHeap_->sectionHeapData_.seSeqDataMgr_ = seSeqDataMgr;
         data_.field_0x80 = seSeqDataMgr;
@@ -489,9 +489,9 @@ JAISeqDataMgr* JAUSection::newSeSeqCollection(void const* bsc, u32 param_1) {
 /* 802A5598-802A56C8 29FED8 0130+00 2/2 0/0 0/0 .text
  * newStaticSeqDataBlock___10JAUSectionF10JAISoundIDUl          */
 u8* JAUSection::newStaticSeqDataBlock_(JAISoundID param_0, u32 size) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x1a3, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x1a4, isBuilding());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x1a5, size);
+    JUT_ASSERT(419, isOpen());
+    JUT_ASSERT(420, isBuilding());
+    JUT_ASSERT(421, size);
     {
         TPushCurrentHeap push(getHeap_());
         JAUSeqDataBlock* seqDataBlock = new JAUSeqDataBlock();
@@ -535,7 +535,7 @@ bool JAUSection::newStaticSeqData(JAISoundID param_0, void const* param_1, u32 p
 #ifdef NONMATCHING
 bool JAUSection::newStaticSeqData(JAISoundID param_0) {
     JKRArchive* seqArchive = data_.field_0x00.getSeqDataArchive();
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x1e1, seqArchive);
+    JUT_ASSERT(481, seqArchive);
     JAUSoundInfo* soundInfo = JASGlobalInstance<JAUSoundInfo>::getInstance();
     if (!soundInfo) {
         return false;
@@ -564,8 +564,8 @@ asm bool JAUSection::newStaticSeqData(JAISoundID param_0) {
 
 /* 802A57F0-802A5854 2A0130 0064+00 3/3 0/0 0/0 .text            newCopy__10JAUSectionFPCvUll */
 void* JAUSection::newCopy(void const* param_0, u32 param_1, s32 param_2) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x204, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x205, isBuilding());
+    JUT_ASSERT(516, isOpen());
+    JUT_ASSERT(517, isBuilding());
     u8* r31 = new(getHeap_(), param_2) u8[param_1];
     if (r31) {
         memcpy(r31, param_0, param_1);
@@ -587,13 +587,13 @@ SECTION_DEAD static char const* const pad_8039B9B9 = "\0\0\0\0\0\0";
 // position of std::__bitset_base<8>::set
 #ifdef NONMATCHING
 JASWaveBank* JAUSection::newWaveBank(u32 bank_no, void const* param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x210, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x211, isBuilding());
+    JUT_ASSERT(528, isOpen());
+    JUT_ASSERT(529, isBuilding());
     TPushCurrentHeap push(getHeap_());
     s32 r27 = getHeap_()->getFreeSize();
     JASWaveBank* waveBank = JASWSParser::createWaveBank(param_1, getHeap_());
     if (waveBank) {
-        JUT_ASSERT("JAUSectionHeap.cpp", 0x218, sectionHeap_->getWaveBankTable().getWaveBank( bank_no ) == 0);
+        JUT_ASSERT(536, sectionHeap_->getWaveBankTable().getWaveBank( bank_no ) == 0);
         sectionHeap_->getWaveBankTable().registWaveBank(bank_no, waveBank);
         data_.registeredWaveBankTables.set(bank_no, true);
         data_.field_0xa0 += r27 - getHeap_()->getFreeSize();
@@ -645,20 +645,20 @@ asm bool JAUSection::loadWaveArc(u32 param_0, u32 param_1) {
 // vtable order JAUBankTableLink
 #ifdef NONMATCHING
 JASBank* JAUSection::newBank(void const* param_0, u32 param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x287, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x288, isBuilding());
+    JUT_ASSERT(647, isOpen());
+    JUT_ASSERT(648, isBuilding());
     JASWaveBank* waveBank = sectionHeap_->getWaveBankTable().getWaveBank(param_1);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x28a, waveBank != 0);
+    JUT_ASSERT(650, waveBank != 0);
     TPushCurrentHeap push(getHeap_());
     u32 bank_no = JASBNKParser::getBankNumber(param_0);
     s32 r25 = getHeap_()->getFreeSize();
     JASBank* bank = JASBNKParser::createBank(param_0, getHeap_());
     if (bank) {
         if (buildingBankTable_) {
-            JUT_ASSERT("JAUSectionHeap.cpp", 0x294, buildingBankTable_->getBank( bank_no ) == 0);
+            JUT_ASSERT(660, buildingBankTable_->getBank( bank_no ) == 0);
             buildingBankTable_->registBank(bank_no, bank);
         } else {
-            JUT_ASSERT("JAUSectionHeap.cpp",0x299, JASDefaultBankTable::getInstance() ->getBank( bank_no ) == 0);
+            JUT_ASSERT(665, JASDefaultBankTable::getInstance() ->getBank( bank_no ) == 0);
             JASDefaultBankTable::getInstance()->registBank(bank_no, bank);
             data_.registeredBankTables.set(bank_no, true);
         }
@@ -683,18 +683,18 @@ asm JASBank* JAUSection::newBank(void const* param_0, u32 param_1) {
 // regalloc
 #ifdef NONMATCHING
 JASVoiceBank* JAUSection::newVoiceBank(u32 bank_no, u32 param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x2ad, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x2ae, isBuilding());
+    JUT_ASSERT(685, isOpen());
+    JUT_ASSERT(686, isBuilding());
     JASWaveBank* waveBank = sectionHeap_->getWaveBankTable().getWaveBank(param_1);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x2b0, waveBank != 0);
+    JUT_ASSERT(688, waveBank != 0);
     TPushCurrentHeap push(getHeap_());
     JASVoiceBank* voiceBank = new JASVoiceBank();
     if (voiceBank) {
         if (buildingBankTable_) {
-            JUT_ASSERT("JAUSectionHeap.cpp",0x2b8,buildingBankTable_->getBank( bank_no ) == 0);
+            JUT_ASSERT(696, buildingBankTable_->getBank( bank_no ) == 0);
             buildingBankTable_->registBank(bank_no, voiceBank);
         } else {
-            JUT_ASSERT("JAUSectionHeap.cpp",0x2bd, JASDefaultBankTable::getInstance() ->getBank( bank_no ) == 0);
+            JUT_ASSERT(701, JASDefaultBankTable::getInstance() ->getBank( bank_no ) == 0);
             JASDefaultBankTable::getInstance()->registBank(bank_no, voiceBank);
             data_.registeredBankTables.set(bank_no, true);
         }
@@ -718,9 +718,9 @@ asm JASVoiceBank* JAUSection::newVoiceBank(u32 param_0, u32 param_1) {
 // JAUBankTable inheritance
 #ifdef NONMATCHING
 bool JAUSection::beginNewBankTable(u32 param_0, u32 param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x2ca, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x2cb, isBuilding());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x2cc, buildingBankTable_ == 0);
+    JUT_ASSERT(714, isOpen());
+    JUT_ASSERT(715, isBuilding());
+    JUT_ASSERT(716, buildingBankTable_ == 0);
     JAUBankTableLink* bankTableLink = NULL;
     {
         TPushCurrentHeap push(getHeap_());
@@ -793,7 +793,7 @@ void JAUSectionHeap::releaseIdleDynamicSeqDataBlock() {
 
 /* 802A5F24-802A5F9C 2A0864 0078+00 1/1 0/0 0/0 .text JAUNewSectionHeap__FP12JKRSolidHeapb */
 static JAUSectionHeap* JAUNewSectionHeap(JKRSolidHeap* heap, bool param_1) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x329, JKRSolidHeap_isEmpty( heap ));
+    JUT_ASSERT(809, JKRSolidHeap_isEmpty( heap ));
     TPushCurrentHeap push(heap);
     s32 r29 = heap->getFreeSize();
     return new JAUSectionHeap(heap, param_1, r29);
@@ -803,7 +803,7 @@ static JAUSectionHeap* JAUNewSectionHeap(JKRSolidHeap* heap, bool param_1) {
 JAUSectionHeap* JAUNewSectionHeap(bool param_0) {
     s32 freeSize = JASDram->getFreeSize();
     JKRSolidHeap* sectionHeap = JKRCreateSolidHeap(freeSize, JASDram, true);
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x335, sectionHeap);
+    JUT_ASSERT(821, sectionHeap);
     return JAUNewSectionHeap(sectionHeap, param_0);
 }
 
@@ -840,9 +840,9 @@ bool JAUSectionHeap::setSeqDataUser(JAISeqDataUser* param_0) {
 
 /* 802A60AC-802A61D0 2A09EC 0124+00 0/0 2/2 0/0 .text newDynamicSeqBlock__14JAUSectionHeapFUl */
 bool JAUSectionHeap::newDynamicSeqBlock(u32 param_0) {
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x3a9, isOpen());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x3aa, isBuilding());
-    JUT_ASSERT("JAUSectionHeap.cpp", 0x3ab, sectionHeap_ == this);
+    JUT_ASSERT(937, isOpen());
+    JUT_ASSERT(938, isBuilding());
+    JUT_ASSERT(939, sectionHeap_ == this);
     TPushCurrentHeap push(base1.getHeap_());
     JAUSeqDataBlock * seqDataBlock = new JAUSeqDataBlock();
     if (!seqDataBlock) {
@@ -871,7 +871,7 @@ bool JAUSectionHeap::newDynamicSeqBlock(u32 param_0) {
 s32 JAUSectionHeap::getSeqData(JAISoundID param_0, JAISeqData* param_1) {
     for (JSULink<JAUSection> * link = mSectionList.getFirst(); link; link = link->getNext()) {
         s32 result = link->getObject()->data_.field_0x00.getSeqData(param_0, sectionHeapData_.seqDataUser, param_1, false);
-        JUT_ASSERT("JAUSectionHeap.cpp", 0x3e2, result != JAI_ASYNC_RESULT_RETRY);
+        JUT_ASSERT(994, result != JAI_ASYNC_RESULT_RETRY);
         if (result == 2) {
             return 2;
         }

--- a/libs/JSystem/JAudio2/JAUSeqCollection.cpp
+++ b/libs/JSystem/JAudio2/JAUSeqCollection.cpp
@@ -70,7 +70,7 @@ JAUSeqDataMgr_SeqCollection::JAUSeqDataMgr_SeqCollection() {
 /* 802A67D0-802A67DC 2A1110 000C+00 1/0 0/0 0/0 .text
  * setSeqDataUser__27JAUSeqDataMgr_SeqCollectionFP14JAISeqDataUser */
 bool JAUSeqDataMgr_SeqCollection::setSeqDataUser(JAISeqDataUser* param_0) {
-    JUT_ASSERT("JAUSeqCollection.cpp", 0x3c, user_ == 0);
+    JUT_ASSERT(60, user_ == 0);
     user_ = param_0;
     return true;
 }

--- a/libs/JSystem/JKernel/JKRDvdFile.cpp
+++ b/libs/JSystem/JKernel/JKRDvdFile.cpp
@@ -99,7 +99,7 @@ s32 JKRDvdFile::readData(void* param_1, long length, long param_3) {
     // The assert condition gets stringified as "( length & 0x1f ) == 0", 
     // with out disabling clang-format the spaces in the condition will  
     // get removed and the string will be incorrect.
-    JUT_ASSERT(__FILE__, 238, ( length & 0x1f ) == 0);
+    JUT_ASSERT(238, ( length & 0x1f ) == 0);
     /* clang-format on */
 
     OSLockMutex(&mMutex1);

--- a/libs/JSystem/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/JKernel/JKRHeap.cpp
@@ -156,7 +156,7 @@ void* JKRHeap::alloc(u32 size, int alignment, JKRHeap* heap) {
 /* 802CE4D4-802CE500 2C8E14 002C+00 1/1 30/30 1/1 .text            alloc__7JKRHeapFUli */
 void* JKRHeap::alloc(u32 size, int alignment) {
     if (mInitFlag) {
-        JUT_WARN(__FILE__, 393, "alloc %x byte in heap %x", size, this);
+        JUT_WARN(393, "alloc %x byte in heap %x", size, this);
     }
     return do_alloc(size, alignment);
 }
@@ -175,7 +175,7 @@ void JKRHeap::free(void* ptr, JKRHeap* heap) {
 /* 802CE548-802CE574 2C8E88 002C+00 1/1 29/29 0/0 .text            free__7JKRHeapFPv */
 void JKRHeap::free(void* ptr) {
     if (mInitFlag) {
-        JUT_WARN(__FILE__, 441, "free %x in heap %x", ptr, this);
+        JUT_WARN(441, "free %x in heap %x", ptr, this);
     }
     do_free(ptr);
 }
@@ -192,7 +192,7 @@ void JKRHeap::callAllDisposer() {
 /* 802CE5CC-802CE5F8 2C8F0C 002C+00 0/0 12/12 0/0 .text            freeAll__7JKRHeapFv */
 void JKRHeap::freeAll() {
     if (mInitFlag) {
-        JUT_WARN(__FILE__, 493, "freeAll in heap %x", this);
+        JUT_WARN(493, "freeAll in heap %x", this);
     }
     do_freeAll();
 }
@@ -200,7 +200,7 @@ void JKRHeap::freeAll() {
 /* 802CE5F8-802CE624 2C8F38 002C+00 0/0 1/1 0/0 .text            freeTail__7JKRHeapFv */
 void JKRHeap::freeTail() {
     if (mInitFlag) {
-        JUT_WARN(__FILE__, 507, "freeTail in heap %x", this);
+        JUT_WARN(507, "freeTail in heap %x", this);
     }
     do_freeTail();
 }
@@ -219,7 +219,7 @@ s32 JKRHeap::resize(void* ptr, u32 size, JKRHeap* heap) {
 /* 802CE684-802CE6B0 2C8FC4 002C+00 1/1 1/1 0/0 .text            resize__7JKRHeapFPvUl */
 s32 JKRHeap::resize(void* ptr, u32 size) {
     if (mInitFlag) {
-        JUT_WARN(__FILE__, 567, "resize block %x into %x in heap %x", ptr, size, this);
+        JUT_WARN(567, "resize block %x into %x in heap %x", ptr, size, this);
     }
     return do_resize(ptr, size);
 }
@@ -258,7 +258,7 @@ s32 JKRHeap::getTotalFreeSize() {
 /* 802CE7B0-802CE7DC 2C90F0 002C+00 0/0 1/1 0/0 .text            changeGroupID__7JKRHeapFUc */
 s32 JKRHeap::changeGroupID(u8 groupID) {
     if (mInitFlag) {
-        JUT_WARN(__FILE__, 646, "change heap ID into %x in heap %x", groupID, this);
+        JUT_WARN(646, "change heap ID into %x in heap %x", groupID, this);
     }
     return do_changeGroupID(groupID);
 }
@@ -482,22 +482,22 @@ void operator delete[](void* ptr) {
 /* 802CED84-802CED88 2C96C4 0004+00 1/0 1/0 0/0 .text
  * state_register__7JKRHeapCFPQ27JKRHeap6TStateUl               */
 u32 JKRHeap::state_register(JKRHeap::TState* p, u32 id) const {
-    JUT_ASSERT(__FILE__, 1213, p != 0);
-    JUT_ASSERT(__FILE__, 1214, p->getHeap() == this);
+    JUT_ASSERT(1213, p != 0);
+    JUT_ASSERT(1214, p->getHeap() == this);
 }
 
 /* 802CED88-802CEDA0 2C96C8 0018+00 1/0 1/0 0/0 .text
  * state_compare__7JKRHeapCFRCQ27JKRHeap6TStateRCQ27JKRHeap6TState */
 bool JKRHeap::state_compare(const JKRHeap::TState& r1, const JKRHeap::TState& r2) const {
-    JUT_ASSERT(__FILE__, 1222, r1.getHeap() == r2.getHeap());
+    JUT_ASSERT(1222, r1.getHeap() == r2.getHeap());
     return r1.getCheckCode() == r2.getCheckCode();
 }
 
 /* 802CEDA0-802CEDA4 2C96E0 0004+00 1/0 3/0 0/0 .text state_dump__7JKRHeapCFRCQ27JKRHeap6TState */
 void JKRHeap::state_dump(const JKRHeap::TState& p) const {
-    JUT_LOG(__FILE__, 1246, "check-code : 0x%08x", p.getCheckCode());
-    JUT_LOG(__FILE__, 1247, "id         : 0x%08x", p.getId());
-    JUT_LOG(__FILE__, 1248, "used size  : %u", p.getUsedSize());
+    JUT_LOG(1246, "check-code : 0x%08x", p.getCheckCode());
+    JUT_LOG(1247, "id         : 0x%08x", p.getId());
+    JUT_LOG(1248, "used size  : %u", p.getUsedSize());
 }
 
 /* 802CEDA4-802CEDAC 2C96E4 0008+00 1/0 1/0 0/0 .text            do_changeGroupID__7JKRHeapFUc */

--- a/libs/JSystem/JKernel/JKRSolidHeap.cpp
+++ b/libs/JSystem/JKernel/JKRSolidHeap.cpp
@@ -99,8 +99,8 @@ void* JKRSolidHeap::do_alloc(u32 size, int alignment) {
     // TODO(Julgodis): JUTAssertion::setConfirmMessage
     if (alignment != 0) {
         int u = abs(alignment);
-        JUT_ASSERT(__FILE__, 0xdb, u < 0x80);
-        JUT_ASSERT(__FILE__, 0xdc, JGadget::binary::isPower2(u));
+        JUT_ASSERT(219, u < 0x80);
+        JUT_ASSERT(220, JGadget::binary::isPower2(u));
     }
 #endif
 
@@ -266,8 +266,8 @@ bool JKRSolidHeap::dump(void) {
 /* 802D11FC-802D1258 2CBB3C 005C+00 1/0 0/0 0/0 .text
  * state_register__12JKRSolidHeapCFPQ27JKRHeap6TStateUl         */
 u32 JKRSolidHeap::state_register(JKRHeap::TState* p, u32 id) const {
-    JUT_ASSERT(__FILE__, 0x25c, p != 0);
-    JUT_ASSERT(__FILE__, 0x25d, p->getHeap() == this);
+    JUT_ASSERT(604, p != 0);
+    JUT_ASSERT(605, p->getHeap() == this);
 
     getState_(p);
     setState_u32ID_(p, id);
@@ -279,7 +279,7 @@ u32 JKRSolidHeap::state_register(JKRHeap::TState* p, u32 id) const {
 /* 802D1258-802D1288 2CBB98 0030+00 1/0 0/0 0/0 .text
  * state_compare__12JKRSolidHeapCFRCQ27JKRHeap6TStateRCQ27JKRHeap6TState */
 bool JKRSolidHeap::state_compare(JKRHeap::TState const& r1, JKRHeap::TState const& r2) const {
-    JUT_ASSERT(__FILE__, 632, r1.getHeap() == r2.getHeap());
+    JUT_ASSERT(632, r1.getHeap() == r2.getHeap());
 
     bool result = true;
     if (r1.getCheckCode() != r2.getCheckCode()) {

--- a/libs/JSystem/JKernel/JKRThread.cpp
+++ b/libs/JSystem/JKernel/JKRThread.cpp
@@ -143,7 +143,7 @@ JKRThreadSwitch::JKRThreadSwitch(JKRHeap* param_0) {
 /* 802D1A14-802D1A70 2CC354 005C+00 0/0 1/1 0/0 .text createManager__15JKRThreadSwitchFP7JKRHeap
  */
 JKRThreadSwitch* JKRThreadSwitch::createManager(JKRHeap* heap) {
-    JUT_ASSERT(__FILE__, 343, sManager == 0);
+    JUT_ASSERT(343, sManager == 0);
 
     if (!heap) {
         heap = JKRGetCurrentHeap();
@@ -224,7 +224,7 @@ void JKRThreadSwitch::callback(OSThread* current, OSThread* next) {
                 } else {
                     switch (thread->getCurrentHeapError()) {
                     case 0:
-                        JUT_PANIC(__FILE__, 508, "JKRThreadSwitch: currentHeap destroyed.");
+                        JUT_PANIC(508, "JKRThreadSwitch: currentHeap destroyed.");
                         break;
                     case 1:
                         JUTWarningConsole("JKRThreadSwitch: currentHeap destroyed.\n");

--- a/libs/Z2AudioLib/Z2AudioMgr.cpp
+++ b/libs/Z2AudioLib/Z2AudioMgr.cpp
@@ -299,7 +299,7 @@ void Z2AudioMgr::init(JKRSolidHeap* param_0, u32 param_1, void* param_2, JKRArch
     sectionHeap->newDynamicSeqBlock(resMaxSize);
     Z2AudioArcLoader stack_a0(sectionHeap);
     bool baaLoadResult = stack_a0.load(param_2);
-    JUT_ASSERT("Z2AudioMgr.cpp", 0xfc, baaLoadResult);
+    JUT_ASSERT(252, baaLoadResult);
     seqMgr->setSeqDataMgr(sectionHeap->getSeqDataMgr());
     if (sectionHeap->getStreamDataMgr()) {
         streamMgr->setStreamDataMgr(sectionHeap->getStreamDataMgr());


### PR DESCRIPTION
simplify the assert macros to not require manually calling __FILE__

## CC0 License Agreement
<!--
By submitting this pull request, I agree to comply with the terms of the Creative Commons Zero v1.0 Universal (CC0) Public Domain Dedication License for my contributions to this project.

I dedicate any and all copyright interest in this contribution to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

To the best of my knowledge and belief, my contribution is either originally created by me, or is derived from a source that also released its contents under CC0 or a compatible license.

I understand that this project and its maintainers are not responsible for enforcing the CC0 license, and I release them from any potential liability related to my contribution.
-->

- [X] I agree to the terms of the CC0 License.

<!--
Please check the checkbox above to indicate your agreement.
-->