### PR TITLE
JKRHeap void state_register

### DIFF
--- a/include/JSystem/JKernel/JKRExpHeap.h
+++ b/include/JSystem/JKernel/JKRExpHeap.h
@@ -84,7 +84,7 @@ public:
     /* vt[18] */ virtual s32 do_getTotalFreeSize();                             /* override */
     /* vt[19] */ virtual s32 do_changeGroupID(u8 newGroupID);                   /* override */
     /* vt[20] */ virtual u8 do_getCurrentGroupId();                             /* override */
-    /* vt[21] */ virtual u32 state_register(JKRHeap::TState* p, u32 id) const; /* override */
+    /* vt[21] */ virtual void state_register(JKRHeap::TState* p, u32 id) const; /* override */
     /* vt[22] */ virtual bool state_compare(JKRHeap::TState const& r1,
                                             JKRHeap::TState const& r2) const; /* override */
 

--- a/include/JSystem/JKernel/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap.h
@@ -76,7 +76,7 @@ public:
     /* vt[18] */ virtual s32 do_getTotalFreeSize() = 0;
     /* vt[19] */ virtual s32 do_changeGroupID(u8 newGroupID);
     /* vt[20] */ virtual u8 do_getCurrentGroupId();
-    /* vt[21] */ virtual u32 state_register(JKRHeap::TState* p, u32 id) const;
+    /* vt[21] */ virtual void state_register(JKRHeap::TState* p, u32 id) const;
     /* vt[22] */ virtual bool state_compare(JKRHeap::TState const& r1, JKRHeap::TState const& r2) const;
     /* vt[23] */ virtual void state_dump(JKRHeap::TState const& p) const;
 

--- a/include/JSystem/JKernel/JKRSolidHeap.h
+++ b/include/JSystem/JKernel/JKRSolidHeap.h
@@ -39,7 +39,7 @@ public:
     /* vt[17] */ virtual void* do_getMaxFreeBlock(void); /* override */
     /* vt[18] */ virtual s32 do_getTotalFreeSize(void);  /* override */
 
-    /* vt[21] */ virtual u32 state_register(JKRHeap::TState*, u32) const; /* override */
+    /* vt[21] */ virtual void state_register(JKRHeap::TState*, u32) const; /* override */
     /* vt[22] */ virtual bool state_compare(JKRHeap::TState const&,
                                             JKRHeap::TState const&) const; /* override */
 

--- a/libs/JSystem/JKernel/JKRExpHeap.cpp
+++ b/libs/JSystem/JKernel/JKRExpHeap.cpp
@@ -1083,7 +1083,7 @@ JKRExpHeap::CMemBlock* JKRExpHeap::CMemBlock::getHeapBlock(void* ptr) {
 
 /* 802D0938-802D09E0 2CB278 00A8+00 1/0 0/0 0/0 .text
  * state_register__10JKRExpHeapCFPQ27JKRHeap6TStateUl           */
-u32 JKRExpHeap::state_register(JKRHeap::TState* p, u32 param_1) const {
+void JKRExpHeap::state_register(JKRHeap::TState* p, u32 param_1) const {
     p->mId = param_1;
     if (param_1 <= 0xff) {
         p->mUsedSize = getUsedSize(param_1);
@@ -1104,7 +1104,6 @@ u32 JKRExpHeap::state_register(JKRHeap::TState* p, u32 param_1) const {
         }
     }
     p->mCheckCode = checkCode;
-    return checkCode;
 }
 
 /* 802D09E0-802D0A10 2CB320 0030+00 1/0 0/0 0/0 .text

--- a/libs/JSystem/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/JKernel/JKRHeap.cpp
@@ -481,7 +481,7 @@ void operator delete[](void* ptr) {
 
 /* 802CED84-802CED88 2C96C4 0004+00 1/0 1/0 0/0 .text
  * state_register__7JKRHeapCFPQ27JKRHeap6TStateUl               */
-u32 JKRHeap::state_register(JKRHeap::TState* p, u32 id) const {
+void JKRHeap::state_register(JKRHeap::TState* p, u32 id) const {
     JUT_ASSERT(1213, p != 0);
     JUT_ASSERT(1214, p->getHeap() == this);
 }

--- a/libs/JSystem/JKernel/JKRSolidHeap.cpp
+++ b/libs/JSystem/JKernel/JKRSolidHeap.cpp
@@ -265,15 +265,16 @@ bool JKRSolidHeap::dump(void) {
 }
 /* 802D11FC-802D1258 2CBB3C 005C+00 1/0 0/0 0/0 .text
  * state_register__12JKRSolidHeapCFPQ27JKRHeap6TStateUl         */
-u32 JKRSolidHeap::state_register(JKRHeap::TState* p, u32 id) const {
+void JKRSolidHeap::state_register(JKRHeap::TState* p, u32 id) const {
     JUT_ASSERT(604, p != 0);
     JUT_ASSERT(605, p->getHeap() == this);
 
     getState_(p);
     setState_u32ID_(p, id);
     setState_uUsedSize_(p, getUsedSize((JKRSolidHeap*)this));
-    setState_u32CheckCode_(p, (u32)mSolidHead + (u32)mSolidTail * 3);
-    return (u32)mSolidHead + (u32)mSolidTail * 3;
+    u32 r29 = (u32)mSolidHead;
+    r29 += (u32)mSolidTail * 3;
+    setState_u32CheckCode_(p, r29);
 }
 
 /* 802D1258-802D1288 2CBB98 0030+00 1/0 0/0 0/0 .text


### PR DESCRIPTION
This resolves some fake matches, and also fixes the warning about JKRHeap::state_register not returning a value.

## CC0 License Agreement
<!--
By submitting this pull request, I agree to comply with the terms of the Creative Commons Zero v1.0 Universal (CC0) Public Domain Dedication License for my contributions to this project.

I dedicate any and all copyright interest in this contribution to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this contribution under copyright law.

To the best of my knowledge and belief, my contribution is either originally created by me, or is derived from a source that also released its contents under CC0 or a compatible license.

I understand that this project and its maintainers are not responsible for enforcing the CC0 license, and I release them from any potential liability related to my contribution.
-->

- [x] I agree to the terms of the CC0 License.

<!--
Please check the checkbox above to indicate your agreement.
-->