### PR TITLE
Fix CI checkout speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,9 @@ jobs:
         version: [GZ2E01]
 
     steps:
-    # Checkout the repository (shallow clone)
+    # Checkout the repository
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
 
     # Set Git config
     - name: Git config


### PR DESCRIPTION
`fetch-depth: 0` was doing the opposite of what it was intended to. It turns out `fetch-depth: 1` was the desired behavior, and coincidentally is the default, so we can simplify this.