### PR TITLE
remove dkp dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiler binaries
 mwcc_compiler/
+binutils/
 
 # Build artifacts
 build/

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ else
 	SHA1SUM := sha1sum
 endif
 
-AS        		:= $(DEVKITPPC)/bin/powerpc-eabi-as
-OBJCOPY   		:= $(DEVKITPPC)/bin/powerpc-eabi-objcopy
-STRIP     		:= $(DEVKITPPC)/bin/powerpc-eabi-strip
+AS        		:= tools/binutils/powerpc-eabi-as
+OBJCOPY   		:= tools/binutils/powerpc-eabi-objcopy
+STRIP     		:= tools/binutils/powerpc-eabi-strip
 CC        		:= $(WINE) tools/mwcc_compiler/$(MWCC_VERSION)/mwcceppc_modded.exe
 DOLPHIN_LIB_CC 	:= $(WINE) tools/mwcc_compiler/1.2.5n/mwcceppc.exe
 LD        		:= $(WINE_LD) tools/mwcc_compiler/$(MWCC_VERSION)/mwldeppc.exe

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -17,4 +17,4 @@ def apply(config, args):
         config['makeflags'].append('DEBUG=1')
     config['source_directories'] = ['src', 'libs', 'include', 'rel']
     config['arch'] = 'ppc'
-    config['objdump_executable'] = f"{os.environ['DEVKITPPC']}/bin/powerpc-eabi-objdump"
+    config['objdump_executable'] = f"tools/binutils/powerpc-eabi-objdump"

--- a/tools/tp.py
+++ b/tools/tp.py
@@ -122,6 +122,15 @@ def expected_copy(debug: bool, build_path: Path, expected_path: Path):
     shutil.copytree(build_path, expected_path, dirs_exist_ok=True)
 
 
+COMPILERS_TAG = "20230715"
+BINUTILS_TAG = "2.42-1"
+BINUTILS_ZIP = "linux-x86_64"
+
+if platform.system() == "Windows":
+    BINUTILS_ZIP = "windows-x86_64"
+elif platform.system() == "Darwin":
+    BINUTILS_ZIP = "macos-universal"
+
 @tp.command(name="setup")
 @click.option("--debug/--no-debug")
 @click.option(
@@ -171,7 +180,7 @@ def setup(debug: bool, game_path: Path, tools_path: Path, yaz0_encoder: str, for
         shutil.rmtree(compilers)
     if not compilers.exists() or not compilers.is_dir():
         os.mkdir(compilers)
-        r = requests.get('https://files.decomp.dev/compilers_20230715.zip')
+        r = requests.get(f'https://files.decomp.dev/compilers_{COMPILERS_TAG}.zip')
         z = zipfile.ZipFile(io.BytesIO(r.content))
         z.extractall(compilers)
         gc_path = compilers.joinpath("GC")
@@ -182,6 +191,22 @@ def setup(debug: bool, game_path: Path, tools_path: Path, yaz0_encoder: str, for
             dst_path = os.path.join(compilers, f)
             shutil.move(src_path, dst_path)
         os.rmdir(gc_path)
+
+    #
+    text = Text("--- Fetching binutils")
+    text.stylize("bold magenta")
+    CONSOLE.print(text)
+
+    binutils = tools_path.joinpath("binutils")
+    if force_download:
+        shutil.rmtree(binutils)
+    if not binutils.exists() or not binutils.is_dir():
+        os.mkdir(binutils)
+        r = requests.get(f'https://github.com/encounter/gc-wii-binutils/releases/download/{BINUTILS_TAG}/{BINUTILS_ZIP}.zip')
+        z = zipfile.ZipFile(io.BytesIO(r.content))
+        z.extractall(binutils)
+        if os.name == 'posix':
+            subprocess.run(['chmod', '+x'] + list(binutils.glob("*")))
 
     #
     text = Text("--- Patching compiler")


### PR DESCRIPTION
removes devkitpro dependency and instead downloads GC binutils from https://github.com/encounter/gc-wii-binutils