### PR TITLE
Update dtk-template & fix source paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,9 @@ Building
   git clone https://github.com/zeldaret/tp.git
   ```
 
-- Copy your disc image to `orig/GZ2E01`.  
-  Supported formats: ISO (GCM), RVZ, WIA, WBFS, CISO, NFS, GCZ, TGC.
-  - To save space, extract the disc image and keep only the following files:
-    - `sys/main.dol`
-    - `files/RELS.arc`
-    - `files/rel/**/*.rel`
+- Copy your game's disc image to `orig/GZ2E01`.
+  - Supported formats: ISO (GCM), RVZ, WIA, WBFS, CISO, NFS, GCZ, TGC.
+  - After the initial build, the disc image can be deleted to save space.
 
 - Configure:
 

--- a/config/GZ2E01/splits.txt
+++ b/config/GZ2E01/splits.txt
@@ -3326,7 +3326,7 @@ PowerPC_EABI_Support/Runtime/Src/Gecko_ExceptionPPC.cp:
 	.text       start:0x803628AC end:0x80362914
 	.bss        start:0x8044D430 end:0x8044D440
 
-PowerPC_EABI_Support/Runtime/Src/GCN_mem_alloc.c:
+PowerPC_EABI_Support/Runtime/Src/GCN_Mem_Alloc.c:
 	.text       start:0x80362914 end:0x803629CC
 	.rodata     start:0x803A21A8 end:0x803A2220
 
@@ -3364,7 +3364,7 @@ PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/buffer_io.c:
 PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/char_io.c:
 	.text       start:0x803651D8 end:0x80365464
 
-PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/critical_regions.gamecube.c:
+PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/Src/critical_regions.gamecube.c:
 	.text       start:0x80365464 end:0x80365470
 
 PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/ctype.c:
@@ -3420,7 +3420,7 @@ PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/strtoul.c:
 PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wchar_io.c:
 	.text       start:0x80369114 end:0x8036919C
 
-PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/uart_console_io_gcn.c:
+PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/Src/uart_console_io_gcn.c:
 	.text       start:0x8036919C end:0x80369274
 	.sbss       start:0x804519B0 end:0x804519B8
 
@@ -3534,7 +3534,7 @@ PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_sqrt.
 	.text       start:0x8036C7A0 end:0x8036C9C4
 	.sdata2     start:0x80456B48 end:0x80456B50
 
-PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/math_ppc.c:
+PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/Src/math_ppc.c:
 	.text       start:0x8036C9C4 end:0x8036CA54
 
 PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_sqrt.c:

--- a/configure.py
+++ b/configure.py
@@ -151,9 +151,9 @@ if not config.non_matching:
 # Tool versions
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20240706"
-config.dtk_tag = "v1.1.2"
-config.objdiff_tag = "v2.3.2"
-config.sjiswrap_tag = "v1.1.1"
+config.dtk_tag = "v1.2.0"
+config.objdiff_tag = "v2.3.4"
+config.sjiswrap_tag = "v1.2.0"
 config.wibo_tag = "0.6.11"
 
 # Project
@@ -1200,7 +1200,7 @@ config.libs = [
             Object(Matching, "PowerPC_EABI_Support/Runtime/Src/runtime.c"),
             Object(NonMatching, "PowerPC_EABI_Support/Runtime/Src/__init_cpp_exceptions.cpp"),
             Object(Matching, "PowerPC_EABI_Support/Runtime/Src/Gecko_ExceptionPPC.cp"),
-            Object(Matching, "PowerPC_EABI_Support/Runtime/Src/GCN_mem_alloc.c", extra_cflags=["-str reuse,nopool,readonly"]),
+            Object(Matching, "PowerPC_EABI_Support/Runtime/Src/GCN_Mem_Alloc.c", extra_cflags=["-str reuse,nopool,readonly"]),
         ],
     },
     {
@@ -1218,7 +1218,7 @@ config.libs = [
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/arith.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/buffer_io.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/char_io.c"),
-            Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/critical_regions.gamecube.c"),
+            Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/Src/critical_regions.gamecube.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/ctype.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/direct_io.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/file_io.c"),
@@ -1234,7 +1234,7 @@ config.libs = [
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/string.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/strtoul.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/wchar_io.c"),
-            Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/uart_console_io_gcn.c"),
+            Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/Src/uart_console_io_gcn.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_acos.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_asin.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_atan2.c"),
@@ -1263,7 +1263,7 @@ config.libs = [
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_fmod.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_pow.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/e_sqrt.c"),
-            Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/SRC/math_ppc.c"),
+            Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/PPC_EABI/Src/math_ppc.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common_Embedded/Math/Double_precision/w_sqrt.c"),
             Object(Matching, "PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/extras.c"),
         ],

--- a/tools/download_tool.py
+++ b/tools/download_tool.py
@@ -55,6 +55,7 @@ def dtk_url(tag: str) -> str:
     repo = "https://github.com/encounter/decomp-toolkit"
     return f"{repo}/releases/download/{tag}/dtk-{system}-{arch}{suffix}"
 
+
 def objdiff_cli_url(tag: str) -> str:
     uname = platform.uname()
     suffix = ""

--- a/tools/ninja_syntax.py
+++ b/tools/ninja_syntax.py
@@ -24,17 +24,10 @@ import textwrap
 import os
 from io import StringIO
 from pathlib import Path
-from typing import Dict, List, Match, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Match, Optional, Tuple, Union
 
 NinjaPath = Union[str, Path]
-NinjaPaths = Union[
-    List[str],
-    List[Path],
-    List[NinjaPath],
-    List[Optional[str]],
-    List[Optional[Path]],
-    List[Optional[NinjaPath]],
-]
+NinjaPaths = Iterable[Optional[NinjaPath]]
 NinjaPathOrPaths = Union[NinjaPath, NinjaPaths]
 
 
@@ -118,8 +111,8 @@ class Writer(object):
         pool: Optional[str] = None,
         dyndep: Optional[NinjaPath] = None,
     ) -> List[str]:
-        outputs = serialize_paths(outputs)
-        out_outputs = [escape_path(x) for x in outputs]
+        str_outputs = serialize_paths(outputs)
+        out_outputs = [escape_path(x) for x in str_outputs]
         all_inputs = [escape_path(x) for x in serialize_paths(inputs)]
 
         if implicit:
@@ -154,7 +147,7 @@ class Writer(object):
             for key, val in iterator:
                 self.variable(key, val, indent=1)
 
-        return outputs
+        return str_outputs
 
     def include(self, path: str) -> None:
         self._line("include %s" % path)
@@ -225,9 +218,11 @@ def serialize_path(input: Optional[NinjaPath]) -> str:
 
 
 def serialize_paths(input: Optional[NinjaPathOrPaths]) -> List[str]:
-    if isinstance(input, list):
+    if isinstance(input, str) or isinstance(input, Path):
+        return [serialize_path(input)] if input else []
+    elif input is not None:
         return [serialize_path(path) for path in input if path]
-    return [serialize_path(input)] if input else []
+    return []
 
 
 def escape(string: str) -> str:


### PR DESCRIPTION
Updates to the latest dtk-template tools & changes. Updates README.md to reflect the new behavior where dtk auto-extracts the required game files, so the disc image can be deleted to save space.

A few source file paths had mismatched casing, which only shows up on case-sensitive filesystems (or in Actions: https://github.com/zeldaret/tp/actions/runs/11602803503/job/32308527565#step:6:18). I went ahead and resolved these. (I should probably add an explicit check for this in dtk-template)