### PR TITLE
Update cLib_calcTimer

### DIFF
--- a/include/SSystem/SComponent/c_lib.h
+++ b/include/SSystem/SComponent/c_lib.h
@@ -87,8 +87,7 @@ inline T cLib_maxLimit(T val, T max) {
 
 template <typename T>
 T cLib_calcTimer(T* value) {
-    // Casting 0 to u16 may not be correct, but is matching for now
-    if (*value != (u16)0) {
+    if (*(T*)value != 0) {
         *value = *value - 1;
     }
     return *value;


### PR DESCRIPTION
Removed u16 cast from cLib_calcTimer.

This fixed cLib_calcTimer\<signed char> in WW, so it seems to be correct.