### PR TITLE
JKRArchive

### DIFF
--- a/include/JSystem/JKernel/JKRAramArchive.h
+++ b/include/JSystem/JKernel/JKRAramArchive.h
@@ -27,8 +27,6 @@ public:
 private:
     /* 0x00 */  // vtable
     /* 0x04 */  // JKRArchive
-    /* 0x5C */ JKRCompression mCompression;
-    /* 0x60 */ EMountDirection mMountDirection;
     /* 0x64 */ JKRAramBlock* mBlock;
     /* 0x68 */ JKRDvdFile* mDvdFile;
 };  // Size = 0x6C

--- a/include/JSystem/JKernel/JKRArchive.h
+++ b/include/JSystem/JKernel/JKRArchive.h
@@ -182,6 +182,8 @@ public:
 
 protected:
     /* 0x58 */ u32 field_0x58;
+    /* 0x5C */ JKRCompression mCompression;
+    /* 0x60 */ EMountDirection mMountDirection;
 
 public:
     static JKRArchive* check_mount_already(s32, JKRHeap*);

--- a/include/JSystem/JKernel/JKRCompArchive.h
+++ b/include/JSystem/JKernel/JKRCompArchive.h
@@ -24,8 +24,6 @@ public:
 private:
     /* 0x00 */  // vtable
     /* 0x04 */  // JKRArchive
-    /* 0x5C */ int mCompression;
-    /* 0x60 */ EMountDirection mMountDirection;
     /* 0x64 */ int field_0x64;
     /* 0x68 */ JKRAramBlock* mAramPart;
     /* 0x6C */ int field_0x6c;

--- a/include/JSystem/JKernel/JKRDvdArchive.h
+++ b/include/JSystem/JKernel/JKRDvdArchive.h
@@ -23,8 +23,6 @@ public:
 private:
     /* 0x00 */  // vtable
     /* 0x04 */  // JKRArchive
-    /* 0x5C */ JKRCompression mCompression;
-    /* 0x60 */ EMountDirection mMountDirection;
     /* 0x64 */ s32 field_0x64;
     /* 0x68 */ JKRDvdFile* mDvdFile;
 };

--- a/include/JSystem/JKernel/JKRMemArchive.h
+++ b/include/JSystem/JKernel/JKRMemArchive.h
@@ -31,8 +31,6 @@ public:
 private:
     /* 0x00 */  // vtable
     /* 0x04 */  // JKRArchive
-    /* 0x5C */ JKRCompression mCompression;
-    /* 0x60 */ EMountDirection mMountDirection;
     /* 0x64 */ SArcHeader* mArcHeader;
     /* 0x68 */ u8* mArchiveData;
     /* 0x6C */ bool mIsOpen;

--- a/libs/JSystem/JKernel/JKRDvdArchive.cpp
+++ b/libs/JSystem/JKernel/JKRDvdArchive.cpp
@@ -80,7 +80,8 @@ extern "C" u8 sSystemHeap__7JKRHeap[4];
 /* 802D7BF0-802D7C98 2D2530 00A8+00 0/0 1/1 0/0 .text
  * __ct__13JKRDvdArchiveFlQ210JKRArchive15EMountDirection       */
 JKRDvdArchive::JKRDvdArchive(s32 entryNum, JKRArchive::EMountDirection mountDirection)
-    : JKRArchive(entryNum, MOUNT_DVD), mMountDirection(mountDirection) {
+    : JKRArchive(entryNum, MOUNT_DVD) {
+    mMountDirection = mountDirection;
     if (!open(entryNum))
         return;
 


### PR DESCRIPTION
Moves `mCompression` and `mMountDirection` from derived classes into `JKRArchive`. There's a `JKRArchive` constructor in the debug rom that assigns a value to `mMountDirection`, and there doesn't appear to be any difference in `JKRArchive` between debug and retail. The same constructor also appears in Wind Waker.

## CC0 License Agreement
<!--
By submitting this pull request, I agree to comply with the terms of the Creative Commons Zero v1.0 Universal (CC0) Public Domain Dedication License for my contributions to this project.

I dedicate any and all copyright interest in this contribution to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

To the best of my knowledge and belief, my contribution is either originally created by me, or is derived from a source that also released its contents under CC0 or a compatible license.

I understand that this project and its maintainers are not responsible for enforcing the CC0 license, and I release them from any potential liability related to my contribution.
-->

- [x] I agree to the terms of the CC0 License.

<!--
Please check the checkbox above to indicate your agreement.
-->