### PR TITLE
d_a_obj_kwheel00, 01, & d_a_obj_klift00 Equivalent (weak func and/or vtable order)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1506,7 +1506,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_kanban2"),
     ActorRel(NonMatching, "d_a_obj_kbacket"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_kgate"),
-    ActorRel(NonMatching, "d_a_obj_klift00"),
+    ActorRel(Equivalent, "d_a_obj_klift00"), # vtable order
     ActorRel(NonMatching, "d_a_obj_ktOnFire"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_ladder"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lv2Candle"),
@@ -1913,8 +1913,8 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_knBullet"),
     ActorRel(NonMatching, "d_a_obj_kshutter"),
     ActorRel(NonMatching, "d_a_obj_kuwagata"),
-    ActorRel(NonMatching, "d_a_obj_kwheel00"),
-    ActorRel(NonMatching, "d_a_obj_kwheel01"),
+    ActorRel(Equivalent, "d_a_obj_kwheel00"), # weak func order
+    ActorRel(Equivalent, "d_a_obj_kwheel01"), # weak func order
     ActorRel(NonMatching, "d_a_obj_kznkarm"),
     ActorRel(NonMatching, "d_a_obj_laundry"),
     ActorRel(NonMatching, "d_a_obj_laundry_rope"),

--- a/include/d/actor/d_a_obj_bky_rock.h
+++ b/include/d/actor/d_a_obj_bky_rock.h
@@ -17,8 +17,6 @@ class daBkyRock_c : public fopAc_ac_c, public request_of_phase_process_class {
 public:
     struct _pieceData {
     public:
-        /* 80BB6914 */ _pieceData() { mMdlObj.mpObj = NULL; }
-
         /* 0x00 */ dMdl_obj_c mMdlObj;
         /* 0x34 */ Vec position;
         /* 0x40 */ f32 targetX;

--- a/include/d/actor/d_a_obj_klift00.h
+++ b/include/d/actor/d_a_obj_klift00.h
@@ -72,13 +72,15 @@ struct daObjKLift00_HIO_c : public mDoHIO_entry_c {
     daObjKLift00_HIO_c();
     ~daObjKLift00_HIO_c() {};
 
-    /* 0x04 */ f32 mChainGravity;  // "チェイン重力" "Chain gravity" | Slider
-    /* 0x08 */ f32 mRideParameters;  // "Ride パラメータ" "Ride parameters" | Slider
-    /* 0x0C */ f32 mWindSwayOccuranceFactor;  // "風影響発生率" "Wind effect occurence rate" | Slider
-    /* 0x10 */ f32 mWindMagnitudeChain;  // "鎖・風" "Chain・Wind" | Slider
-    /* 0x14 */ f32 mWindMagnitudeFoundation;  // "土台・風" "Foundation・Wind" | Slider
-    /* 0x18 */ f32 mChainHitSpeed;  // "鎖ヒット速度" "Chain hit speed" | Slider
-    /* 0x1C */ f32 field_0x1C;  // "ハンマー調整" "Hammer adjustment" | Slider
+    void genMessage(JORMContext*);
+
+    /* 0x04 */ f32 mChainGravity;
+    /* 0x08 */ f32 mRideParameters;
+    /* 0x0C */ f32 mWindSwayOccuranceFactor;
+    /* 0x10 */ f32 mWindMagnitudeChain;
+    /* 0x14 */ f32 mWindMagnitudeFoundation;
+    /* 0x18 */ f32 mChainHitSpeed;
+    /* 0x1C */ f32 field_0x1C;
 };
 
 #endif /* D_A_OBJ_KLIFT00_H */

--- a/include/d/actor/d_a_obj_klift00.h
+++ b/include/d/actor/d_a_obj_klift00.h
@@ -1,37 +1,87 @@
 #ifndef D_A_OBJ_KLIFT00_H
 #define D_A_OBJ_KLIFT00_H
 
+#include "SSystem/SComponent/c_phase.h"
+#include "d/d_bg_s_movebg_actor.h"
+#include "d/d_cc_d.h"
+#include "d/d_model.h"
+#include "f_op/f_op_actor.h"
 #include "f_op/f_op_actor_mng.h"
+#include "m_Do/m_Do_hostIO.h"
 
 /**
  * @ingroup actors-objects
  * @class daObjKLift00_c
- * @brief Water Wheel Lift?
+ * @brief Water Wheel/Gear Lift
  *
- * @details
+ * @details Lakebed temple lifts connected to large water wheels/gears (see d_a_obj_kwheel01) by chains
  *
  */
-class daObjKLift00_c : public fopAc_ac_c {
+class daObjKLift00_c : public dBgS_MoveBgActor, public request_of_phase_process_class {
 public:
-    struct ChainPos {
-        /* 8058C338 */ ~ChainPos();
-        /* 8058C374 */ ChainPos();
-    };
-
-    /* 8058B02C */ void create1st();
+    /* 8058B02C */ cPhs__Step create1st();
     /* 8058B0D0 */ void setMtx();
     /* 8058B4B0 */ void rideActor(fopAc_ac_c*);
-    /* 8058B5EC */ void CreateHeap();
-    /* 8058B77C */ void Create();
-    /* 8058B97C */ void Execute(f32 (**)[3][4]);
-    /* 8058BEEC */ void Draw();
-    /* 8058C014 */ void Delete();
+    /* 8058B5EC */ int CreateHeap();
+    /* 8058B77C */ int Create();
+    /* 8058B97C */ int Execute(Mtx**);
+    /* 8058BEEC */ int Draw();
+    /* 8058C014 */ int Delete();
+
+    enum Param_e {
+        LOCK_e = (1 << 6), NO_BASE_DISP = (1 << 7)
+    };
 
 private:
-    /* 0x568 */ u8 field_0x568[0x1160 - 0x568];
+    struct ChainPos {
+        cXyz mDeltaPosVector;
+        cXyz mCurrentPos;
+        cXyz mPrevPos;
+    };
+
+    /* 0x05A8 */ Mtx mNewBgMtx;
+    /* 0x05D8 */ Mtx mCullMtx;
+    /* 0x0608 */ J3DModel* mpLiftPlatform;
+    /* 0x060C */ J3DModel* mpChainBase;
+    /* 0x0610 */ J3DModelData* mChainModelData;     // JUT_ASSERT string shows this was called mChainModelData
+    /* 0x0614 */ int mNumChains;                    // Foundation "chain" is the bottom-most "chain" (doesn't have an associated chain model), and is used to transform the platform itself; = 1 + mNumChainModels
+    /* 0x0618 */ ChainPos* mChainPositions;
+    /* 0x061C */ int mNumChainModels;
+    /* 0x0620 */ dMdl_obj_c* mChainMdlObjs;
+    /* 0x0624 */ dCcD_Stts mStts;
+    /* 0x0660 */ dCcD_Sph mChainSphereColliders[8];
+    /* 0x1020 */ dCcD_Cyl mCylinderCollider;
+    /* 0x115C */ s32 mStopSwingingFrames;
+
+    // Number of chain models
+    u32 getArg0() {
+        return fopAcM_GetParamBit(this, 0, 6);
+    }
+
+    // Determines whether lift swinging should be dampened upon creation
+    u32 getLock() {
+        return fopAcM_GetParamBit(this, 6, 1);
+    }
+
+    // Determines whether the metal base from which the chain hands should be drawn (Drawn if 0)
+    u32 getNoBaseDisp() {
+        return fopAcM_GetParamBit(this, 7, 1);
+    }
 };
 
 STATIC_ASSERT(sizeof(daObjKLift00_c) == 0x1160);
 
+struct daObjKLift00_HIO_c : public mDoHIO_entry_c {
+    daObjKLift00_HIO_c();
+    ~daObjKLift00_HIO_c() {};
+
+    /* 0x04 */ f32 mChainGravity;  // "チェイン重力" "Chain gravity" | Slider
+    /* 0x08 */ f32 mRideParameters;  // "Ride パラメータ" "Ride parameters" | Slider
+    /* 0x0C */ f32 mWindSwayOccuranceFactor;  // "風影響発生率" "Wind effect occurence rate" | Slider
+    /* 0x10 */ f32 mWindMagnitudeChain;  // "鎖・風" "Chain・Wind" | Slider
+    /* 0x14 */ f32 mWindMagnitudeFoundation;  // "土台・風" "Foundation・Wind" | Slider
+    /* 0x18 */ f32 mChainHitSpeed;  // "鎖ヒット速度" "Chain hit speed" | Slider
+    /* 0x1C */ f32 field_0x1C;  // "ハンマー調整" "Hammer adjustment" | Slider
+};
 
 #endif /* D_A_OBJ_KLIFT00_H */

--- a/include/d/actor/d_a_obj_klift00.h
+++ b/include/d/actor/d_a_obj_klift00.h
@@ -1,13 +1,10 @@
 #ifndef D_A_OBJ_KLIFT00_H
 #define D_A_OBJ_KLIFT00_H
 
-#include "SSystem/SComponent/c_phase.h"
 #include "d/d_bg_s_movebg_actor.h"
 #include "d/d_cc_d.h"
 #include "d/d_model.h"
-#include "f_op/f_op_actor.h"
 #include "f_op/f_op_actor_mng.h"
-#include "m_Do/m_Do_hostIO.h"
 
 /**
  * @ingroup actors-objects

--- a/include/d/actor/d_a_obj_kwheel00.h
+++ b/include/d/actor/d_a_obj_kwheel00.h
@@ -1,33 +1,79 @@
 #ifndef D_A_OBJ_KWHEEL00_H
 #define D_A_OBJ_KWHEEL00_H
 
+#include "d/d_bg_s_movebg_actor.h"
+#include "d/d_cc_d.h"
+#include "d/d_event_lib.h"
 #include "f_op/f_op_actor_mng.h"
 
 /**
  * @ingroup actors-objects
  * @class daObjKWheel00_c
- * @brief Water Wheel 00?
+ * @brief Water Wheel/Gear
  *
- * @details
- *
+ * @details Lakebed temple water wheels/gears without clawshot targets.
+ * There are two types:
+ *  1.) Larger gold-colored ones that are completely solid and lie near the end of the long axle
+ *  2.) Smaller dark-colored ones where the largest gear teeth are grated and lie centered on a short axle (seen on bridges to/from central room)
  */
-class daObjKWheel00_c : public fopAc_ac_c {
+
+class daObjKWheel00_c : public dBgS_MoveBgActor, public request_of_phase_process_class, public dEvLib_callback_c {
 public:
-    /* 80C4D6F8 */ void create1st();
+    daObjKWheel00_c() : dEvLib_callback_c(this) {}
+    ~daObjKWheel00_c() {}
+
+    /* 80C4D6F8 */ int create1st();
     /* 80C4D86C */ void setMtx();
-    /* 80C4D9B8 */ void CreateHeap();
-    /* 80C4DA38 */ void Create();
-    /* 80C4DBBC */ void Execute(f32 (**)[3][4]);
-    /* 80C4E1B0 */ void Draw();
-    /* 80C4E254 */ void Delete();
-    /* 80C4E298 */ void eventStart();
-    /* 80C4E6E4 */ ~daObjKWheel00_c();
+    /* 80C4D9B8 */ int CreateHeap();
+    /* 80C4DA38 */ int Create();
+    /* 80C4DBBC */ int Execute(Mtx**);
+    /* 80C4E1B0 */ int Draw();
+    /* 80C4E254 */ int Delete();
+    /* 80C4E298 */ BOOL eventStart();
+
+    int getSwNo() {
+        return fopAcM_GetParamBit(this, 0, 8);
+    }
+
+    u32 getType() {
+        return fopAcM_GetParamBit(this,17,1);
+    }
+
+    enum Type_e { TYPE_LARGE_GOLD, TYPE_SMALL_PLATINUM };
 
 private:
-    /* 0x568 */ u8 field_0x568[0xb44 - 0x568];
+    enum QuadrantalAngle_e { DEG_INVALID = -1, DEG_0, DEG_90, DEG_180, DEG_270, DEG_MAX};
+
+    /* 0x5B8 */ Mtx mNewBgMtx;
+    /* 0x5E8 */ Mtx mTransformMtx;
+    /* 0x618 */ J3DModel* mpModel;
+    /* 0x61C */ s16 mZAngularVelocity;
+    /* 0x620 */ Type_e m_type;    // JUT_ASSERT string shows this was called m_type
+    /* 0x624 */ dCcD_Stts mStts;
+    /* 0x660 */ dCcD_Sph mLargeGearTeethSphereColliders[4];
+    /* 0xB40 */ QuadrantalAngle_e mPrevQuadrantalZAngle;
+
+    // Determines rotational direction of gear; 0 = counter-clockwise, 1 = clockwise
+    u32 getArg0() {
+        return fopAcM_GetParamBit(this, 8, 1);
+    }
+
+    s32 getEvent() {
+        return fopAcM_GetParamBit(this, 9, 8);
+    }
+
+    
 };
+
 
 STATIC_ASSERT(sizeof(daObjKWheel00_c) == 0xb44);
 
+struct daObjKWheel00_HIO_c : public mDoHIO_entry_c {
+    daObjKWheel00_HIO_c();
+    ~daObjKWheel00_HIO_c();
+
+    /* 0x4 */ s16 mTargetZAngularSpeed;    // "回転速度(short)" "Rotational speed(short)" | Slider
+    /* 0x6 */ s16 mZAngularAcceleration;    // "回転加速度(short) "Rotational acceleration(short)" | Slider
+};
 
 #endif /* D_A_OBJ_KWHEEL00_H */

--- a/include/d/actor/d_a_obj_kwheel00.h
+++ b/include/d/actor/d_a_obj_kwheel00.h
@@ -72,8 +72,10 @@ struct daObjKWheel00_HIO_c : public mDoHIO_entry_c {
     daObjKWheel00_HIO_c();
     ~daObjKWheel00_HIO_c();
 
-    /* 0x4 */ s16 mTargetZAngularSpeed;    // "回転速度(short)" "Rotational speed(short)" | Slider
-    /* 0x6 */ s16 mZAngularAcceleration;    // "回転加速度(short) "Rotational acceleration(short)" | Slider
+    void genMessage(JORMContext*);
+
+    /* 0x4 */ s16 mTargetZAngularSpeed;
+    /* 0x6 */ s16 mZAngularAcceleration;
 };
 
 #endif /* D_A_OBJ_KWHEEL00_H */

--- a/include/d/actor/d_a_obj_kwheel01.h
+++ b/include/d/actor/d_a_obj_kwheel01.h
@@ -1,33 +1,82 @@
 #ifndef D_A_OBJ_KWHEEL01_H
 #define D_A_OBJ_KWHEEL01_H
 
+#include "SSystem/SComponent/c_phase.h"
+#include "d/actor/d_a_obj_klift00.h"
+#include "d/d_bg_s_movebg_actor.h"
+#include "d/d_event_lib.h"
+#include "f_op/f_op_actor.h"
 #include "f_op/f_op_actor_mng.h"
+#include "d/d_bg_w.h"
 
 /**
  * @ingroup actors-objects
  * @class daObjKWheel01_c
- * @brief Water Wheel 01?
+ * @brief Water Wheel/Gear
  *
- * @details
- *
+ * @details Lakebed temple large water wheels/gears with clawshot targets and/or lifts
  */
-class daObjKWheel01_c : public fopAc_ac_c {
+class daObjKWheel01_c : public dBgS_MoveBgActor, public request_of_phase_process_class, public dEvLib_callback_c {
 public:
-    /* 80C4EA78 */ void create1st();
+    daObjKWheel01_c() : dEvLib_callback_c(this) {}
+    ~daObjKWheel01_c() {};
+
+    /* 80C4EA78 */ cPhs__Step create1st();
     /* 80C4EC54 */ void setMtx();
-    /* 80C4EDCC */ void CreateHeap();
-    /* 80C4EF38 */ void Create();
-    /* 80C4F048 */ void Execute(f32 (**)[3][4]);
-    /* 80C4F344 */ void Draw();
-    /* 80C4F3E8 */ void Delete();
-    /* 80C4F498 */ void eventStart();
-    /* 80C4F60C */ ~daObjKWheel01_c();
+    /* 80C4EDCC */ int CreateHeap();
+    /* 80C4EF38 */ int Create();
+    /* 80C4F048 */ int Execute(Mtx**);
+    /* 80C4F344 */ int Draw();
+    /* 80C4F3E8 */ int Delete();
+    /* 80C4F498 */ BOOL eventStart();
 
 private:
-    /* 0x568 */ u8 field_0x568[0x704 - 0x568];
+    /* 0x5B8 */ Mtx mNewBgMtx;
+    /* 0x5E8 */ Mtx mTransformMtx;
+    /* 0x618 */ J3DModel* mpModel;
+    /* 0x61C */ s16 mYAngularVelocity;
+    /* 0x620 */ fpc_ProcID m_klift_pid[4];  // JUT_ASSERT debug string shows this was called m_klift_pid
+    /* 0x630 */ dBgW* mKLiftCollisions[4];
+    /* 0x640 */ Mtx mKLiftBaseMatrices[4];
+    /* 0x700 */ u8 mCreatedKLifts;
+
+    // Switch number to check if water is flowing and the gear should turn, and whether the gear should accelerate to the target speed or start off at it
+    int getSwNo() {
+        return fopAcM_GetParamBit(this, 0, 8);
+    }
+
+    // Determines rotational direction of gear; 0 = counter-clockwise, 1 = clockwise
+    u32 getArg0() {
+        return fopAcM_GetParamBit(this, 8, 1);
+    }
+
+    int getEvent() {
+        return fopAcM_GetParamBit(this, 9, 8);
+    }
+
+    // Determines the number of chain models each lift should use
+    u32 getArg2() {
+        return fopAcM_GetParamBit(this, 17, 6);
+    }
+
+    // Determines whether each of 4 potential lifts should be created and/or updated
+    u32 getArg4567() {
+        return fopAcM_GetParamBit(this, 23, 4);
+    }
+
+    u32 getOut() {
+        return fopAcM_GetParamBit(this, 27, 1);
+    }
 };
 
 STATIC_ASSERT(sizeof(daObjKWheel01_c) == 0x704);
 
+struct daObjKWheel01_HIO_c : public mDoHIO_entry_c {
+    daObjKWheel01_HIO_c();
+    ~daObjKWheel01_HIO_c() {};
+
+    /* 0x4 */ s16 mTargetYAngularSpeed;    // "回転速度(short)" "Rotational speed(short)" | Slider
+    /* 0x6 */ s16 mYAngularAcceleration;    // "回転加速度(short) "Rotational acceleration(short)" | Slider
+};
 
 #endif /* D_A_OBJ_KWHEEL01_H */

--- a/include/d/actor/d_a_obj_kwheel01.h
+++ b/include/d/actor/d_a_obj_kwheel01.h
@@ -72,8 +72,10 @@ struct daObjKWheel01_HIO_c : public mDoHIO_entry_c {
     daObjKWheel01_HIO_c();
     ~daObjKWheel01_HIO_c() {};
 
-    /* 0x4 */ s16 mTargetYAngularSpeed;    // "回転速度(short)" "Rotational speed(short)" | Slider
-    /* 0x6 */ s16 mYAngularAcceleration;    // "回転加速度(short) "Rotational acceleration(short)" | Slider
+    void genMessage(JORMContext*);
+
+    /* 0x4 */ s16 mTargetYAngularSpeed;
+    /* 0x6 */ s16 mYAngularAcceleration;
 };
 
 #endif /* D_A_OBJ_KWHEEL01_H */

--- a/include/d/actor/d_a_obj_kwheel01.h
+++ b/include/d/actor/d_a_obj_kwheel01.h
@@ -1,13 +1,10 @@
 #ifndef D_A_OBJ_KWHEEL01_H
 #define D_A_OBJ_KWHEEL01_H
 
-#include "SSystem/SComponent/c_phase.h"
-#include "d/actor/d_a_obj_klift00.h"
+
 #include "d/d_bg_s_movebg_actor.h"
 #include "d/d_event_lib.h"
-#include "f_op/f_op_actor.h"
 #include "f_op/f_op_actor_mng.h"
-#include "d/d_bg_w.h"
 
 /**
  * @ingroup actors-objects

--- a/include/d/d_model.h
+++ b/include/d/d_model.h
@@ -9,6 +9,7 @@ class dKy_tevstr_c;
 
 class dMdl_obj_c {
 public:
+    dMdl_obj_c() : mpObj(NULL) {}
     MtxP getMtx() { return mMtx; }
     void setMtx(Mtx mtx) { cMtx_copy(mtx, mMtx); }
 

--- a/src/d/actor/d_a_obj_klift00.cpp
+++ b/src/d/actor/d_a_obj_klift00.cpp
@@ -4,23 +4,10 @@
 */
 
 #include "d/actor/d_a_obj_klift00.h"
-#include "SSystem/SComponent/c_cc_d.h"
-#include "SSystem/SComponent/c_m3d.h"
 #include "SSystem/SComponent/c_math.h"
-#include "Z2AudioLib/Z2AudioMgr.h"
-#include "d/actor/d_a_player.h"
 #include "d/d_bg_w.h"
-#include "d/d_cc_d.h"
 #include "d/d_cc_uty.h"
 #include "d/d_com_inf_game.h"
-#include "d/d_kankyo_wether.h"
-#include "f_op/f_op_actor.h"
-#include "f_op/f_op_actor_mng.h"
-#include "m_Do/m_Do_audio.h"
-#include "m_Do/m_Do_controller_pad.h"
-#include "mtx/vec.h"
-#include "os.h"
-
 
 static int daObjKLift00_create1st(daObjKLift00_c*);
 static int daObjKLift00_MoveBGDelete(daObjKLift00_c*);

--- a/src/d/actor/d_a_obj_klift00.cpp
+++ b/src/d/actor/d_a_obj_klift00.cpp
@@ -17,9 +17,7 @@ static int daObjKLift00_MoveBGDraw(daObjKLift00_c*);
 
 #ifdef DEBUG
 static daObjKLift00_HIO_c l_HIO;
-#endif
 
-#ifdef DEBUG
 daObjKLift00_HIO_c::daObjKLift00_HIO_c() {
     mChainGravity = -20.0f;
     mRideParameters = 0.0025f;
@@ -29,7 +27,6 @@ daObjKLift00_HIO_c::daObjKLift00_HIO_c() {
     mChainHitSpeed = 15.0f;
     field_0x1C = 1.0f;
 }
-#endif
 
 void daObjKLift00_HIO_c::genMessage(JORMContext* ctx) {
     // "Foothold"
@@ -56,6 +53,7 @@ void daObjKLift00_HIO_c::genMessage(JORMContext* ctx) {
     // "Hammer adjustment"
     ctx->genSlider("ハンマー調整", &field_0x1C, 0.0, 10.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
 }
+#endif
 
 /* 8058AF38-8058AF60 000078 0028+00 1/1 0/0 0/0 .text
  * rideCallBack__FP4dBgWP10fopAc_ac_cP10fopAc_ac_c              */
@@ -145,7 +143,9 @@ cPhs__Step daObjKLift00_c::create1st() {
     }
 
     // "Foothold(Lv3)"
+    #ifdef DEBUG
     l_HIO.entryHIO("足場(Lv3)");
+    #endif
 
     return phase;
 }
@@ -485,7 +485,10 @@ int daObjKLift00_c::Draw() {
 /* 8058C014-8058C050 001154 003C+00 1/0 0/0 0/0 .text            Delete__14daObjKLift00_cFv */
 int daObjKLift00_c::Delete() {
     dComIfG_resDelete(this, l_arcName);
+
+    #ifdef DEBUG
     l_HIO.removeHIO();
+    #endif
 
     return 1;
 }

--- a/src/d/actor/d_a_obj_klift00.cpp
+++ b/src/d/actor/d_a_obj_klift00.cpp
@@ -4,6 +4,7 @@
 */
 
 #include "d/actor/d_a_obj_klift00.h"
+#include "JSystem/JHostIO/JORMContext.h"
 #include "SSystem/SComponent/c_math.h"
 #include "d/d_bg_w.h"
 #include "d/d_cc_uty.h"
@@ -29,6 +30,32 @@ daObjKLift00_HIO_c::daObjKLift00_HIO_c() {
     field_0x1C = 1.0f;
 }
 #endif
+
+void daObjKLift00_HIO_c::genMessage(JORMContext* ctx) {
+    // "Foothold"
+    ctx->genLabel("足場", 0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Chain gravity"
+    ctx->genSlider("チェイン重力", &mChainGravity, -40.0, 0.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Ride parameters"
+    ctx->genSlider("Ride パラメータ", &mRideParameters, 0.0, 0.1, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Wind effect occurence rate"
+    ctx->genSlider("風影響発生率", &mWindSwayOccuranceFactor, 0.0, 0.5, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Chain・Wind"
+    ctx->genSlider("鎖・風", &mWindMagnitudeChain, 0.0, 1000.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Foundation・Wind"
+    ctx->genSlider("土台・風", &mWindMagnitudeFoundation, 0.0, 1000.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Chain hit speed"
+    ctx->genSlider("鎖ヒット速度", &mChainHitSpeed, 0.0, 50.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Hammer adjustment"
+    ctx->genSlider("ハンマー調整", &field_0x1C, 0.0, 10.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+}
 
 /* 8058AF38-8058AF60 000078 0028+00 1/1 0/0 0/0 .text
  * rideCallBack__FP4dBgWP10fopAc_ac_cP10fopAc_ac_c              */
@@ -116,6 +143,9 @@ cPhs__Step daObjKLift00_c::create1st() {
         if(phase == cPhs_ERROR_e)
             return phase;
     }
+
+    // "Foothold(Lv3)"
+    l_HIO.entryHIO("足場(Lv3)");
 
     return phase;
 }
@@ -455,6 +485,8 @@ int daObjKLift00_c::Draw() {
 /* 8058C014-8058C050 001154 003C+00 1/0 0/0 0/0 .text            Delete__14daObjKLift00_cFv */
 int daObjKLift00_c::Delete() {
     dComIfG_resDelete(this, l_arcName);
+    l_HIO.removeHIO();
+
     return 1;
 }
 

--- a/src/d/actor/d_a_obj_klift00.cpp
+++ b/src/d/actor/d_a_obj_klift00.cpp
@@ -4,129 +4,56 @@
 */
 
 #include "d/actor/d_a_obj_klift00.h"
+#include "SSystem/SComponent/c_cc_d.h"
+#include "SSystem/SComponent/c_m3d.h"
+#include "SSystem/SComponent/c_math.h"
+#include "Z2AudioLib/Z2AudioMgr.h"
+#include "d/actor/d_a_player.h"
+#include "d/d_bg_w.h"
 #include "d/d_cc_d.h"
-#include "dol2asm.h"
+#include "d/d_cc_uty.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_kankyo_wether.h"
+#include "f_op/f_op_actor.h"
+#include "f_op/f_op_actor_mng.h"
+#include "m_Do/m_Do_audio.h"
+#include "m_Do/m_Do_controller_pad.h"
+#include "mtx/vec.h"
+#include "os.h"
 
 
-//
-// Forward References:
-//
+static int daObjKLift00_create1st(daObjKLift00_c*);
+static int daObjKLift00_MoveBGDelete(daObjKLift00_c*);
+static int daObjKLift00_MoveBGExecute(daObjKLift00_c*);
+static int daObjKLift00_MoveBGDraw(daObjKLift00_c*);
 
-extern "C" static void rideCallBack__FP4dBgWP10fopAc_ac_cP10fopAc_ac_c();
-extern "C" void __dt__8dCcD_SphFv();
-extern "C" void create1st__14daObjKLift00_cFv();
-extern "C" void setMtx__14daObjKLift00_cFv();
-extern "C" void rideActor__14daObjKLift00_cFP10fopAc_ac_c();
-extern "C" void CreateHeap__14daObjKLift00_cFv();
-extern "C" void Create__14daObjKLift00_cFv();
-extern "C" void Execute__14daObjKLift00_cFPPA3_A4_f();
-extern "C" void Draw__14daObjKLift00_cFv();
-extern "C" void Delete__14daObjKLift00_cFv();
-extern "C" static void daObjKLift00_create1st__FP14daObjKLift00_c();
-extern "C" void __dt__8cM3dGCylFv();
-extern "C" void __dt__8cM3dGAabFv();
-extern "C" void __ct__8dCcD_SphFv();
-extern "C" void __dt__8cM3dGSphFv();
-extern "C" static void daObjKLift00_MoveBGDelete__FP14daObjKLift00_c();
-extern "C" static void daObjKLift00_MoveBGExecute__FP14daObjKLift00_c();
-extern "C" static void daObjKLift00_MoveBGDraw__FP14daObjKLift00_c();
-extern "C" void __ct__10dMdl_obj_cFv();
-extern "C" void __dt__Q214daObjKLift00_c8ChainPosFv();
-extern "C" void __ct__Q214daObjKLift00_c8ChainPosFv();
-extern "C" extern char const* const d_a_obj_klift00__stringBase0;
+#ifdef DEBUG
+static daObjKLift00_HIO_c l_HIO;
+#endif
 
-//
-// External References:
-//
-
-extern "C" void mDoMtx_YrotM__FPA4_fs();
-extern "C" void mDoMtx_ZrotM__FPA4_fs();
-extern "C" void transS__14mDoMtx_stack_cFRC4cXyz();
-extern "C" void scaleM__14mDoMtx_stack_cFfff();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void fopAcM_setCullSizeBox__FP10fopAc_ac_cffffff();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void getRes__14dRes_control_cFPCclP11dRes_info_ci();
-extern "C" void dKyw_get_wind_vecpow__Fv();
-extern "C" void dBgS_MoveBGProc_TypicalRotY__FP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz();
-extern "C" void __ct__16dBgS_MoveBgActorFv();
-extern "C" bool IsDelete__16dBgS_MoveBgActorFv();
-extern "C" bool ToFore__16dBgS_MoveBgActorFv();
-extern "C" bool ToBack__16dBgS_MoveBgActorFv();
-extern "C" void
-MoveBGCreate__16dBgS_MoveBgActorFPCciPFP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz_vUlPA3_A4_f();
-extern "C" void MoveBGDelete__16dBgS_MoveBgActorFv();
-extern "C" void MoveBGExecute__16dBgS_MoveBgActorFv();
-extern "C" void __ct__10dCcD_GSttsFv();
-extern "C" void Move__10dCcD_GSttsFv();
-extern "C" void Init__9dCcD_SttsFiiP10fopAc_ac_c();
-extern "C" void __ct__12dCcD_GObjInfFv();
-extern "C" void __dt__12dCcD_GObjInfFv();
-extern "C" void ChkTgHit__12dCcD_GObjInfFv();
-extern "C" void GetTgHitObj__12dCcD_GObjInfFv();
-extern "C" void getHitSeID__12dCcD_GObjInfFUci();
-extern "C" void Set__8dCcD_CylFRC11dCcD_SrcCyl();
-extern "C" void Set__8dCcD_SphFRC11dCcD_SrcSph();
-extern "C" void entryObj__6dMdl_cFP10dMdl_obj_c();
-extern "C" void entry__10dMdl_mng_cFP12J3DModelDataUsi();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void GetAc__8cCcD_ObjFv();
-extern "C" void Set__4cCcSFP8cCcD_Obj();
-extern "C" void __pl__4cXyzCFRC3Vec();
-extern "C" void __mi__4cXyzCFRC3Vec();
-extern "C" void __ml__4cXyzCFf();
-extern "C" void normalize__4cXyzFv();
-extern "C" void cM_rndF__Ff();
-extern "C" void cM_rndFX__Ff();
-extern "C" void SetC__8cM3dGSphFRC4cXyz();
-extern "C" void seStart__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void* __nwa__FUl();
-extern "C" void __dl__FPv();
-extern "C" void __construct_array();
-extern "C" void __construct_new_array();
-extern "C" void _savegpr_22();
-extern "C" void _savegpr_26();
-extern "C" void _savegpr_27();
-extern "C" void _savegpr_29();
-extern "C" void _restgpr_22();
-extern "C" void _restgpr_26();
-extern "C" void _restgpr_27();
-extern "C" void _restgpr_29();
-extern "C" extern void* __vt__8dCcD_Sph[36];
-extern "C" extern void* __vt__8dCcD_Cyl[36];
-extern "C" extern void* __vt__9dCcD_Stts[11];
-extern "C" extern void* __vt__12cCcD_SphAttr[25];
-extern "C" extern void* __vt__12cCcD_CylAttr[25];
-extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
-extern "C" extern void* __vt__9cCcD_Stts[8];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" f32 Zero__4cXyz[3];
-extern "C" u8 BaseZ__4cXyz[12];
-extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
-
-//
-// Declarations:
-//
+#ifdef DEBUG
+daObjKLift00_HIO_c::daObjKLift00_HIO_c() {
+    mChainGravity = -20.0f;
+    mRideParameters = 0.0025f;
+    mWindSwayOccuranceFactor = 0.05f;
+    mWindMagnitudeChain = 0.05f;
+    mWindMagnitudeFoundation = 1.25f;
+    mChainHitSpeed = 15.0f;
+    field_0x1C = 1.0f;
+}
+#endif
 
 /* 8058AF38-8058AF60 000078 0028+00 1/1 0/0 0/0 .text
  * rideCallBack__FP4dBgWP10fopAc_ac_cP10fopAc_ac_c              */
-static void rideCallBack(dBgW* param_0, fopAc_ac_c* param_1, fopAc_ac_c* param_2) {
-    // NONMATCHING
+static void rideCallBack(dBgW* unused, fopAc_ac_c* k_lift, fopAc_ac_c* riding_actor) {
+    daObjKLift00_c* const kLift = static_cast<daObjKLift00_c*>(k_lift);
+    fopAc_ac_c* const rideActor = riding_actor;
+
+    kLift->rideActor(rideActor);
 }
 
-/* ############################################################################################## */
-/* 8058C3E8-8058C3E8 000068 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_8058C3E8 = "K_lift00";
-#pragma pop
-
 /* 8058C3F4-8058C3F8 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
-SECTION_DATA static void* l_arcName = (void*)&d_a_obj_klift00__stringBase0;
+static const char* l_arcName = "K_lift00";
 
 /* 8058C3F8-8058C438 000004 0040+00 1/1 0/0 0/0 .data            l_cc_sph_src */
 static dCcD_SrcSph l_cc_sph_src = {
@@ -158,11 +85,11 @@ static dCcD_SrcCyl l_cc_cyl_src = {
 
 /* 8058C47C-8058C49C -00001 0020+00 1/0 0/0 0/0 .data            daObjKLift00_METHODS */
 static actor_method_class daObjKLift00_METHODS = {
-    (process_method_func)daObjKLift00_create1st__FP14daObjKLift00_c,
-    (process_method_func)daObjKLift00_MoveBGDelete__FP14daObjKLift00_c,
-    (process_method_func)daObjKLift00_MoveBGExecute__FP14daObjKLift00_c,
+    (process_method_func)daObjKLift00_create1st,
+    (process_method_func)daObjKLift00_MoveBGDelete,
+    (process_method_func)daObjKLift00_MoveBGExecute,
     0,
-    (process_method_func)daObjKLift00_MoveBGDraw__FP14daObjKLift00_c,
+    (process_method_func)daObjKLift00_MoveBGDraw,
 };
 
 /* 8058C49C-8058C4CC -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_KLift00 */
@@ -183,309 +110,388 @@ extern actor_process_profile_definition g_profile_Obj_KLift00 = {
   fopAc_CULLBOX_CUSTOM_e, // cullType
 };
 
-/* 8058C4CC-8058C4F4 0000D8 0028+00 1/1 0/0 0/0 .data            __vt__14daObjKLift00_c */
-SECTION_DATA extern void* __vt__14daObjKLift00_c[10] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)CreateHeap__14daObjKLift00_cFv,
-    (void*)Create__14daObjKLift00_cFv,
-    (void*)Execute__14daObjKLift00_cFPPA3_A4_f,
-    (void*)Draw__14daObjKLift00_cFv,
-    (void*)Delete__14daObjKLift00_cFv,
-    (void*)IsDelete__16dBgS_MoveBgActorFv,
-    (void*)ToFore__16dBgS_MoveBgActorFv,
-    (void*)ToBack__16dBgS_MoveBgActorFv,
-};
-
-/* 8058C4F4-8058C500 000100 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGSph */
-SECTION_DATA extern void* __vt__8cM3dGSph[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGSphFv,
-};
-
-/* 8058C500-8058C50C 00010C 000C+00 4/4 0/0 0/0 .data            __vt__8cM3dGAab */
-SECTION_DATA extern void* __vt__8cM3dGAab[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGAabFv,
-};
-
-/* 8058AF60-8058B02C 0000A0 00CC+00 1/1 0/0 0/0 .text            __dt__8dCcD_SphFv */
-// dCcD_Sph::~dCcD_Sph() {
-extern "C" void __dt__8dCcD_SphFv() {
-    // NONMATCHING
-}
+#ifdef DEBUG
+static const int l_dzbidx[] = {9};
+#endif
 
 /* 8058B02C-8058B0D0 00016C 00A4+00 1/1 0/0 0/0 .text            create1st__14daObjKLift00_cFv */
-void daObjKLift00_c::create1st() {
-    // NONMATCHING
+cPhs__Step daObjKLift00_c::create1st() {
+    mNumChainModels = getArg0();
+    mNumChains = mNumChainModels + 1;
+
+    cPhs__Step phase = static_cast<cPhs__Step>(dComIfG_resLoad(this, l_arcName));
+    if(phase == cPhs_COMPLEATE_e) {
+        #if DEBUG
+        phase = static_cast<cPhs__Step>(MoveBGCreate(l_arcName, l_dzbidx[0], dBgS_MoveBGProc_TypicalRotY, 0x2000, NULL));
+        #else
+        phase = static_cast<cPhs__Step>(MoveBGCreate(l_arcName, 9, dBgS_MoveBGProc_TypicalRotY, 0x2000, NULL));
+        #endif
+        if(phase == cPhs_ERROR_e)
+            return phase;
+    }
+
+    return phase;
 }
 
 /* ############################################################################################## */
 /* 8058C380-8058C38C 000000 000C+00 5/5 0/0 0/0 .rodata          l_bmdidx */
-SECTION_RODATA static u8 const l_bmdidx[12] = {
-    0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x04,
-};
-COMPILER_STRIP_GATE(0x8058C380, &l_bmdidx);
-
-/* 8058C38C-8058C398 00000C 000C+00 0/1 0/0 0/0 .rodata          @3711 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3711[12] = {
-    0x00, 0x00, 0x00, 0x00, 0xBF, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8058C38C, &lit_3711);
-#pragma pop
-
-/* 8058C398-8058C39C 000018 0004+00 0/2 0/0 0/0 .rodata          @3799 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3799 = -1.0f;
-COMPILER_STRIP_GATE(0x8058C398, &lit_3799);
-#pragma pop
-
-/* 8058C39C-8058C3A0 00001C 0004+00 0/3 0/0 0/0 .rodata          @3800 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3800 = 1.0f;
-COMPILER_STRIP_GATE(0x8058C39C, &lit_3800);
-#pragma pop
+static const int l_bmdidx[3] = {5, 6, 4};
 
 /* 8058B0D0-8058B4B0 000210 03E0+00 2/2 0/0 0/0 .text            setMtx__14daObjKLift00_cFv */
 void daObjKLift00_c::setMtx() {
-    // NONMATCHING
+    Mtx nonFoundationChainRotationMatrix;
+    mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
+    mDoMtx_stack_c::YrotM(shape_angle.y);
+
+    if(!getNoBaseDisp())
+        mpChainBase->setBaseTRMtx(mDoMtx_stack_c::get());
+
+    MTXCopy(mDoMtx_stack_c::get(), mCullMtx);
+
+    s16 negativeHomeYAngle = -home.angle.y;
+
+    // Compute rotation matrices to make the chains' rotation match their change in position
+    for(int i = 0; i < mNumChainModels; i++) {
+        cXyz vectorToLowerChain =  mChainPositions[i + 1].mCurrentPos - mChainPositions[i].mCurrentPos;
+        cXyz crossProductXAxis;
+        VECCrossProduct(&cXyz::BaseZ, &vectorToLowerChain, &crossProductXAxis);
+
+        if(!cM3d_IsZero(vectorToLowerChain.getSquareMag())) {
+            vectorToLowerChain.normalize();
+            f32 vectorToLowerChainNormalizedZComponent = VECDotProduct(&vectorToLowerChain, &cXyz::BaseZ);
+
+            if(!cM3d_IsZero(crossProductXAxis.getSquareMag()) && -1.0f <= vectorToLowerChainNormalizedZComponent && vectorToLowerChainNormalizedZComponent <= 1.0f) {
+                // |vectorToLowerChainNormalizedZComponent||BaseZ|cos(t) = 1 * 1 * cos(t) = cos(t)
+                f32 currentChainPairZAngle = acos(vectorToLowerChainNormalizedZComponent);
+                crossProductXAxis.normalize();
+                MTXRotAxisRad(nonFoundationChainRotationMatrix, &crossProductXAxis, currentChainPairZAngle);
+            }
+            else {
+                MTXIdentity(nonFoundationChainRotationMatrix);
+            }
+        }
+        else {
+            MTXIdentity(nonFoundationChainRotationMatrix);
+        }
+
+        negativeHomeYAngle += static_cast<s16>(0x4000);
+        mDoMtx_stack_c::transS(mChainPositions[i].mCurrentPos);
+        mDoMtx_stack_c::concat(nonFoundationChainRotationMatrix);
+        mDoMtx_stack_c::ZrotM(negativeHomeYAngle);
+
+        MtxP const now = mDoMtx_stack_c::get();
+        mChainMdlObjs[i].setMtx(now);
+    }
+
+    Mtx foundationChainRotationMatrix;
+    cXyz vectorFromSecondLowestChainToFoundation = mChainPositions[mNumChainModels].mCurrentPos - mChainPositions[mNumChainModels - 1].mCurrentPos;
+    cXyz crossProduct;
+    Vec inverseBaseY = {0.0f, -1.0f, 0.0f};
+    if(!cM3d_IsZero(vectorFromSecondLowestChainToFoundation.getSquareMag())) {
+        vectorFromSecondLowestChainToFoundation.normalize();
+        VECCrossProduct(&inverseBaseY, &vectorFromSecondLowestChainToFoundation, &crossProduct);
+        f32 dotProduct = VECDotProduct(&vectorFromSecondLowestChainToFoundation, &inverseBaseY);
+
+        if(!cM3d_IsZero(crossProduct.getSquareMag()) && -1.0f <= dotProduct && dotProduct <= 1.0f) {
+            f32 arcCos = acos(dotProduct);
+            crossProduct.normalize();
+            MTXRotAxisRad(foundationChainRotationMatrix, &crossProduct, arcCos);
+        }
+        else {
+            MTXIdentity(foundationChainRotationMatrix);
+        }
+    }
+    else {
+        MTXIdentity(foundationChainRotationMatrix);
+    }
+
+    mDoMtx_stack_c::transS(mChainPositions[mNumChainModels].mCurrentPos);
+    mDoMtx_stack_c::concat(foundationChainRotationMatrix);
+    mDoMtx_stack_c::YrotM(-negativeHomeYAngle);
+    mpLiftPlatform->setBaseTRMtx(mDoMtx_stack_c::get());
+    mDoMtx_stack_c::scaleM(scale.x, scale.y, scale.z);
+    MTXCopy(mDoMtx_stack_c::get(), mNewBgMtx);
 }
 
-/* ############################################################################################## */
-/* 8058C3A0-8058C3A4 000020 0004+00 0/1 0/0 0/0 .rodata          @3822 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3822 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8058C3A0, &lit_3822);
-#pragma pop
-
-/* 8058C3A4-8058C3A8 000024 0004+00 0/1 0/0 0/0 .rodata          @3823 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3823 = 3.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8058C3A4, &lit_3823);
-#pragma pop
-
-/* 8058C3A8-8058C3AC 000028 0004+00 0/1 0/0 0/0 .rodata          @3824 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u32 const lit_3824 = 0x3B23D70A;
-COMPILER_STRIP_GATE(0x8058C3A8, &lit_3824);
-#pragma pop
-
 /* 8058B4B0-8058B5EC 0005F0 013C+00 1/1 0/0 0/0 .text rideActor__14daObjKLift00_cFP10fopAc_ac_c */
-void daObjKLift00_c::rideActor(fopAc_ac_c* param_0) {
-    // NONMATCHING
+void daObjKLift00_c::rideActor(fopAc_ac_c* riding_actor) {
+    if(!fopAcM_CheckCondition(this, fopAcCnd_NOEXEC_e)) {
+        cXyz vectorFromFoundationChainToRideActor = riding_actor->current.pos - mChainPositions[mNumChains - 1].mCurrentPos;
+
+        f32 weightMagnitude = 0.01f;
+
+        if(!cM3d_IsZero(riding_actor->speed.getSquareMag()))
+            weightMagnitude = 0.03f;
+
+        #if DEBUG
+        mChainPositions[mNumChains - 1].mDeltaPosVector.x -= vectorFromFoundationChainToRideActor.x * 0.0025f * (cM_rndFX(weightMagnitude) + l_HIO.mRideParameters);
+        mChainPositions[mNumChains - 1].mDeltaPosVector.z -= vectorFromFoundationChainToRideActor.z * 0.0025f * (cM_rndFX(weightMagnitude) + l_HIO.mRideParameters);
+        #else
+        mChainPositions[mNumChains - 1].mDeltaPosVector.x -= vectorFromFoundationChainToRideActor.x * 0.0025f * (cM_rndFX(weightMagnitude) + 1.0f);
+        mChainPositions[mNumChains - 1].mDeltaPosVector.z -= vectorFromFoundationChainToRideActor.z * 0.0025f * (cM_rndFX(weightMagnitude) + 1.0f);
+        #endif
+    }
 }
 
 /* 8058B5EC-8058B77C 00072C 0190+00 1/0 0/0 0/0 .text            CreateHeap__14daObjKLift00_cFv */
-void daObjKLift00_c::CreateHeap() {
-    // NONMATCHING
+int daObjKLift00_c::CreateHeap() {
+    J3DModelData* const model_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(l_arcName, l_bmdidx[2]));
+    JUT_ASSERT(304, model_data != 0);
+    mpLiftPlatform = mDoExt_J3DModel__create(model_data, (1 << 19), 0x11000084);
+    if(!mpLiftPlatform)
+        return 0;
+
+    if(!getNoBaseDisp()) {
+        J3DModelData* const model_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(l_arcName, l_bmdidx[0]));
+        JUT_ASSERT(315, model_data != 0);
+        mpChainBase = mDoExt_J3DModel__create(model_data, (1 << 19), 0x11000084);
+        if(!mpChainBase)
+            return 0;
+    }
+    else {
+        mpChainBase = NULL;
+    }
+
+    mChainPositions = new ChainPos[mNumChains];
+    if(!mChainPositions)
+        return 0;
+
+    mChainModelData = static_cast<J3DModelData*>(dComIfG_getObjectRes(l_arcName, l_bmdidx[1]));
+    JUT_ASSERT(334, mChainModelData != 0);
+
+    mChainMdlObjs = new dMdl_obj_c[mNumChainModels];
+
+    return mChainMdlObjs ? TRUE : FALSE;
 }
-
-/* ############################################################################################## */
-/* 8058C3AC-8058C3B0 00002C 0004+00 0/2 0/0 0/0 .rodata          @3928 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3928 = 35.0f;
-COMPILER_STRIP_GATE(0x8058C3AC, &lit_3928);
-#pragma pop
-
-/* 8058C3B0-8058C3B4 000030 0004+00 0/1 0/0 0/0 .rodata          @3929 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3929 = -350.0f;
-COMPILER_STRIP_GATE(0x8058C3B0, &lit_3929);
-#pragma pop
-
-/* 8058C3B4-8058C3B8 000034 0004+00 0/1 0/0 0/0 .rodata          @3930 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3930 = 40.0f;
-COMPILER_STRIP_GATE(0x8058C3B4, &lit_3930);
-#pragma pop
-
-/* 8058C3B8-8058C3BC 000038 0004+00 0/1 0/0 0/0 .rodata          @3931 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3931 = 100.0f;
-COMPILER_STRIP_GATE(0x8058C3B8, &lit_3931);
-#pragma pop
-
-/* 8058C3BC-8058C3C0 00003C 0004+00 0/1 0/0 0/0 .rodata          @3932 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3932 = 350.0f;
-COMPILER_STRIP_GATE(0x8058C3BC, &lit_3932);
-#pragma pop
-
-/* 8058C3C0-8058C3C8 000040 0004+04 0/1 0/0 0/0 .rodata          @3933 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3933[1 + 1 /* padding */] = {
-    10.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8058C3C0, &lit_3933);
-#pragma pop
-
-/* 8058C3C8-8058C3D0 000048 0008+00 0/1 0/0 0/0 .rodata          @3935 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3935[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8058C3C8, &lit_3935);
-#pragma pop
 
 /* 8058B77C-8058B97C 0008BC 0200+00 1/0 0/0 0/0 .text            Create__14daObjKLift00_cFv */
-void daObjKLift00_c::Create() {
-    // NONMATCHING
+int daObjKLift00_c::Create() {
+    mpLiftPlatform->setBaseScale(scale);
+    mChainPositions[0].mCurrentPos = current.pos; 
+    mChainPositions[0].mDeltaPosVector = cXyz::Zero;
+
+    for(int i = 1; i < mNumChains; i++) {
+        mChainPositions[i].mDeltaPosVector = cXyz::Zero;
+
+        mChainPositions[i].mCurrentPos.x = current.pos.x;
+        mChainPositions[i].mCurrentPos.y = mChainPositions[i-1].mCurrentPos.y - 35.0f;
+        mChainPositions[i].mCurrentPos.z = current.pos.z;
+    }
+
+    setMtx();
+    fopAcM_SetMtx(this, mCullMtx);
+    fopAcM_setCullSizeBox(this, -350.0f, (-mNumChainModels * 40.0f) - 100.0f, -350.0f, 350.0f, 10.0f, 350.0f);
+
+    mpBgW->SetRideCallback(rideCallBack);
+    mStts.Init(0xFF, 0, this);
+
+    for(int i = 0; i < 8; i++) {
+        mChainSphereColliders[i].Set(l_cc_sph_src);
+        mChainSphereColliders[i].SetStts(&mStts);
+    }
+
+    mCylinderCollider.Set(l_cc_cyl_src);
+    mCylinderCollider.SetStts(&mStts);
+    mStopSwingingFrames = 0;
+
+    if(getLock())
+        mStopSwingingFrames = 5;
+
+    return 1;
 }
-
-/* ############################################################################################## */
-/* 8058C3D0-8058C3D4 000050 0004+00 0/1 0/0 0/0 .rodata          @4122 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4122 = 1.0f / 20.0f;
-COMPILER_STRIP_GATE(0x8058C3D0, &lit_4122);
-#pragma pop
-
-/* 8058C3D4-8058C3D8 000054 0004+00 0/1 0/0 0/0 .rodata          @4123 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4123 = 1.25f;
-COMPILER_STRIP_GATE(0x8058C3D4, &lit_4123);
-#pragma pop
-
-/* 8058C3D8-8058C3DC 000058 0004+00 0/1 0/0 0/0 .rodata          @4124 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4124 = 15.0f;
-COMPILER_STRIP_GATE(0x8058C3D8, &lit_4124);
-#pragma pop
-
-/* 8058C3DC-8058C3E0 00005C 0004+00 0/1 0/0 0/0 .rodata          @4125 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4125 = -4.0f;
-COMPILER_STRIP_GATE(0x8058C3DC, &lit_4125);
-#pragma pop
-
-/* 8058C3E0-8058C3E4 000060 0004+00 0/1 0/0 0/0 .rodata          @4126 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4126 = 1.0f / 3.0f;
-COMPILER_STRIP_GATE(0x8058C3E0, &lit_4126);
-#pragma pop
-
-/* 8058C3E4-8058C3E8 000064 0004+00 0/1 0/0 0/0 .rodata          @4127 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4127[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8058C3E4, &lit_4127);
-#pragma pop
 
 /* 8058B97C-8058BEEC 000ABC 0570+00 1/0 0/0 0/0 .text            Execute__14daObjKLift00_cFPPA3_A4_f
  */
-void daObjKLift00_c::Execute(f32 (**param_0)[3][4]) {
-    // NONMATCHING
+int daObjKLift00_c::Execute(Mtx** i_mtx) {
+    // Apply wind sway
+    #if DEBUG
+    if(cM_rndF(1.0f) < l_HIO.mWindSwayOccuranceFactor) {
+        for(int i = 1; i < mNumChains; i++) {
+            cXyz windVector = dKyw_get_wind_vecpow();
+            windVector *= cM_rndF(l_HIO.mWindMagnitudeChain);
+            mChainPositions[i].mDeltaPosVector += windVector;
+
+            if(i == mNumChains - 1) {
+                windVector *= cM_rndF(l_HIO.mWindMagnitudeFoundation);
+                mChainPositions[i].mDeltaPosVector += windVector;
+            }
+        }
+    }
+    #else
+    if(cM_rndF(1.0f) < 0.05f) {
+        for(int i = 1; i < mNumChains; i++) {
+            cXyz windVector = dKyw_get_wind_vecpow();
+            VECScale(&windVector, &windVector, cM_rndF(0.05f));
+            VECAdd(&mChainPositions[i].mDeltaPosVector, &windVector, &mChainPositions[i].mDeltaPosVector);
+
+            if(i == mNumChains - 1) {
+                VECScale(&windVector, &windVector, cM_rndF(1.25f));
+                VECAdd(&mChainPositions[i].mDeltaPosVector, &windVector, &mChainPositions[i].mDeltaPosVector);
+            }
+        }
+    }
+    #endif
+
+    // Check if player hit chains, and play sfx & move the chains accordingly
+    bool playedHitSfx = false;
+    #ifdef DEBUG
+    for(int i = 0; i < 8; i++) {
+        const s32 currentChainIdx = (mNumChains - 1) - (i * 2);
+        if(currentChainIdx >= 0 && mChainSphereColliders[i].ChkTgHit() ) {
+            dCcD_GObjInf* const hitObj = static_cast<dCcD_GObjInf*>(mChainSphereColliders[i].GetTgHitObj());
+            fopAc_ac_c* const hitObjActor = dCc_GetAc(hitObj->GetAc());
+            cXyz vectorFromHitActorToCurrentChain = mChainPositions[currentChainIdx].mCurrentPos - hitObjActor->current.pos;
+            if(!cM3d_IsZero(vectorFromHitActorToCurrentChain.getSquareMag())) {
+                vectorFromHitActorToCurrentChain.normalize();
+                vectorFromHitActorToCurrentChain *= l_HIO.mChainHitSpeed;
+                mChainPositions[currentChainIdx].mDeltaPosVector += vectorFromHitActorToCurrentChain;
+            }
+
+            if(!playedHitSfx) {
+                playedHitSfx = true;
+                Z2GetAudioMgr()->seStart(mChainSphereColliders[i].getHitSeID(hitObj->GetAtSe(), 0), mChainSphereColliders[i].GetCP(), 53, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+            }
+        }
+    }
+    #else
+    for(int i = 0; i < 8; i++) {
+        const s32 currentChainIdx = (mNumChains - 1) - (i * 2);
+        if(currentChainIdx >= 0 && mChainSphereColliders[i].ChkTgHit() ) {
+            dCcD_GObjInf* const hitObj = static_cast<dCcD_GObjInf*>(mChainSphereColliders[i].GetTgHitObj());
+            fopAc_ac_c* const hitObjActor = dCc_GetAc(hitObj->GetAc());
+            cXyz vectorFromHitActorToCurrentChain = mChainPositions[currentChainIdx].mCurrentPos - hitObjActor->current.pos;
+            if(!cM3d_IsZero(vectorFromHitActorToCurrentChain.getSquareMag())) {
+                vectorFromHitActorToCurrentChain.normalize();
+                VECScale(&vectorFromHitActorToCurrentChain, &vectorFromHitActorToCurrentChain, 15.0f);
+                VECAdd(&mChainPositions[currentChainIdx].mDeltaPosVector, &vectorFromHitActorToCurrentChain, &mChainPositions[currentChainIdx].mDeltaPosVector);
+            }
+
+            if(!playedHitSfx) {
+                playedHitSfx = true;
+                Z2GetAudioMgr()->seStart(mChainSphereColliders[i].getHitSeID(hitObj->GetAtSe(), 0), mChainSphereColliders[i].GetCP(), 53, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+            }
+        }
+    }
+    #endif
+
+    // Apply chain gravity
+    #if DEBUG
+    mChainPositions[0].mDeltaPosVector = cXyz::Zero;
+    mChainPositions[0].mCurrentPos = current.pos;
+    for(int i = 1; i < mNumChains; i++) {
+        mChainPositions[i].mPrevPos = mChainPositions[i].mCurrentPos;
+        mChainPositions[i].mDeltaPosVector.y += l_HIO.mChainGravity;
+        mChainPositions[i].mCurrentPos += mChainPositions[i].mDeltaPosVector;
+    }
+    #else
+    mChainPositions[0].mDeltaPosVector = cXyz::Zero;
+    mChainPositions[0].mCurrentPos = current.pos;
+    for(int i = 1; i < mNumChains; i++) {
+        mChainPositions[i].mPrevPos = mChainPositions[i].mCurrentPos;
+        mChainPositions[i].mDeltaPosVector.y += -4.0f;
+        VECAdd(&mChainPositions[i].mCurrentPos, &mChainPositions[i].mDeltaPosVector, &mChainPositions[i].mCurrentPos);
+    }
+    #endif
+
+    for(int i = 1; i < mNumChains - 1; i++) {
+        if(i != mNumChains - 1) {
+            mChainPositions[i].mCurrentPos = (mChainPositions[i - 1].mCurrentPos + mChainPositions[i].mCurrentPos + mChainPositions[i + 1].mCurrentPos) * 0.33333334f;
+        }
+    }
+
+    for(int i = 1; i < mNumChains; i++) {
+        cXyz vectorFromChainAboveToCurrentChain = mChainPositions[i].mCurrentPos - mChainPositions[i - 1].mCurrentPos;
+        if(mStopSwingingFrames > 0) {
+            vectorFromChainAboveToCurrentChain.set(0.0f, -1.0f, 0.0f); 
+        }
+        else {
+            if(!cM3d_IsZero(vectorFromChainAboveToCurrentChain.getSquareMag()))
+                vectorFromChainAboveToCurrentChain.normalize(); 
+            else
+                vectorFromChainAboveToCurrentChain.set(0.0f, -1.0f, 0.0f); 
+        }
+        #if DEBUG
+            vectorFromChainAboveToCurrentChain *= 35.0f;
+        #else
+        VECScale(&vectorFromChainAboveToCurrentChain, &vectorFromChainAboveToCurrentChain, 35.0f);
+        #endif
+        mChainPositions[i].mCurrentPos = vectorFromChainAboveToCurrentChain + mChainPositions[i - 1].mCurrentPos;
+        mChainPositions[i].mDeltaPosVector = mChainPositions[i].mCurrentPos - mChainPositions[i].mPrevPos;
+    }
+
+    if(mStopSwingingFrames > 0) {
+        mStopSwingingFrames--;
+        if(mStopSwingingFrames < 0)
+            mStopSwingingFrames = 0;
+    }
+
+    for(int i = 0; i < 8; i++) {
+        const s32 currentChainIdx = (mNumChains - 1) - (i * 2);
+        if(currentChainIdx >= 0) {
+            mChainSphereColliders[i].SetC(mChainPositions[currentChainIdx].mCurrentPos);
+            dComIfG_Ccsp()->Set(&mChainSphereColliders[i]);
+        }
+    }
+
+    mStts.Move();
+    setMtx();
+    *i_mtx = &mNewBgMtx;
+
+    return 1;
 }
 
 /* 8058BEEC-8058C014 00102C 0128+00 1/0 0/0 0/0 .text            Draw__14daObjKLift00_cFv */
-void daObjKLift00_c::Draw() {
-    // NONMATCHING
+int daObjKLift00_c::Draw() {
+    g_env_light.settingTevStruct(16, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpLiftPlatform, &tevStr);
+
+    if(!getNoBaseDisp())
+        g_env_light.setLightTevColorType_MAJI(mpChainBase, &tevStr);
+
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpLiftPlatform);
+    
+    if(!getNoBaseDisp())
+        mDoExt_modelUpdateDL(mpChainBase);
+
+    dMdl_c* const dMdl = dMdl_mng_c::entry(mChainModelData, 0, current.roomNo);
+    if(dMdl) {
+        for(int i = 0; i < mNumChainModels; i++)
+            dMdl->entryObj(&mChainMdlObjs[i]);
+    }
+
+    dComIfGd_setList();
+
+    return 1;
 }
 
 /* 8058C014-8058C050 001154 003C+00 1/0 0/0 0/0 .text            Delete__14daObjKLift00_cFv */
-void daObjKLift00_c::Delete() {
-    // NONMATCHING
+int daObjKLift00_c::Delete() {
+    dComIfG_resDelete(this, l_arcName);
+    return 1;
 }
-
-/* ############################################################################################## */
-/* 8058C50C-8058C518 000118 000C+00 2/2 0/0 0/0 .data            __vt__8cM3dGCyl */
-SECTION_DATA extern void* __vt__8cM3dGCyl[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGCylFv,
-};
 
 /* 8058C050-8058C164 001190 0114+00 1/0 0/0 0/0 .text daObjKLift00_create1st__FP14daObjKLift00_c
  */
-static void daObjKLift00_create1st(daObjKLift00_c* param_0) {
-    // NONMATCHING
-}
-
-/* 8058C164-8058C1AC 0012A4 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGCylFv */
-// cM3dGCyl::~cM3dGCyl() {
-extern "C" void __dt__8cM3dGCylFv() {
-    // NONMATCHING
-}
-
-/* 8058C1AC-8058C1F4 0012EC 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGAabFv */
-// cM3dGAab::~cM3dGAab() {
-extern "C" void __dt__8cM3dGAabFv() {
-    // NONMATCHING
-}
-
-/* 8058C1F4-8058C278 001334 0084+00 1/1 0/0 0/0 .text            __ct__8dCcD_SphFv */
-// dCcD_Sph::dCcD_Sph() {
-extern "C" void __ct__8dCcD_SphFv() {
-    // NONMATCHING
-}
-
-/* 8058C278-8058C2C0 0013B8 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGSphFv */
-// cM3dGSph::~cM3dGSph() {
-extern "C" void __dt__8cM3dGSphFv() {
-    // NONMATCHING
+static int daObjKLift00_create1st(daObjKLift00_c* i_this) {
+    fopAcM_SetupActor(i_this, daObjKLift00_c);
+    return i_this->create1st();
 }
 
 /* 8058C2C0-8058C2E0 001400 0020+00 1/0 0/0 0/0 .text
  * daObjKLift00_MoveBGDelete__FP14daObjKLift00_c                */
-static void daObjKLift00_MoveBGDelete(daObjKLift00_c* param_0) {
-    // NONMATCHING
+static int daObjKLift00_MoveBGDelete(daObjKLift00_c* i_this) {
+    return i_this->MoveBGDelete();
 }
 
 /* 8058C2E0-8058C300 001420 0020+00 1/0 0/0 0/0 .text
  * daObjKLift00_MoveBGExecute__FP14daObjKLift00_c               */
-static void daObjKLift00_MoveBGExecute(daObjKLift00_c* param_0) {
-    // NONMATCHING
+static int daObjKLift00_MoveBGExecute(daObjKLift00_c* i_this) {
+    return i_this->MoveBGExecute();
 }
 
 /* 8058C300-8058C32C 001440 002C+00 1/0 0/0 0/0 .text daObjKLift00_MoveBGDraw__FP14daObjKLift00_c
  */
-static void daObjKLift00_MoveBGDraw(daObjKLift00_c* param_0) {
-    // NONMATCHING
+static int daObjKLift00_MoveBGDraw(daObjKLift00_c* i_this) {
+    return i_this->MoveBGDraw();
 }
-
-/* 8058C32C-8058C338 00146C 000C+00 1/1 0/0 0/0 .text            __ct__10dMdl_obj_cFv */
-// dMdl_obj_c::dMdl_obj_c() {
-extern "C" void __ct__10dMdl_obj_cFv() {
-    // NONMATCHING
-}
-
-/* 8058C338-8058C374 001478 003C+00 1/1 0/0 0/0 .text            __dt__Q214daObjKLift00_c8ChainPosFv
- */
-daObjKLift00_c::ChainPos::~ChainPos() {
-    // NONMATCHING
-}
-
-/* 8058C374-8058C378 0014B4 0004+00 1/1 0/0 0/0 .text            __ct__Q214daObjKLift00_c8ChainPosFv
- */
-daObjKLift00_c::ChainPos::ChainPos() {
-    /* empty function */
-}
-
-/* 8058C3E8-8058C3E8 000068 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */

--- a/src/d/actor/d_a_obj_kwheel00.cpp
+++ b/src/d/actor/d_a_obj_kwheel00.cpp
@@ -4,173 +4,121 @@
 */
 
 #include "d/actor/d_a_obj_kwheel00.h"
-#include "d/d_cc_d.h"
-#include "dol2asm.h"
+#include "Z2AudioLib/Z2AudioMgr.h"
+#include "d/actor/d_a_obj_lv3Water.h"
+#include "d/d_com_inf_game.h"
+#include "SSystem/SComponent/c_math.h"
 
+static int daObjKWheel00_create1st(daObjKWheel00_c*);
+static int daObjKWheel00_MoveBGDelete(daObjKWheel00_c*);
+static int daObjKWheel00_MoveBGExecute(daObjKWheel00_c*);
+static int daObjKWheel00_MoveBGDraw(daObjKWheel00_c*);
 
-//
-// Forward References:
-//
+#ifdef DEBUG
+static daObjKWheel00_HIO_c l_HIO;
+#endif
 
-extern "C" void create1st__15daObjKWheel00_cFv();
-extern "C" static void searchLv3Water__FPvPv();
-extern "C" void setMtx__15daObjKWheel00_cFv();
-extern "C" void CreateHeap__15daObjKWheel00_cFv();
-extern "C" void Create__15daObjKWheel00_cFv();
-extern "C" void Execute__15daObjKWheel00_cFPPA3_A4_f();
-extern "C" void Draw__15daObjKWheel00_cFv();
-extern "C" void Delete__15daObjKWheel00_cFv();
-extern "C" void eventStart__15daObjKWheel00_cFv();
-extern "C" static void daObjKWheel00_create1st__FP15daObjKWheel00_c();
-extern "C" void __dt__8dCcD_SphFv();
-extern "C" void __ct__8dCcD_SphFv();
-extern "C" void __dt__8cM3dGSphFv();
-extern "C" void __dt__8cM3dGAabFv();
-extern "C" void __dt__10dCcD_GSttsFv();
-extern "C" static void daObjKWheel00_MoveBGDelete__FP15daObjKWheel00_c();
-extern "C" static void daObjKWheel00_MoveBGExecute__FP15daObjKWheel00_c();
-extern "C" static void daObjKWheel00_MoveBGDraw__FP15daObjKWheel00_c();
-extern "C" void __dt__10cCcD_GSttsFv();
-extern "C" void __dt__17dEvLib_callback_cFv();
-extern "C" bool eventStart__17dEvLib_callback_cFv();
-extern "C" bool eventRun__17dEvLib_callback_cFv();
-extern "C" bool eventEnd__17dEvLib_callback_cFv();
-extern "C" void __dt__15daObjKWheel00_cFv();
-extern "C" static void func_80C4E7E8();
-extern "C" static void func_80C4E7F0();
-extern "C" extern char const* const d_a_obj_kwheel00__stringBase0;
-
-//
-// External References:
-//
-
-extern "C" void mDoMtx_YrotM__FPA4_fs();
-extern "C" void mDoMtx_ZrotM__FPA4_fs();
-extern "C" void transM__14mDoMtx_stack_cFfff();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void __dt__10fopAc_ac_cFv();
-extern "C" void fopAc_IsActor__FPv();
-extern "C" void fopAcIt_Judge__FPFPvPv_PvPv();
-extern "C" void fopAcM_setCullSizeBox__FP10fopAc_ac_cffffff();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void isSwitch__10dSv_info_cCFii();
-extern "C" void getRes__14dRes_control_cFPCclP11dRes_info_ci();
-extern "C" void eventUpdate__17dEvLib_callback_cFv();
-extern "C" void orderEvent__17dEvLib_callback_cFiii();
-extern "C" void
-set__13dPa_control_cFUcUsPC4cXyzPC12dKy_tevstr_cPC5csXyzPC4cXyzUcP18dPa_levelEcallBackScPC8_GXColorPC8_GXColorPC4cXyzf();
-extern "C" void __ct__16dBgS_MoveBgActorFv();
-extern "C" bool IsDelete__16dBgS_MoveBgActorFv();
-extern "C" bool ToFore__16dBgS_MoveBgActorFv();
-extern "C" bool ToBack__16dBgS_MoveBgActorFv();
-extern "C" void
-MoveBGCreate__16dBgS_MoveBgActorFPCciPFP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz_vUlPA3_A4_f();
-extern "C" void MoveBGDelete__16dBgS_MoveBgActorFv();
-extern "C" void MoveBGExecute__16dBgS_MoveBgActorFv();
-extern "C" void __ct__10dCcD_GSttsFv();
-extern "C" void Init__9dCcD_SttsFiiP10fopAc_ac_c();
-extern "C" void __ct__12dCcD_GObjInfFv();
-extern "C" void __dt__12dCcD_GObjInfFv();
-extern "C" void Set__8dCcD_SphFRC11dCcD_SrcSph();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void Set__4cCcSFP8cCcD_Obj();
-extern "C" void cM_rndFX__Ff();
-extern "C" void SetC__8cM3dGSphFRC4cXyz();
-extern "C" void SetR__8cM3dGSphFf();
-extern "C" void seStart__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void seStartLevel__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void __dl__FPv();
-extern "C" void __destroy_arr();
-extern "C" void __construct_array();
-extern "C" void _savegpr_21();
-extern "C" void _savegpr_27();
-extern "C" void _restgpr_21();
-extern "C" void _restgpr_27();
-extern "C" extern void* __vt__16dBgS_MoveBgActor[10];
-extern "C" extern void* __vt__8dCcD_Sph[36];
-extern "C" extern void* __vt__9dCcD_Stts[11];
-extern "C" extern void* __vt__12cCcD_SphAttr[25];
-extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
-extern "C" extern void* __vt__9cCcD_Stts[8];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
-
-//
-// Declarations:
-//
+daObjKWheel00_HIO_c::daObjKWheel00_HIO_c() {
+    mTargetZAngularSpeed = 64;
+    mZAngularAcceleration = 2;
+}
 
 /* ############################################################################################## */
 /* 80C4E800-80C4E808 000000 0008+00 2/2 0/0 0/0 .rodata          l_dzbidx */
-SECTION_RODATA static u8 const l_dzbidx[8] = {
-    0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x07,
-};
-COMPILER_STRIP_GATE(0x80C4E800, &l_dzbidx);
-
-/* 80C4E85C-80C4E85C 00005C 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80C4E85C = "K_Wheel00";
-SECTION_DEAD static char const* const stringBase_80C4E866 = "S_wheel00";
-#pragma pop
+static const u32 l_dzbidx[2] = {7, 7};
 
 /* 80C4E870-80C4E878 -00001 0008+00 3/3 0/0 0/0 .data            l_arcName */
-SECTION_DATA static void* l_arcName[2] = {
-    (void*)&d_a_obj_kwheel00__stringBase0,
-    (void*)(((char*)&d_a_obj_kwheel00__stringBase0) + 0xA),
-};
+static const char* l_arcName[2] = { "K_Wheel00", "S_wheel00" }; // K = Kinto, S = Shirogane?
 
 /* 80C4D6F8-80C4D7A8 000078 00B0+00 1/1 0/0 0/0 .text            create1st__15daObjKWheel00_cFv */
-void daObjKWheel00_c::create1st() {
-    // NONMATCHING
+int daObjKWheel00_c::create1st() {
+    m_type = static_cast<Type_e>(getType());
+    JUT_ASSERT(118, m_type == 0 || m_type == 1);
+
+    cPhs__Step phase = static_cast<cPhs__Step>(dComIfG_resLoad(this, l_arcName[m_type]));
+    if(phase == cPhs_COMPLEATE_e) {
+        setMtx();
+
+        phase = static_cast<cPhs__Step>(MoveBGCreate(l_arcName[m_type], l_dzbidx[m_type], NULL, 0x4000, &mNewBgMtx));
+
+        if(phase == cPhs_ERROR_e)
+            return phase;
+
+        /* 
+        TODO
+        "Waterwheel(Lv3)"
+
+        if(phase != cPhs_ERROR_e)
+            entryHIO(&l_HIO, "水車(Lv3)")
+        */
+    }
+    return phase;
+
 }
 
 /* 80C4D7A8-80C4D86C 000128 00C4+00 1/1 0/0 0/0 .text            searchLv3Water__FPvPv */
-static void searchLv3Water(void* param_0, void* param_1) {
-    // NONMATCHING
+static void* searchLv3Water(void* param_0, void* i_this) {
+    daLv3Water_c* const lv3Water = static_cast<daLv3Water_c*>(param_0);
+    daObjKWheel00_c* const kWheel00 = static_cast<daObjKWheel00_c*>(i_this);
+
+    if(lv3Water && fopAcM_IsActor(lv3Water) && fopAcM_GetProfName(lv3Water) == PROC_Obj_Lv3Water) {
+        if(
+            (fopAcM_GetRoomNo(kWheel00) == 7 && lv3Water->getType() == 8) || 
+            (fopAcM_GetRoomNo(kWheel00) == 11 && lv3Water->getType() == 14) ||
+            (fopAcM_GetRoomNo(kWheel00) == 2 && ((kWheel00->getSwNo() == 9 && lv3Water->getType() == 13) || (kWheel00->getSwNo() == 18 && lv3Water->getType() == 12)))
+        ) 
+        {
+            return param_0;
+        }
+    }
+    return NULL;
 }
 
 /* ############################################################################################## */
 /* 80C4E808-80C4E810 000008 0008+00 1/1 0/0 0/0 .rodata          l_bmdidx */
-SECTION_RODATA static u8 const l_bmdidx[8] = {
-    0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x04,
-};
-COMPILER_STRIP_GATE(0x80C4E808, &l_bmdidx);
+static const int l_bmdidx[2] = {4, 4};
 
 /* 80C4E810-80C4E840 000010 0030+00 1/1 0/0 0/0 .rodata          l_cull_box */
-SECTION_RODATA static u8 const l_cull_box[48] = {
-    0xC4, 0x4F, 0x80, 0x00, 0xC4, 0x4F, 0x80, 0x00, 0xC5, 0x1C, 0x40, 0x00, 0x44, 0x4F, 0x80, 0x00,
-    0x44, 0x4F, 0x80, 0x00, 0x43, 0x48, 0x00, 0x00, 0xC4, 0x0C, 0x00, 0x00, 0xC4, 0x0C, 0x00, 0x00,
-    0xC3, 0xAF, 0x00, 0x00, 0x44, 0x0C, 0x00, 0x00, 0x44, 0x0C, 0x00, 0x00, 0x43, 0xAF, 0x00, 0x00,
+const Vec l_cull_box[4] = {
+    {-830.0f, -830.0f, -2500.0f}, {830.0f, 830.0f, 200.0f}, // Type 0
+    {-560.0f, -560.0f, -350.0f}, {560.0f, 560.0f, 350.0f}   // Type 1
 };
-COMPILER_STRIP_GATE(0x80C4E810, &l_cull_box);
-
-/* 80C4E840-80C4E844 000040 0004+00 1/2 0/0 0/0 .rodata          @3696 */
-SECTION_RODATA static f32 const lit_3696 = 1.0f;
-COMPILER_STRIP_GATE(0x80C4E840, &lit_3696);
-
-/* 80C4E844-80C4E848 000044 0004+00 1/1 0/0 0/0 .rodata          @3697 */
-SECTION_RODATA static f32 const lit_3697 = 1.0f / 10.0f;
-COMPILER_STRIP_GATE(0x80C4E844, &lit_3697);
 
 /* 80C4D86C-80C4D9B8 0001EC 014C+00 2/2 0/0 0/0 .text            setMtx__15daObjKWheel00_cFv */
 void daObjKWheel00_c::setMtx() {
-    // NONMATCHING
+    mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
+    mDoMtx_stack_c::YrotM(current.angle.y);
+    mDoMtx_stack_c::ZrotM(current.angle.z);
+    
+    MTXCopy(mDoMtx_stack_c::get(), mTransformMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mNewBgMtx);
+
+    if(mZAngularVelocity) {
+        mDoMtx_stack_c::copy(mTransformMtx);
+
+        if(m_type == TYPE_LARGE_GOLD)
+            mDoMtx_stack_c::transM(cM_rndFX(1.0f), cM_rndFX(1.0f), cM_rndFX(1.0f));
+        else
+            mDoMtx_stack_c::transM(cM_rndFX(0.1f), cM_rndFX(0.1f), cM_rndFX(0.1f));
+
+        MTXCopy(mDoMtx_stack_c::get(), mTransformMtx);
+    }
 }
 
 /* 80C4D9B8-80C4DA38 000338 0080+00 1/0 0/0 0/0 .text            CreateHeap__15daObjKWheel00_cFv */
-void daObjKWheel00_c::CreateHeap() {
-    // NONMATCHING
+int daObjKWheel00_c::CreateHeap() {
+    J3DModelData* const model_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(l_arcName[m_type], l_bmdidx[m_type]));
+    JUT_ASSERT(206, model_data != 0);
+
+    mpModel = mDoExt_J3DModel__create(model_data, (1 << 19), 0x11000084);
+    return !mpModel ? 0 : 1;
 }
 
 /* ############################################################################################## */
 /* 80C4E878-80C4E8B8 000008 0040+00 1/1 0/0 0/0 .data            l_sphSrc */
 static dCcD_SrcSph l_sphSrc = {
     {
-        {0x0, {{0x0, 0x1, 0x0}, {0xd8fbfdff, 0x0}, 0x79}}, // mObj
+        {0x0, {{AT_TYPE_0, 0x1, 0x0}, {0xd8fbfdff, 0x0}, 0x79}}, // mObj
         {dCcD_SE_NONE, 0x0, 0x0, 0x0, 0x1}, // mGObjAt
         {dCcD_SE_NONE, 0x0, 0x0, 0x0, 0x0}, // mGObjTg
         {0x0}, // mGObjCo
@@ -181,89 +129,236 @@ static dCcD_SrcSph l_sphSrc = {
 };
 
 /* 80C4E8B8-80C4E8C0 000048 0008+00 2/2 0/0 0/0 .data            l_se_angle */
-SECTION_DATA static u8 l_se_angle[8] = {
-    0x00, 0x00, 0x3F, 0xFF, 0x7F, 0xFF, 0xBF, 0xFF,
-};
+u16 l_se_angle[4] = {0, 0x3FFF, 0x7FFF, 0xBFFF}; // {0°, 90°, 180°, 270°}
 
 /* 80C4DA38-80C4DBBC 0003B8 0184+00 1/0 0/0 0/0 .text            Create__15daObjKWheel00_cFv */
-void daObjKWheel00_c::Create() {
-    // NONMATCHING
+int daObjKWheel00_c::Create() {
+    mpModel->setBaseTRMtx(mTransformMtx);
+    fopAcM_SetMtx(this, mTransformMtx);
+
+    mZAngularVelocity = 0;
+    if(getSwNo() != 0xFF && fopAcM_isSwitch(this, getSwNo())) {
+        #ifdef DEBUG
+        if(getArg0())
+            mZAngularVelocity = l_HIO.mTargetZAngularSpeed;
+        else
+            mZAngularVelocity = -l_HIO.mTargetZAngularSpeed;
+        #else
+        if(getArg0())
+            mZAngularVelocity = 64;
+        else
+            mZAngularVelocity = -64;
+        #endif
+    }
+
+    const u32 minCullIdx = m_type << 1;
+    const u32 maxCullIdx = minCullIdx + 1;
+    fopAcM_setCullSizeBox(this, l_cull_box[minCullIdx].x, l_cull_box[minCullIdx].y, l_cull_box[minCullIdx].z, l_cull_box[maxCullIdx].x, l_cull_box[maxCullIdx].y, l_cull_box[maxCullIdx].z);
+
+    if(m_type == TYPE_SMALL_PLATINUM)
+        fopAcM_SetStatus(this, 0);
+
+    mStts.Init(254, 0, this);
+
+    for(int i = 0; i < 4; i++) {
+        mLargeGearTeethSphereColliders[i].SetStts(&mStts);
+        mLargeGearTeethSphereColliders[i].Set(l_sphSrc);
+    }
+
+    mPrevQuadrantalZAngle = DEG_INVALID;
+
+    for(int i = 0; i < 4; i++) {
+        if(current.angle.z == l_se_angle[i])
+            mPrevQuadrantalZAngle = static_cast<QuadrantalAngle_e>(i);
+    }
+
+    return 1;
 }
 
-/* ############################################################################################## */
-/* 80C4E848-80C4E84C 000048 0004+00 0/1 0/0 0/0 .rodata          @3904 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3904 = 830.0f;
-COMPILER_STRIP_GATE(0x80C4E848, &lit_3904);
-#pragma pop
-
-/* 80C4E84C-80C4E850 00004C 0004+00 0/1 0/0 0/0 .rodata          @3905 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3905 = 560.0f;
-COMPILER_STRIP_GATE(0x80C4E84C, &lit_3905);
-#pragma pop
-
-/* 80C4E850-80C4E854 000050 0004+00 0/1 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3906 = -1.0f;
-COMPILER_STRIP_GATE(0x80C4E850, &lit_3906);
-#pragma pop
-
-/* 80C4E854-80C4E858 000054 0004+00 0/1 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3907 = 160.0f;
-COMPILER_STRIP_GATE(0x80C4E854, &lit_3907);
-#pragma pop
-
-/* 80C4E858-80C4E85C 000058 0004+00 0/1 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3908 = 140.0f;
-COMPILER_STRIP_GATE(0x80C4E858, &lit_3908);
-#pragma pop
-
 /* 80C4E8C0-80C4E920 000050 0060+00 1/1 0/0 0/0 .data            l_pos */
-SECTION_DATA static u8 l_pos[96] = {
-    0x44, 0x4F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x44, 0x4F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC4, 0x4F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC4, 0x4F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x44, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x44, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC4, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC4, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+static Vec l_pos[8] = {
+    {830.0f, 0.0f, 0.0f}, {0.0f, 830.0f, 0.0f},
+    {-830.0f, 0.0f, 0.0f}, {0.0f, -830.0f, 0.0f},
+    {560.0f, 0.0f, 0.0f}, {0.0f, 560.0f, 0.0f},
+    {-560.0f, 0.0f, 0.0f}, {0.0f, -560.0f, 0.0f}
 };
 
 /* 80C4DBBC-80C4E1B0 00053C 05F4+00 1/0 0/0 0/0 .text Execute__15daObjKWheel00_cFPPA3_A4_f */
-void daObjKWheel00_c::Execute(f32 (**param_0)[3][4]) {
-    // NONMATCHING
+int daObjKWheel00_c::Execute(Mtx** i_mtx) {
+    eventUpdate();
+
+    if(mZAngularVelocity == 0 && fopAcM_isSwitch(this, getSwNo())) {
+        if(getEvent() != 0xFF)
+            orderEvent(getEvent(), 0xFF, 1);
+        else
+            eventStart();
+    }
+
+    // Only draw particles and play SFX if gear is moving
+    if(mZAngularVelocity != 0) {
+        // Increase angular velocity via an arithmetic sequence with a ratio of 2
+        #ifdef DEBUG
+        if(mZAngularVelocity > 0) {
+            if(mZAngularVelocity < l_HIO.mTargetZAngularSpeed)
+                mZAngularVelocity += l_HIO.mZAngularAcceleration;
+        }
+        else if(mZAngularVelocity > -l_HIO.mTargetZAngularSpeed) {
+            mZAngularVelocity -= l_HIO.mZAngularAcceleration;
+        }
+        #else
+        if(mZAngularVelocity > 0) {
+            if(mZAngularVelocity < 64)
+                mZAngularVelocity += 2;
+        }
+        else if(mZAngularVelocity > -64) {
+            mZAngularVelocity -= 2;
+        }
+        #endif
+
+        cXyz sfxPos = current.pos;
+        u32 wheelSfxID;
+        if(m_type == TYPE_LARGE_GOLD) {
+            sfxPos.y -= 830.0f; // Offset of tip of large gear tooth
+            wheelSfxID =  Z2SE_OBJ_WTR_WHL_1;
+        }
+        else {
+            sfxPos.y -= 560.0f; // Offset of tip of large gear tooth
+            wheelSfxID =  Z2SE_OBJ_WTR_WHL_2;
+        }
+
+        Z2GetAudioMgr()->seStartLevel(wheelSfxID, &sfxPos, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+
+        u16 currentIntermediateZAngle = current.angle.z;
+        s32 totalZAngleChange = mZAngularVelocity;
+
+        // Assume clockwise movement, change to counter-clockwise if angular velocity is negative
+        s32 angleStep = 1;
+        if(totalZAngleChange < 0) {
+            totalZAngleChange *= -1;
+            angleStep = -1;
+        }
+
+        bool passedQuadrantalAngle = false;
+        for(int angleOffset = 0; angleOffset < totalZAngleChange; angleOffset++) {
+            for(int quadrantalAngle = DEG_0; quadrantalAngle < DEG_MAX; quadrantalAngle++) {
+                // Only draw particles & make splash sfx if a quadrantal angle is passed (reults in larger gear teeth hitting water)
+                if(currentIntermediateZAngle == l_se_angle[quadrantalAngle] && quadrantalAngle != mPrevQuadrantalZAngle) {
+                    passedQuadrantalAngle = true;
+                    mPrevQuadrantalZAngle = static_cast<QuadrantalAngle_e>(quadrantalAngle);
+
+                    u32 splashSfxID;
+                    if(m_type == TYPE_LARGE_GOLD)
+                        splashSfxID = Z2SE_OBJ_WTR_WHL_1_SPLSH;
+                    else
+                        splashSfxID = Z2SE_OBJ_WTR_WHL_2_SPLSH;
+
+                    Z2GetAudioMgr()->seStart(splashSfxID, &sfxPos, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+                    
+                    if(fopAcM_GetRoomNo(this) == 7) {
+                        daLv3Water_c* const lv3Water = static_cast<daLv3Water_c*>(fopAcM_Search(searchLv3Water, this));
+                        if(lv3Water) {
+                            dComIfGp_particle_set(0x8AB0,&lv3Water->current.pos,NULL, NULL);
+                            dComIfGp_particle_set(0x8AB1,&lv3Water->current.pos,NULL, NULL);
+                        }
+                    }
+                    else if(fopAcM_GetRoomNo(this) == 11) {
+                        daLv3Water_c* const lv3Water = static_cast<daLv3Water_c*>(fopAcM_Search(searchLv3Water, this));
+                        if(lv3Water) {
+                            dComIfGp_particle_set(0x8ABD,&lv3Water->current.pos,NULL, NULL);
+                            dComIfGp_particle_set(0x8ABE,&lv3Water->current.pos,NULL, NULL);
+                        }
+                    }
+                    else if(fopAcM_GetRoomNo(this) == 2) {
+                        daLv3Water_c* const lv3Water = static_cast<daLv3Water_c*>(fopAcM_Search(searchLv3Water, this));
+                        if(lv3Water) {
+                            if(getSwNo() == 9) {
+                                dComIfGp_particle_set(0x8B04,&lv3Water->current.pos,NULL, NULL);
+                                dComIfGp_particle_set(0x8B05,&lv3Water->current.pos,NULL, NULL);
+                            }
+                            else {
+                                dComIfGp_particle_set(0x8B06,&lv3Water->current.pos,NULL, NULL);
+                                dComIfGp_particle_set(0x8B07,&lv3Water->current.pos,NULL, NULL);
+                            }
+                        }
+                    }
+
+                    break;
+                }
+            }
+
+            if(passedQuadrantalAngle == true) break;
+            currentIntermediateZAngle += angleStep;
+        }
+    }
+
+    current.angle.z += mZAngularVelocity;
+    setMtx();
+    mpModel->setBaseTRMtx(mTransformMtx);
+    *i_mtx = &mNewBgMtx;
+
+    // Only update colliders if gear is moving
+    if(mZAngularVelocity) {
+        for(int sphereColliderIdx = 0; sphereColliderIdx < 4; sphereColliderIdx++) {
+            cXyz largeGearToothPos;
+            MTXMultVec(mNewBgMtx, &l_pos[sphereColliderIdx + (m_type << 2)], &largeGearToothPos);
+            mLargeGearTeethSphereColliders[sphereColliderIdx].SetC(largeGearToothPos);
+
+            if(m_type == TYPE_LARGE_GOLD)
+                mLargeGearTeethSphereColliders[sphereColliderIdx].SetR(160.0f);
+            else
+                mLargeGearTeethSphereColliders[sphereColliderIdx].SetR(140.0f);
+            
+            dComIfG_Ccsp()->Set(&mLargeGearTeethSphereColliders[sphereColliderIdx]);
+        }
+    }
+
+    return 1;
 }
 
 /* 80C4E1B0-80C4E254 000B30 00A4+00 1/0 0/0 0/0 .text            Draw__15daObjKWheel00_cFv */
-void daObjKWheel00_c::Draw() {
-    // NONMATCHING
+int daObjKWheel00_c::Draw() {
+    g_env_light.settingTevStruct(16, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpModel, &tevStr);
+
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+
+    return 1;
 }
 
 /* 80C4E254-80C4E298 000BD4 0044+00 1/0 0/0 0/0 .text            Delete__15daObjKWheel00_cFv */
-void daObjKWheel00_c::Delete() {
-    // NONMATCHING
+int daObjKWheel00_c::Delete() {
+    dComIfG_resDelete(this, l_arcName[m_type]);
+
+    return 1;
 }
 
 /* 80C4E298-80C4E2C0 000C18 0028+00 2/1 0/0 0/0 .text            eventStart__15daObjKWheel00_cFv */
-void daObjKWheel00_c::eventStart() {
-    // NONMATCHING
+BOOL daObjKWheel00_c::eventStart() {
+    #if DEBUG
+    if(getArg0())
+        mZAngularVelocity = l_HIO.mZAngularAcceleration;
+    else
+        mZAngularVelocity = -l_HIO.mZAngularAcceleration;
+    #else
+    if(getArg0())
+        mZAngularVelocity = 2;
+    else
+        mZAngularVelocity = -2;
+    #endif
+
+    return TRUE;
 }
 
 /* ############################################################################################## */
 /* 80C4E920-80C4E940 -00001 0020+00 1/0 0/0 0/0 .data            daObjKWheel00_METHODS */
 static actor_method_class daObjKWheel00_METHODS = {
-    (process_method_func)daObjKWheel00_create1st__FP15daObjKWheel00_c,
-    (process_method_func)daObjKWheel00_MoveBGDelete__FP15daObjKWheel00_c,
-    (process_method_func)daObjKWheel00_MoveBGExecute__FP15daObjKWheel00_c,
+    (process_method_func)daObjKWheel00_create1st,
+    (process_method_func)daObjKWheel00_MoveBGDelete,
+    (process_method_func)daObjKWheel00_MoveBGExecute,
     0,
-    (process_method_func)daObjKWheel00_MoveBGDraw__FP15daObjKWheel00_c,
+    (process_method_func)daObjKWheel00_MoveBGDraw,
 };
 
 /* 80C4E940-80C4E970 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_KWheel00 */
@@ -284,164 +379,27 @@ extern actor_process_profile_definition g_profile_Obj_KWheel00 = {
   fopAc_CULLBOX_CUSTOM_e,  // cullType
 };
 
-/* 80C4E970-80C4E97C 000100 000C+00 3/3 0/0 0/0 .data            __vt__10cCcD_GStts */
-SECTION_DATA extern void* __vt__10cCcD_GStts[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__10cCcD_GSttsFv,
-};
-
-/* 80C4E97C-80C4E988 00010C 000C+00 2/2 0/0 0/0 .data            __vt__10dCcD_GStts */
-SECTION_DATA extern void* __vt__10dCcD_GStts[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__10dCcD_GSttsFv,
-};
-
-/* 80C4E988-80C4E994 000118 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGAab */
-SECTION_DATA extern void* __vt__8cM3dGAab[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGAabFv,
-};
-
-/* 80C4E994-80C4E9A0 000124 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGSph */
-SECTION_DATA extern void* __vt__8cM3dGSph[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGSphFv,
-};
-
-/* 80C4E9A0-80C4E9B8 000130 0018+00 3/3 0/0 0/0 .data            __vt__17dEvLib_callback_c */
-SECTION_DATA extern void* __vt__17dEvLib_callback_c[6] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__17dEvLib_callback_cFv,
-    (void*)eventStart__17dEvLib_callback_cFv,
-    (void*)eventRun__17dEvLib_callback_cFv,
-    (void*)eventEnd__17dEvLib_callback_cFv,
-};
-
-/* 80C4E9B8-80C4EA00 000148 0048+00 2/2 0/0 0/0 .data            __vt__15daObjKWheel00_c */
-SECTION_DATA extern void* __vt__15daObjKWheel00_c[18] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)CreateHeap__15daObjKWheel00_cFv,
-    (void*)Create__15daObjKWheel00_cFv,
-    (void*)Execute__15daObjKWheel00_cFPPA3_A4_f,
-    (void*)Draw__15daObjKWheel00_cFv,
-    (void*)Delete__15daObjKWheel00_cFv,
-    (void*)IsDelete__16dBgS_MoveBgActorFv,
-    (void*)ToFore__16dBgS_MoveBgActorFv,
-    (void*)ToBack__16dBgS_MoveBgActorFv,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80C4E7F0,
-    (void*)func_80C4E7E8,
-    (void*)eventRun__17dEvLib_callback_cFv,
-    (void*)eventEnd__17dEvLib_callback_cFv,
-    (void*)__dt__15daObjKWheel00_cFv,
-    (void*)eventStart__15daObjKWheel00_cFv,
-};
-
 /* 80C4E2C0-80C4E394 000C40 00D4+00 1/0 0/0 0/0 .text daObjKWheel00_create1st__FP15daObjKWheel00_c
  */
-static void daObjKWheel00_create1st(daObjKWheel00_c* param_0) {
-    // NONMATCHING
-}
-
-/* 80C4E394-80C4E460 000D14 00CC+00 2/2 0/0 0/0 .text            __dt__8dCcD_SphFv */
-// dCcD_Sph::~dCcD_Sph() {
-extern "C" void __dt__8dCcD_SphFv() {
-    // NONMATCHING
-}
-
-/* 80C4E460-80C4E4E4 000DE0 0084+00 1/1 0/0 0/0 .text            __ct__8dCcD_SphFv */
-// dCcD_Sph::dCcD_Sph() {
-extern "C" void __ct__8dCcD_SphFv() {
-    // NONMATCHING
-}
-
-/* 80C4E4E4-80C4E52C 000E64 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGSphFv */
-// cM3dGSph::~cM3dGSph() {
-extern "C" void __dt__8cM3dGSphFv() {
-    // NONMATCHING
-}
-
-/* 80C4E52C-80C4E574 000EAC 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGAabFv */
-// cM3dGAab::~cM3dGAab() {
-extern "C" void __dt__8cM3dGAabFv() {
-    // NONMATCHING
-}
-
-/* 80C4E574-80C4E5D0 000EF4 005C+00 1/0 0/0 0/0 .text            __dt__10dCcD_GSttsFv */
-// dCcD_GStts::~dCcD_GStts() {
-extern "C" void __dt__10dCcD_GSttsFv() {
-    // NONMATCHING
+static int daObjKWheel00_create1st(daObjKWheel00_c* i_this) {
+    fopAcM_SetupActor(i_this, daObjKWheel00_c);
+    return i_this->create1st();
 }
 
 /* 80C4E5D0-80C4E5F0 000F50 0020+00 1/0 0/0 0/0 .text
  * daObjKWheel00_MoveBGDelete__FP15daObjKWheel00_c              */
-static void daObjKWheel00_MoveBGDelete(daObjKWheel00_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel00_MoveBGDelete(daObjKWheel00_c* i_this) {
+    return i_this->MoveBGDelete();
 }
 
 /* 80C4E5F0-80C4E610 000F70 0020+00 1/0 0/0 0/0 .text
  * daObjKWheel00_MoveBGExecute__FP15daObjKWheel00_c             */
-static void daObjKWheel00_MoveBGExecute(daObjKWheel00_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel00_MoveBGExecute(daObjKWheel00_c* i_this) {
+    return i_this->MoveBGExecute();
 }
 
 /* 80C4E610-80C4E63C 000F90 002C+00 1/0 0/0 0/0 .text
  * daObjKWheel00_MoveBGDraw__FP15daObjKWheel00_c                */
-static void daObjKWheel00_MoveBGDraw(daObjKWheel00_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel00_MoveBGDraw(daObjKWheel00_c* i_this) {
+    return i_this->MoveBGDraw();
 }
-
-/* 80C4E63C-80C4E684 000FBC 0048+00 1/0 0/0 0/0 .text            __dt__10cCcD_GSttsFv */
-// cCcD_GStts::~cCcD_GStts() {
-extern "C" void __dt__10cCcD_GSttsFv() {
-    // NONMATCHING
-}
-
-/* 80C4E684-80C4E6CC 001004 0048+00 1/0 0/0 0/0 .text            __dt__17dEvLib_callback_cFv */
-// dEvLib_callback_c::~dEvLib_callback_c() {
-extern "C" void __dt__17dEvLib_callback_cFv() {
-    // NONMATCHING
-}
-
-/* 80C4E6CC-80C4E6D4 00104C 0008+00 1/0 0/0 0/0 .text            eventStart__17dEvLib_callback_cFv
- */
-// bool dEvLib_callback_c::eventStart()() {
-extern "C" bool eventStart__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C4E6D4-80C4E6DC 001054 0008+00 2/0 0/0 0/0 .text            eventRun__17dEvLib_callback_cFv */
-// bool dEvLib_callback_c::eventRun() {
-extern "C" bool eventRun__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C4E6DC-80C4E6E4 00105C 0008+00 2/0 0/0 0/0 .text            eventEnd__17dEvLib_callback_cFv */
-// bool dEvLib_callback_c::eventEnd() {
-extern "C" bool eventEnd__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C4E6E4-80C4E7E8 001064 0104+00 2/1 0/0 0/0 .text            __dt__15daObjKWheel00_cFv */
-daObjKWheel00_c::~daObjKWheel00_c() {
-    // NONMATCHING
-}
-
-/* 80C4E7E8-80C4E7F0 001168 0008+00 1/0 0/0 0/0 .text @1448@eventStart__15daObjKWheel00_cFv */
-static void func_80C4E7E8() {
-    // NONMATCHING
-}
-
-/* 80C4E7F0-80C4E7F8 001170 0008+00 1/0 0/0 0/0 .text            @1448@__dt__15daObjKWheel00_cFv */
-static void func_80C4E7F0() {
-    // NONMATCHING
-}
-
-/* 80C4E85C-80C4E85C 00005C 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */

--- a/src/d/actor/d_a_obj_kwheel00.cpp
+++ b/src/d/actor/d_a_obj_kwheel00.cpp
@@ -4,9 +4,11 @@
 */
 
 #include "d/actor/d_a_obj_kwheel00.h"
+#include "JSystem/JHostIO/JORMContext.h"
 #include "d/actor/d_a_obj_lv3Water.h"
 #include "d/d_com_inf_game.h"
 #include "SSystem/SComponent/c_math.h"
+#include "m_Do/m_Do_hostIO.h"
 
 static int daObjKWheel00_create1st(daObjKWheel00_c*);
 static int daObjKWheel00_MoveBGDelete(daObjKWheel00_c*);
@@ -20,6 +22,17 @@ static daObjKWheel00_HIO_c l_HIO;
 daObjKWheel00_HIO_c::daObjKWheel00_HIO_c() {
     mTargetZAngularSpeed = 64;
     mZAngularAcceleration = 2;
+}
+
+void daObjKWheel00_HIO_c::genMessage(JORMContext* ctx) {
+    // "Water wheel"
+    ctx->genLabel("水車", 0, 0, NULL, 0xFFFF, 0xFFFF, 0x200, 0x18);
+
+    // "Rotational speed(short)"
+    ctx->genSlider("回転速度(short)",&mTargetZAngularSpeed, 0, 0x4000, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Rotational acceleration(short)"
+    ctx->genSlider("回転加速度(short)",&mZAngularAcceleration, 0, 32, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
 }
 
 /* ############################################################################################## */
@@ -43,13 +56,8 @@ int daObjKWheel00_c::create1st() {
         if(phase == cPhs_ERROR_e)
             return phase;
 
-        /* 
-        TODO
-        "Waterwheel(Lv3)"
-
-        if(phase != cPhs_ERROR_e)
-            entryHIO(&l_HIO, "水車(Lv3)")
-        */
+        // "Water wheel(Lv3)"
+        l_HIO.entryHIO("水車(Lv3)");
     }
     return phase;
 
@@ -329,6 +337,7 @@ int daObjKWheel00_c::Draw() {
 /* 80C4E254-80C4E298 000BD4 0044+00 1/0 0/0 0/0 .text            Delete__15daObjKWheel00_cFv */
 int daObjKWheel00_c::Delete() {
     dComIfG_resDelete(this, l_arcName[m_type]);
+    l_HIO.removeHIO();
 
     return 1;
 }

--- a/src/d/actor/d_a_obj_kwheel00.cpp
+++ b/src/d/actor/d_a_obj_kwheel00.cpp
@@ -4,7 +4,6 @@
 */
 
 #include "d/actor/d_a_obj_kwheel00.h"
-#include "Z2AudioLib/Z2AudioMgr.h"
 #include "d/actor/d_a_obj_lv3Water.h"
 #include "d/d_com_inf_game.h"
 #include "SSystem/SComponent/c_math.h"

--- a/src/d/actor/d_a_obj_kwheel00.cpp
+++ b/src/d/actor/d_a_obj_kwheel00.cpp
@@ -17,7 +17,6 @@ static int daObjKWheel00_MoveBGDraw(daObjKWheel00_c*);
 
 #ifdef DEBUG
 static daObjKWheel00_HIO_c l_HIO;
-#endif
 
 daObjKWheel00_HIO_c::daObjKWheel00_HIO_c() {
     mTargetZAngularSpeed = 64;
@@ -34,6 +33,7 @@ void daObjKWheel00_HIO_c::genMessage(JORMContext* ctx) {
     // "Rotational acceleration(short)"
     ctx->genSlider("回転加速度(short)",&mZAngularAcceleration, 0, 32, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
 }
+#endif
 
 /* ############################################################################################## */
 /* 80C4E800-80C4E808 000000 0008+00 2/2 0/0 0/0 .rodata          l_dzbidx */
@@ -56,8 +56,10 @@ int daObjKWheel00_c::create1st() {
         if(phase == cPhs_ERROR_e)
             return phase;
 
+        #ifdef DEBUG
         // "Water wheel(Lv3)"
         l_HIO.entryHIO("水車(Lv3)");
+        #endif
     }
     return phase;
 
@@ -337,7 +339,10 @@ int daObjKWheel00_c::Draw() {
 /* 80C4E254-80C4E298 000BD4 0044+00 1/0 0/0 0/0 .text            Delete__15daObjKWheel00_cFv */
 int daObjKWheel00_c::Delete() {
     dComIfG_resDelete(this, l_arcName[m_type]);
+
+    #ifdef DEBUG
     l_HIO.removeHIO();
+    #endif
 
     return 1;
 }

--- a/src/d/actor/d_a_obj_kwheel01.cpp
+++ b/src/d/actor/d_a_obj_kwheel01.cpp
@@ -4,9 +4,35 @@
 */
 
 #include "d/actor/d_a_obj_kwheel01.h"
+#include "SSystem/SComponent/c_math.h"
+#include "SSystem/SComponent/c_phase.h"
+#include "Z2AudioLib/Z2AudioMgr.h"
+#include "Z2AudioLib/Z2SeMgr.h"
+#include "d/actor/d_a_obj_klift00.h"
+#include "d/actor/d_a_obj_kwheel00.h"
+#include "d/actor/d_a_player.h"
+#include "d/d_bg_s.h"
+#include "d/d_bg_w.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_event_manager.h"
+#include "d/d_kankyo.h"
+#include "d/d_procname.h"
 #include "dol2asm.h"
+#include "f_op/f_op_actor.h"
+#include "f_op/f_op_actor_iter.h"
+#include "f_op/f_op_actor_mng.h"
+#include "f_pc/f_pc_base.h"
+#include "f_pc/f_pc_searcher.h"
+#include "m_Do/m_Do_ext.h"
+#include "m_Do/m_Do_mtx.h"
+#include "mtx.h"
 
+static int daObjKWheel01_create1st(daObjKWheel01_c*);
+static int daObjKWheel01_MoveBGDelete(daObjKWheel01_c*);
+static int daObjKWheel01_MoveBGExecute(daObjKWheel01_c*);
+static int daObjKWheel01_MoveBGDraw(daObjKWheel01_c*);
 
+#if 0
 //
 // Forward References:
 //
@@ -87,6 +113,7 @@ extern "C" extern void* __vt__16dBgS_MoveBgActor[10];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
+#endif
 
 //
 // Declarations:
@@ -94,103 +121,366 @@ extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 
 /* ############################################################################################## */
 /* 80C4F6B8-80C4F6C4 000000 000C+00 2/2 0/0 0/0 .rodata          l_dzbidx */
+static const u32 l_dzbidx[3] = {9, 8, 10};
+#if 0
 SECTION_RODATA static u8 const l_dzbidx[12] = {
     0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x0A,
 };
 COMPILER_STRIP_GATE(0x80C4F6B8, &l_dzbidx);
+#endif
 
 /* 80C4F6EC-80C4F6EC 000034 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
+#if 0
 #pragma push
 #pragma force_active on
 SECTION_DEAD static char const* const stringBase_80C4F6EC = "K_Wheel01";
 #pragma pop
+#endif
 
 /* 80C4F6F8-80C4F6FC -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
+static const char* l_arcName = "K_Wheel01";
+#if 0
 SECTION_DATA static void* l_arcName = (void*)&d_a_obj_kwheel01__stringBase0;
+#endif
+
+#ifdef DEBUG
+static daObjKWheel01_HIO_c l_HIO;
+#endif
+
+// Likely to have been a macro; matches for loop at beginning of create1st for both debug and retail, despite retail only calling getArg4567()
+#define CHECK_KLIFT_EXISTS(kLiftNum) (!((1 << kLiftNum) & getArg4567()))
+
+daObjKWheel01_HIO_c::daObjKWheel01_HIO_c() {
+    mTargetYAngularSpeed = 64;
+    mYAngularAcceleration = 2;
+}
 
 /* 80C4F6FC-80C4F72C 000004 0030+00 3/3 0/0 0/0 .data            l_pos */
+static Vec l_pos[4] = {
+    {930.0f, -165.0f, 0.0f}, {0.0f, -165.0f, 930.0f},
+    {-930.0f, -165.0f, 0.0f}, {0.0f, -165.0f, -930.0f}
+};
+#if 0
 SECTION_DATA static u8 l_pos[48] = {
     0x44, 0x68, 0x80, 0x00, 0xC3, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0xC3, 0x25, 0x00, 0x00, 0x44, 0x68, 0x80, 0x00, 0xC4, 0x68, 0x80, 0x00, 0xC3, 0x25, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC3, 0x25, 0x00, 0x00, 0xC4, 0x68, 0x80, 0x00,
 };
+#endif
 
 /* 80C4EA78-80C4EC54 000078 01DC+00 1/1 0/0 0/0 .text            create1st__15daObjKWheel01_cFv */
-void daObjKWheel01_c::create1st() {
-    // NONMATCHING
+cPhs__Step daObjKWheel01_c::create1st() {
+    bool atLeastOneKLiftExists = false;
+    s8 debugStackVar;
+
+    for(int i = 0; i < 4; i++) {
+        if(CHECK_KLIFT_EXISTS(i)) {
+            atLeastOneKLiftExists = true;
+        } 
+    }
+
+    if(!mCreatedKLifts) {
+        setMtx();
+        u32 createLiftParameters = (getArg2() & 0x3F) | daObjKLift00_c::LOCK_e | daObjKLift00_c::NO_BASE_DISP;
+        for(int i = 0; i < 4; i++) {
+            if(CHECK_KLIFT_EXISTS(i)) {
+                cXyz kLiftPos;
+                MTXMultVec(mNewBgMtx, &l_pos[i], &kLiftPos);
+                m_klift_pid[i] = fopAcM_create(PROC_Obj_KLift00, createLiftParameters, &kLiftPos, fopAcM_GetHomeRoomNo(this), 0, 0, -1);
+                JUT_ASSERT(146, m_klift_pid[i] != fpcM_ERROR_PROCESS_ID_e);
+
+                mCreatedKLifts = true;
+            }
+        }
+    }
+
+    cPhs__Step phase = static_cast<cPhs__Step>(dComIfG_resLoad(this, l_arcName));
+    if(phase == cPhs_COMPLEATE_e) {
+        mYAngularVelocity = 0;
+        setMtx();
+
+
+        phase = static_cast<cPhs__Step>(MoveBGCreate(l_arcName, (getOut() ? l_dzbidx[2] : l_dzbidx[0]), dBgS_MoveBGProc_TypicalRotY, 0x5D98, &mNewBgMtx));
+        if(phase == cPhs_ERROR_e)
+            return phase;
+
+        for(int i = 0; i < 4; i++) {
+            if(CHECK_KLIFT_EXISTS(i) && dComIfG_Bgsp().Regist(mKLiftCollisions[i], this))
+                return cPhs_ERROR_e;
+        }
+    }
+
+    return phase;
 }
 
 /* ############################################################################################## */
 /* 80C4F6C4-80C4F6CC 00000C 0008+00 1/1 0/0 0/0 .rodata          l_bmdidx */
+static const int l_bmdidx[2] = {4, 5};
+#if 0
 SECTION_RODATA static u8 const l_bmdidx[8] = {
     0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x05,
 };
 COMPILER_STRIP_GATE(0x80C4F6C4, &l_bmdidx);
+#endif
 
 /* 80C4F6CC-80C4F6E4 000014 0018+00 1/1 0/0 0/0 .rodata          l_cull_box */
+static const Vec l_cull_box[2] = {
+    {-1260.0f, -3050.0f, -1260.0f},
+    {1260.0f, 2800.0f, 1260.0f}
+};
+#if 0
 SECTION_RODATA static u8 const l_cull_box[24] = {
     0xC4, 0x9D, 0x80, 0x00, 0xC5, 0x3E, 0xA0, 0x00, 0xC4, 0x9D, 0x80, 0x00,
     0x44, 0x9D, 0x80, 0x00, 0x45, 0x2F, 0x00, 0x00, 0x44, 0x9D, 0x80, 0x00,
 };
 COMPILER_STRIP_GATE(0x80C4F6CC, &l_cull_box);
+#endif
 
+#if 0
 /* 80C4F6E4-80C4F6E8 00002C 0004+00 2/2 0/0 0/0 .rodata          @3717 */
 SECTION_RODATA static f32 const lit_3717 = 1.0f;
 COMPILER_STRIP_GATE(0x80C4F6E4, &lit_3717);
+#endif
 
 /* 80C4EC54-80C4EDCC 000254 0178+00 2/2 0/0 0/0 .text            setMtx__15daObjKWheel01_cFv */
 void daObjKWheel01_c::setMtx() {
-    // NONMATCHING
+    mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
+    mDoMtx_stack_c::YrotM(current.angle.y);
+    
+    MTXCopy(mDoMtx_stack_c::get(), mTransformMtx);
+    MTXCopy(mDoMtx_stack_c::get(), mNewBgMtx);
+
+    if(mYAngularVelocity) {
+        mDoMtx_stack_c::copy(mTransformMtx);
+        mDoMtx_stack_c::transM(cM_rndFX(1.0f), cM_rndFX(1.0f), cM_rndFX(1.0f));
+        MTXCopy(mDoMtx_stack_c::get(), mTransformMtx);
+    }
+
+    for(int i = 0; i < 4; i++) {
+        if(CHECK_KLIFT_EXISTS(i)) {
+            Vec kLiftPos;
+            MTXMultVec(mNewBgMtx, &l_pos[i], &kLiftPos);
+            mDoMtx_stack_c::transS(kLiftPos.x, kLiftPos.y, kLiftPos.z);
+            MTXCopy(mDoMtx_stack_c::get(), mKLiftBaseMatrices[i]);
+        }
+    }
 }
 
 /* 80C4EDCC-80C4EF38 0003CC 016C+00 1/0 0/0 0/0 .text            CreateHeap__15daObjKWheel01_cFv */
-void daObjKWheel01_c::CreateHeap() {
-    // NONMATCHING
+int daObjKWheel01_c::CreateHeap() {
+    J3DModelData* model_data = static_cast<J3DModelData*>(dComIfG_getObjectRes(l_arcName, l_bmdidx[getOut()]));
+    JUT_ASSERT(229, model_data != 0);
+    mpModel = mDoExt_J3DModel__create(model_data, (1 << 19), 0x11000084);
+
+    if(!mpModel)
+        return 0;
+
+    for(int i = 0; i < 4; i++) {
+        if(!CHECK_KLIFT_EXISTS(i)) {
+            mKLiftCollisions[i] = NULL;
+        }
+        else {
+            mKLiftCollisions[i] = new (dBgW);
+
+            if(!mKLiftCollisions[i])
+                return 0;
+
+            if(mKLiftCollisions[i]->Set(static_cast<cBgD_t*>(dComIfG_getObjectRes(l_arcName, l_dzbidx[1])), 1, &mKLiftBaseMatrices[i])) {
+                mKLiftCollisions[i] = NULL;
+                return 0;
+            }
+        }
+    }
+
+    return 1;
 }
 
 /* 80C4EF38-80C4EFEC 000538 00B4+00 1/0 0/0 0/0 .text            Create__15daObjKWheel01_cFv */
-void daObjKWheel01_c::Create() {
-    // NONMATCHING
+int daObjKWheel01_c::Create() {
+    mpModel->setBaseTRMtx(mTransformMtx);
+    fopAcM_SetMtx(this, mTransformMtx);
+
+    if(getSwNo() != 0xFF && fopAcM_isSwitch(this, getSwNo())) {
+        #ifdef DEBUG
+        if(getArg0()) {
+            mYAngularVelocity = l_HIO.mTargetYAngularSpeed;
+        }
+        else
+            mYAngularVelocity = -l_HIO.mTargetYAngularSpeed;
+        #else
+        if(getArg0())
+            mYAngularVelocity = 64;
+        else
+            mYAngularVelocity = -64;
+        #endif
+    }
+
+    fopAcM_setCullSizeBox(this, l_cull_box[0].x, l_cull_box[0].y, l_cull_box[0].z, l_cull_box[1].x, l_cull_box[1].y, l_cull_box[1].z);
+
+    return 1;
 }
 
 /* 80C4EFEC-80C4F048 0005EC 005C+00 1/1 0/0 0/0 .text            searchKWheel00__FPvPv */
-static void searchKWheel00(void* param_0, void* param_1) {
-    // NONMATCHING
+static void* searchKWheel00(void* param_0, void* i_this) {
+    i_this; // Needed to bring closer to matching debug REL
+    if(param_0 && fopAcM_IsActor(param_0) && fopAcM_GetProfName(param_0) == PROC_Obj_KWheel00) {
+        daObjKWheel00_c* const kWheel00 = static_cast<daObjKWheel00_c*>(param_0);
+        if(kWheel00->getType() == daObjKWheel00_c::TYPE_LARGE_GOLD) {
+            return kWheel00;
+        }
+    }
+
+    return NULL;
 }
 
+#if 0
 /* ############################################################################################## */
 /* 80C4F6E8-80C4F6EC 000030 0004+00 1/1 0/0 0/0 .rodata          @3888 */
 SECTION_RODATA static f32 const lit_3888 = -1.0f;
 COMPILER_STRIP_GATE(0x80C4F6E8, &lit_3888);
+#endif
 
 /* 80C4F048-80C4F344 000648 02FC+00 1/0 0/0 0/0 .text Execute__15daObjKWheel01_cFPPA3_A4_f */
-void daObjKWheel01_c::Execute(f32 (**param_0)[3][4]) {
-    // NONMATCHING
+int daObjKWheel01_c::Execute(Mtx** i_mtx) {
+    eventUpdate();
+
+    if(getSwNo() == 0xFF) {
+        daObjKWheel00_c* const foundKWheel00 = static_cast<daObjKWheel00_c*>(fopAcM_Search(searchKWheel00, this));
+        if(foundKWheel00) {
+            if(getArg0())
+                current.angle.y += foundKWheel00->current.angle.z - foundKWheel00->old.angle.z;
+            else
+                current.angle.y -= foundKWheel00->current.angle.z - foundKWheel00->old.angle.z;
+
+            shape_angle.y = current.angle.y;
+
+            if(current.angle.y != old.angle.y) {
+                #ifdef DEBUG
+                mYAngularVelocity = l_HIO.mTargetYAngularSpeed;
+                #else
+                mYAngularVelocity = 64;
+                #endif
+            }
+        }
+    }
+    else {
+        if(mYAngularVelocity == 0) {
+            if(fopAcM_isSwitch(this, getSwNo())) {
+                if(getEvent() != 0xFF) {
+                    const s32 eventIndex = dComIfGp_getEventManager().getEventIdx(this, getEvent());
+                    setEvent(eventIndex, getEvent(), 1);
+                }
+                else {
+                    eventStart();
+                }
+            }
+        }
+
+        if(mYAngularVelocity != 0) {
+            #ifdef DEBUG
+            if(mYAngularVelocity > 0) {
+                if(mYAngularVelocity < l_HIO.mTargetYAngularSpeed)
+                    mYAngularVelocity += l_HIO.mYAngularAcceleration;
+            }
+            else if(mYAngularVelocity > -l_HIO.mTargetYAngularSpeed) {
+                mYAngularVelocity -= l_HIO.mYAngularAcceleration;
+            }
+            #else
+            if(mYAngularVelocity > 0) {
+                if(mYAngularVelocity < 64)
+                    mYAngularVelocity += 2;
+            }
+            else if(mYAngularVelocity > -64) {
+                mYAngularVelocity -= 2;
+            }
+            #endif
+        }
+
+        current.angle.y += mYAngularVelocity;
+        shape_angle.y = current.angle.y;
+    }
+
+    setMtx();
+    mpModel->setBaseTRMtx(mTransformMtx);
+    *i_mtx = &mNewBgMtx;
+
+    for(int i = 0; i < 4; i++) {
+        if(CHECK_KLIFT_EXISTS(i)) {
+            daObjKLift00_c* const foundKLift = static_cast<daObjKLift00_c*>(fopAcM_SearchByID(m_klift_pid[i]));
+
+            if(foundKLift) {
+                cXyz kLiftOffset;
+                MTXMultVec(mNewBgMtx, &l_pos[i], &kLiftOffset);
+
+                foundKLift->current.pos = kLiftOffset;
+                foundKLift->shape_angle.y += mpBgW->GetDiffShapeAngleY();
+                foundKLift->home.angle.y += mpBgW->GetDiffShapeAngleY();
+            }
+        }
+    }
+
+
+    for(int i = 0; i < 4; i++) {
+        if(CHECK_KLIFT_EXISTS(i)) 
+            mKLiftCollisions[i]->Move();
+    }
+
+    // Stack ordering issues arise if mDoAud_seStartLevel is used
+    if(mYAngularVelocity)
+        Z2GetAudioMgr()->seStartLevel(Z2SE_OBJ_GEAR_LV, &current.pos, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+
+    return 1;
 }
 
 /* 80C4F344-80C4F3E8 000944 00A4+00 1/0 0/0 0/0 .text            Draw__15daObjKWheel01_cFv */
-void daObjKWheel01_c::Draw() {
-    // NONMATCHING
+int daObjKWheel01_c::Draw() {
+    g_env_light.settingTevStruct(16, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpModel, &tevStr);
+
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+
+    return 1;
 }
 
 /* 80C4F3E8-80C4F498 0009E8 00B0+00 1/0 0/0 0/0 .text            Delete__15daObjKWheel01_cFv */
-void daObjKWheel01_c::Delete() {
-    // NONMATCHING
+int daObjKWheel01_c::Delete() {
+    dComIfG_resDelete(this, l_arcName);
+
+    for(int i = 0; i < 4; i++) {
+        if(CHECK_KLIFT_EXISTS(i) && mKLiftCollisions[i] && mKLiftCollisions[i]->ChkUsed())
+            dComIfG_Bgsp().Release(mKLiftCollisions[i]);
+    }
+
+    return 1;
 }
 
 /* 80C4F498-80C4F4C0 000A98 0028+00 2/2 0/0 0/0 .text            eventStart__15daObjKWheel01_cFv */
-void daObjKWheel01_c::eventStart() {
-    // NONMATCHING
+BOOL daObjKWheel01_c::eventStart() {
+    #ifdef DEBUG
+    if(getArg0())
+        mYAngularVelocity = l_HIO.mYAngularAcceleration;
+    else
+        mYAngularVelocity = -l_HIO.mYAngularAcceleration;
+    #else
+    if(getArg0())
+        mYAngularVelocity = 2;
+    else
+        mYAngularVelocity = -2;
+    #endif
+
+    return TRUE;
 }
 
 /* ############################################################################################## */
 /* 80C4F72C-80C4F74C -00001 0020+00 1/0 0/0 0/0 .data            daObjKWheel01_METHODS */
 static actor_method_class daObjKWheel01_METHODS = {
-    (process_method_func)daObjKWheel01_create1st__FP15daObjKWheel01_c,
-    (process_method_func)daObjKWheel01_MoveBGDelete__FP15daObjKWheel01_c,
-    (process_method_func)daObjKWheel01_MoveBGExecute__FP15daObjKWheel01_c,
+    (process_method_func)daObjKWheel01_create1st,
+    (process_method_func)daObjKWheel01_MoveBGDelete,
+    (process_method_func)daObjKWheel01_MoveBGExecute,
     0,
-    (process_method_func)daObjKWheel01_MoveBGDraw__FP15daObjKWheel01_c,
+    (process_method_func)daObjKWheel01_MoveBGDraw,
 };
 
 /* 80C4F74C-80C4F77C -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_KWheel01 */
@@ -211,6 +501,7 @@ extern actor_process_profile_definition g_profile_Obj_KWheel01 = {
   fopAc_CULLBOX_CUSTOM_e,  // cullType
 };
 
+#if 0
 /* 80C4F77C-80C4F794 000084 0018+00 3/3 0/0 0/0 .data            __vt__17dEvLib_callback_c */
 SECTION_DATA extern void* __vt__17dEvLib_callback_c[6] = {
     (void*)NULL /* RTTI */,
@@ -242,31 +533,34 @@ SECTION_DATA extern void* __vt__15daObjKWheel01_c[18] = {
     (void*)__dt__15daObjKWheel01_cFv,
     (void*)eventStart__15daObjKWheel01_cFv,
 };
+#endif
 
 /* 80C4F4C0-80C4F540 000AC0 0080+00 1/1 0/0 0/0 .text daObjKWheel01_create1st__FP15daObjKWheel01_c
  */
-static void daObjKWheel01_create1st(daObjKWheel01_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel01_create1st(daObjKWheel01_c* i_this) {
+    fopAcM_SetupActor(i_this, daObjKWheel01_c);
+    return i_this->create1st();
 }
 
 /* 80C4F540-80C4F560 000B40 0020+00 1/0 0/0 0/0 .text
  * daObjKWheel01_MoveBGDelete__FP15daObjKWheel01_c              */
-static void daObjKWheel01_MoveBGDelete(daObjKWheel01_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel01_MoveBGDelete(daObjKWheel01_c* i_this) {
+    return i_this->MoveBGDelete();
 }
 
 /* 80C4F560-80C4F580 000B60 0020+00 1/0 0/0 0/0 .text
  * daObjKWheel01_MoveBGExecute__FP15daObjKWheel01_c             */
-static void daObjKWheel01_MoveBGExecute(daObjKWheel01_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel01_MoveBGExecute(daObjKWheel01_c* i_this) {
+    return i_this->MoveBGExecute();
 }
 
 /* 80C4F580-80C4F5AC 000B80 002C+00 1/0 0/0 0/0 .text
  * daObjKWheel01_MoveBGDraw__FP15daObjKWheel01_c                */
-static void daObjKWheel01_MoveBGDraw(daObjKWheel01_c* param_0) {
-    // NONMATCHING
+static int daObjKWheel01_MoveBGDraw(daObjKWheel01_c* i_this) {
+    return i_this->MoveBGDraw();
 }
 
+#if 0
 /* 80C4F5AC-80C4F5F4 000BAC 0048+00 1/0 0/0 0/0 .text            __dt__17dEvLib_callback_cFv */
 // dEvLib_callback_c::~dEvLib_callback_c() {
 extern "C" void __dt__17dEvLib_callback_cFv() {
@@ -291,12 +585,16 @@ extern "C" bool eventRun__17dEvLib_callback_cFv() {
 extern "C" bool eventEnd__17dEvLib_callback_cFv() {
     return true;
 }
+#endif
 
+#if 0
 /* 80C4F60C-80C4F6A0 000C0C 0094+00 2/1 0/0 0/0 .text            __dt__15daObjKWheel01_cFv */
 daObjKWheel01_c::~daObjKWheel01_c() {
     // NONMATCHING
 }
+#endif
 
+#if 0
 /* 80C4F6A0-80C4F6A8 000CA0 0008+00 1/0 0/0 0/0 .text @1448@eventStart__15daObjKWheel01_cFv */
 static void func_80C4F6A0() {
     // NONMATCHING
@@ -308,3 +606,4 @@ static void func_80C4F6A8() {
 }
 
 /* 80C4F6EC-80C4F6EC 000034 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
+#endif

--- a/src/d/actor/d_a_obj_kwheel01.cpp
+++ b/src/d/actor/d_a_obj_kwheel01.cpp
@@ -28,12 +28,11 @@ static const int l_bmdidx[2] = {4, 5};
 /* 80C4F6F8-80C4F6FC -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
 static const char* l_arcName = "K_Wheel01";
 
-#ifdef DEBUG
-static daObjKWheel01_HIO_c l_HIO;
-#endif
-
 // Likely to have been a macro; matches for loop at beginning of create1st for both debug and retail, despite retail only calling getArg4567()
 #define CHECK_KLIFT_EXISTS(kLiftNum) (!((1 << kLiftNum) & getArg4567()))
+
+#ifdef DEBUG
+static daObjKWheel01_HIO_c l_HIO;
 
 daObjKWheel01_HIO_c::daObjKWheel01_HIO_c() {
     mTargetYAngularSpeed = 64;
@@ -50,6 +49,7 @@ void daObjKWheel01_HIO_c::genMessage(JORMContext* ctx) {
     // "Rotational acceleration"
     ctx->genSlider("回転加速度", &mYAngularAcceleration, 0, 0x20, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
 }
+#endif
 
 /* 80C4F6FC-80C4F72C 000004 0030+00 3/3 0/0 0/0 .data            l_pos */
 static Vec l_pos[4] = {
@@ -99,8 +99,10 @@ cPhs__Step daObjKWheel01_c::create1st() {
         }
     }
 
+    #ifdef DEBUG
     // "Pulley(Lv3)"
     l_HIO.entryHIO("滑車(Lv3)");
+    #endif
 
     return phase;
 }
@@ -309,7 +311,10 @@ int daObjKWheel01_c::Draw() {
 /* 80C4F3E8-80C4F498 0009E8 00B0+00 1/0 0/0 0/0 .text            Delete__15daObjKWheel01_cFv */
 int daObjKWheel01_c::Delete() {
     dComIfG_resDelete(this, l_arcName);
+
+    #ifdef DEBUG
     l_HIO.removeHIO();
+    #endif
 
     for(int i = 0; i < 4; i++) {
         if(CHECK_KLIFT_EXISTS(i) && mKLiftCollisions[i] && mKLiftCollisions[i]->ChkUsed())

--- a/src/d/actor/d_a_obj_kwheel01.cpp
+++ b/src/d/actor/d_a_obj_kwheel01.cpp
@@ -4,6 +4,7 @@
 */
 
 #include "d/actor/d_a_obj_kwheel01.h"
+#include "JSystem/JHostIO/JORMContext.h"
 #include "SSystem/SComponent/c_math.h"
 #include "d/actor/d_a_obj_klift00.h"
 #include "d/actor/d_a_obj_kwheel00.h"
@@ -19,6 +20,10 @@ static int daObjKWheel01_MoveBGDraw(daObjKWheel01_c*);
 /* 80C4F6B8-80C4F6C4 000000 000C+00 2/2 0/0 0/0 .rodata          l_dzbidx */
 static const u32 l_dzbidx[3] = {9, 8, 10};
 
+/* ############################################################################################## */
+/* 80C4F6C4-80C4F6CC 00000C 0008+00 1/1 0/0 0/0 .rodata          l_bmdidx */
+static const int l_bmdidx[2] = {4, 5};
+
 
 /* 80C4F6F8-80C4F6FC -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
 static const char* l_arcName = "K_Wheel01";
@@ -33,6 +38,17 @@ static daObjKWheel01_HIO_c l_HIO;
 daObjKWheel01_HIO_c::daObjKWheel01_HIO_c() {
     mTargetYAngularSpeed = 64;
     mYAngularAcceleration = 2;
+}
+
+void daObjKWheel01_HIO_c::genMessage(JORMContext* ctx) {
+    // "Pulley"
+    ctx->genLabel("滑車", 0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Rotational speed"
+    ctx->genSlider("回転速度", &mTargetYAngularSpeed, 0, 0x2000, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+
+    // "Rotational acceleration"
+    ctx->genSlider("回転加速度", &mYAngularAcceleration, 0, 0x20, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
 }
 
 /* 80C4F6FC-80C4F72C 000004 0030+00 3/3 0/0 0/0 .data            l_pos */
@@ -82,6 +98,9 @@ cPhs__Step daObjKWheel01_c::create1st() {
                 return cPhs_ERROR_e;
         }
     }
+
+    // "Pulley(Lv3)"
+    l_HIO.entryHIO("滑車(Lv3)");
 
     return phase;
 }
@@ -290,6 +309,7 @@ int daObjKWheel01_c::Draw() {
 /* 80C4F3E8-80C4F498 0009E8 00B0+00 1/0 0/0 0/0 .text            Delete__15daObjKWheel01_cFv */
 int daObjKWheel01_c::Delete() {
     dComIfG_resDelete(this, l_arcName);
+    l_HIO.removeHIO();
 
     for(int i = 0; i < 4; i++) {
         if(CHECK_KLIFT_EXISTS(i) && mKLiftCollisions[i] && mKLiftCollisions[i]->ChkUsed())

--- a/src/d/actor/d_a_obj_kwheel01.cpp
+++ b/src/d/actor/d_a_obj_kwheel01.cpp
@@ -5,143 +5,23 @@
 
 #include "d/actor/d_a_obj_kwheel01.h"
 #include "SSystem/SComponent/c_math.h"
-#include "SSystem/SComponent/c_phase.h"
-#include "Z2AudioLib/Z2AudioMgr.h"
-#include "Z2AudioLib/Z2SeMgr.h"
 #include "d/actor/d_a_obj_klift00.h"
 #include "d/actor/d_a_obj_kwheel00.h"
-#include "d/actor/d_a_player.h"
-#include "d/d_bg_s.h"
 #include "d/d_bg_w.h"
 #include "d/d_com_inf_game.h"
-#include "d/d_event_manager.h"
-#include "d/d_kankyo.h"
-#include "d/d_procname.h"
-#include "dol2asm.h"
-#include "f_op/f_op_actor.h"
-#include "f_op/f_op_actor_iter.h"
-#include "f_op/f_op_actor_mng.h"
-#include "f_pc/f_pc_base.h"
-#include "f_pc/f_pc_searcher.h"
-#include "m_Do/m_Do_ext.h"
-#include "m_Do/m_Do_mtx.h"
-#include "mtx.h"
 
 static int daObjKWheel01_create1st(daObjKWheel01_c*);
 static int daObjKWheel01_MoveBGDelete(daObjKWheel01_c*);
 static int daObjKWheel01_MoveBGExecute(daObjKWheel01_c*);
 static int daObjKWheel01_MoveBGDraw(daObjKWheel01_c*);
 
-#if 0
-//
-// Forward References:
-//
-
-extern "C" void create1st__15daObjKWheel01_cFv();
-extern "C" void setMtx__15daObjKWheel01_cFv();
-extern "C" void CreateHeap__15daObjKWheel01_cFv();
-extern "C" void Create__15daObjKWheel01_cFv();
-extern "C" static void searchKWheel00__FPvPv();
-extern "C" void Execute__15daObjKWheel01_cFPPA3_A4_f();
-extern "C" void Draw__15daObjKWheel01_cFv();
-extern "C" void Delete__15daObjKWheel01_cFv();
-extern "C" void eventStart__15daObjKWheel01_cFv();
-extern "C" static void daObjKWheel01_create1st__FP15daObjKWheel01_c();
-extern "C" static void daObjKWheel01_MoveBGDelete__FP15daObjKWheel01_c();
-extern "C" static void daObjKWheel01_MoveBGExecute__FP15daObjKWheel01_c();
-extern "C" static void daObjKWheel01_MoveBGDraw__FP15daObjKWheel01_c();
-extern "C" void __dt__17dEvLib_callback_cFv();
-extern "C" bool eventStart__17dEvLib_callback_cFv();
-extern "C" bool eventRun__17dEvLib_callback_cFv();
-extern "C" bool eventEnd__17dEvLib_callback_cFv();
-extern "C" void __dt__15daObjKWheel01_cFv();
-extern "C" static void func_80C4F6A0();
-extern "C" static void func_80C4F6A8();
-extern "C" extern char const* const d_a_obj_kwheel01__stringBase0;
-
-//
-// External References:
-//
-
-extern "C" void mDoMtx_YrotM__FPA4_fs();
-extern "C" void transM__14mDoMtx_stack_cFfff();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void __dt__10fopAc_ac_cFv();
-extern "C" void fopAc_IsActor__FPv();
-extern "C" void fopAcIt_Judge__FPFPvPv_PvPv();
-extern "C" void fopAcM_create__FsUlPC4cXyziPC5csXyzPC4cXyzSc();
-extern "C" void fopAcM_setCullSizeBox__FP10fopAc_ac_cffffff();
-extern "C" void fpcSch_JudgeByID__FPvPv();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void isSwitch__10dSv_info_cCFii();
-extern "C" void getRes__14dRes_control_cFPCclP11dRes_info_ci();
-extern "C" void getEventIdx__16dEvent_manager_cFP10fopAc_ac_cUc();
-extern "C" void eventUpdate__17dEvLib_callback_cFv();
-extern "C" void setEvent__17dEvLib_callback_cFiii();
-extern "C" void Release__4cBgSFP9dBgW_Base();
-extern "C" void Regist__4dBgSFP9dBgW_BaseP10fopAc_ac_c();
-extern "C" void dBgS_MoveBGProc_TypicalRotY__FP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz();
-extern "C" void __ct__16dBgS_MoveBgActorFv();
-extern "C" bool IsDelete__16dBgS_MoveBgActorFv();
-extern "C" bool ToFore__16dBgS_MoveBgActorFv();
-extern "C" bool ToBack__16dBgS_MoveBgActorFv();
-extern "C" void
-MoveBGCreate__16dBgS_MoveBgActorFPCciPFP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz_vUlPA3_A4_f();
-extern "C" void MoveBGDelete__16dBgS_MoveBgActorFv();
-extern "C" void MoveBGExecute__16dBgS_MoveBgActorFv();
-extern "C" void Set__4cBgWFP6cBgD_tUlPA3_A4_f();
-extern "C" void __ct__4dBgWFv();
-extern "C" void Move__4dBgWFv();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void cM_rndFX__Ff();
-extern "C" void ChkUsed__9cBgW_BgIdCFv();
-extern "C" void seStartLevel__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void* __nw__FUl();
-extern "C" void __dl__FPv();
-extern "C" void _savegpr_25();
-extern "C" void _savegpr_26();
-extern "C" void _savegpr_27();
-extern "C" void _savegpr_28();
-extern "C" void _restgpr_25();
-extern "C" void _restgpr_26();
-extern "C" void _restgpr_27();
-extern "C" void _restgpr_28();
-extern "C" extern void* __vt__16dBgS_MoveBgActor[10];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
-#endif
-
-//
-// Declarations:
-//
-
 /* ############################################################################################## */
 /* 80C4F6B8-80C4F6C4 000000 000C+00 2/2 0/0 0/0 .rodata          l_dzbidx */
 static const u32 l_dzbidx[3] = {9, 8, 10};
-#if 0
-SECTION_RODATA static u8 const l_dzbidx[12] = {
-    0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x0A,
-};
-COMPILER_STRIP_GATE(0x80C4F6B8, &l_dzbidx);
-#endif
 
-/* 80C4F6EC-80C4F6EC 000034 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#if 0
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80C4F6EC = "K_Wheel01";
-#pragma pop
-#endif
 
 /* 80C4F6F8-80C4F6FC -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
 static const char* l_arcName = "K_Wheel01";
-#if 0
-SECTION_DATA static void* l_arcName = (void*)&d_a_obj_kwheel01__stringBase0;
-#endif
 
 #ifdef DEBUG
 static daObjKWheel01_HIO_c l_HIO;
@@ -160,13 +40,6 @@ static Vec l_pos[4] = {
     {930.0f, -165.0f, 0.0f}, {0.0f, -165.0f, 930.0f},
     {-930.0f, -165.0f, 0.0f}, {0.0f, -165.0f, -930.0f}
 };
-#if 0
-SECTION_DATA static u8 l_pos[48] = {
-    0x44, 0x68, 0x80, 0x00, 0xC3, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0xC3, 0x25, 0x00, 0x00, 0x44, 0x68, 0x80, 0x00, 0xC4, 0x68, 0x80, 0x00, 0xC3, 0x25, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC3, 0x25, 0x00, 0x00, 0xC4, 0x68, 0x80, 0x00,
-};
-#endif
 
 /* 80C4EA78-80C4EC54 000078 01DC+00 1/1 0/0 0/0 .text            create1st__15daObjKWheel01_cFv */
 cPhs__Step daObjKWheel01_c::create1st() {
@@ -213,34 +86,11 @@ cPhs__Step daObjKWheel01_c::create1st() {
     return phase;
 }
 
-/* ############################################################################################## */
-/* 80C4F6C4-80C4F6CC 00000C 0008+00 1/1 0/0 0/0 .rodata          l_bmdidx */
-static const int l_bmdidx[2] = {4, 5};
-#if 0
-SECTION_RODATA static u8 const l_bmdidx[8] = {
-    0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x05,
-};
-COMPILER_STRIP_GATE(0x80C4F6C4, &l_bmdidx);
-#endif
-
 /* 80C4F6CC-80C4F6E4 000014 0018+00 1/1 0/0 0/0 .rodata          l_cull_box */
 static const Vec l_cull_box[2] = {
     {-1260.0f, -3050.0f, -1260.0f},
     {1260.0f, 2800.0f, 1260.0f}
 };
-#if 0
-SECTION_RODATA static u8 const l_cull_box[24] = {
-    0xC4, 0x9D, 0x80, 0x00, 0xC5, 0x3E, 0xA0, 0x00, 0xC4, 0x9D, 0x80, 0x00,
-    0x44, 0x9D, 0x80, 0x00, 0x45, 0x2F, 0x00, 0x00, 0x44, 0x9D, 0x80, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C4F6CC, &l_cull_box);
-#endif
-
-#if 0
-/* 80C4F6E4-80C4F6E8 00002C 0004+00 2/2 0/0 0/0 .rodata          @3717 */
-SECTION_RODATA static f32 const lit_3717 = 1.0f;
-COMPILER_STRIP_GATE(0x80C4F6E4, &lit_3717);
-#endif
 
 /* 80C4EC54-80C4EDCC 000254 0178+00 2/2 0/0 0/0 .text            setMtx__15daObjKWheel01_cFv */
 void daObjKWheel01_c::setMtx() {
@@ -332,13 +182,6 @@ static void* searchKWheel00(void* param_0, void* i_this) {
 
     return NULL;
 }
-
-#if 0
-/* ############################################################################################## */
-/* 80C4F6E8-80C4F6EC 000030 0004+00 1/1 0/0 0/0 .rodata          @3888 */
-SECTION_RODATA static f32 const lit_3888 = -1.0f;
-COMPILER_STRIP_GATE(0x80C4F6E8, &lit_3888);
-#endif
 
 /* 80C4F048-80C4F344 000648 02FC+00 1/0 0/0 0/0 .text Execute__15daObjKWheel01_cFPPA3_A4_f */
 int daObjKWheel01_c::Execute(Mtx** i_mtx) {
@@ -501,40 +344,6 @@ extern actor_process_profile_definition g_profile_Obj_KWheel01 = {
   fopAc_CULLBOX_CUSTOM_e,  // cullType
 };
 
-#if 0
-/* 80C4F77C-80C4F794 000084 0018+00 3/3 0/0 0/0 .data            __vt__17dEvLib_callback_c */
-SECTION_DATA extern void* __vt__17dEvLib_callback_c[6] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__17dEvLib_callback_cFv,
-    (void*)eventStart__17dEvLib_callback_cFv,
-    (void*)eventRun__17dEvLib_callback_cFv,
-    (void*)eventEnd__17dEvLib_callback_cFv,
-};
-
-/* 80C4F794-80C4F7DC 00009C 0048+00 2/2 0/0 0/0 .data            __vt__15daObjKWheel01_c */
-SECTION_DATA extern void* __vt__15daObjKWheel01_c[18] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)CreateHeap__15daObjKWheel01_cFv,
-    (void*)Create__15daObjKWheel01_cFv,
-    (void*)Execute__15daObjKWheel01_cFPPA3_A4_f,
-    (void*)Draw__15daObjKWheel01_cFv,
-    (void*)Delete__15daObjKWheel01_cFv,
-    (void*)IsDelete__16dBgS_MoveBgActorFv,
-    (void*)ToFore__16dBgS_MoveBgActorFv,
-    (void*)ToBack__16dBgS_MoveBgActorFv,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80C4F6A8,
-    (void*)func_80C4F6A0,
-    (void*)eventRun__17dEvLib_callback_cFv,
-    (void*)eventEnd__17dEvLib_callback_cFv,
-    (void*)__dt__15daObjKWheel01_cFv,
-    (void*)eventStart__15daObjKWheel01_cFv,
-};
-#endif
-
 /* 80C4F4C0-80C4F540 000AC0 0080+00 1/1 0/0 0/0 .text daObjKWheel01_create1st__FP15daObjKWheel01_c
  */
 static int daObjKWheel01_create1st(daObjKWheel01_c* i_this) {
@@ -559,51 +368,3 @@ static int daObjKWheel01_MoveBGExecute(daObjKWheel01_c* i_this) {
 static int daObjKWheel01_MoveBGDraw(daObjKWheel01_c* i_this) {
     return i_this->MoveBGDraw();
 }
-
-#if 0
-/* 80C4F5AC-80C4F5F4 000BAC 0048+00 1/0 0/0 0/0 .text            __dt__17dEvLib_callback_cFv */
-// dEvLib_callback_c::~dEvLib_callback_c() {
-extern "C" void __dt__17dEvLib_callback_cFv() {
-    // NONMATCHING
-}
-
-/* 80C4F5F4-80C4F5FC 000BF4 0008+00 1/0 0/0 0/0 .text            eventStart__17dEvLib_callback_cFv
- */
-// bool dEvLib_callback_c::eventStart()() {
-extern "C" bool eventStart__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C4F5FC-80C4F604 000BFC 0008+00 2/0 0/0 0/0 .text            eventRun__17dEvLib_callback_cFv */
-// bool dEvLib_callback_c::eventRun() {
-extern "C" bool eventRun__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C4F604-80C4F60C 000C04 0008+00 2/0 0/0 0/0 .text            eventEnd__17dEvLib_callback_cFv */
-// bool dEvLib_callback_c::eventEnd() {
-extern "C" bool eventEnd__17dEvLib_callback_cFv() {
-    return true;
-}
-#endif
-
-#if 0
-/* 80C4F60C-80C4F6A0 000C0C 0094+00 2/1 0/0 0/0 .text            __dt__15daObjKWheel01_cFv */
-daObjKWheel01_c::~daObjKWheel01_c() {
-    // NONMATCHING
-}
-#endif
-
-#if 0
-/* 80C4F6A0-80C4F6A8 000CA0 0008+00 1/0 0/0 0/0 .text @1448@eventStart__15daObjKWheel01_cFv */
-static void func_80C4F6A0() {
-    // NONMATCHING
-}
-
-/* 80C4F6A8-80C4F6B0 000CA8 0008+00 1/0 0/0 0/0 .text            @1448@__dt__15daObjKWheel01_cFv */
-static void func_80C4F6A8() {
-    // NONMATCHING
-}
-
-/* 80C4F6EC-80C4F6EC 000034 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#endif


### PR DESCRIPTION
* Three rels equivalent
* Basic documentation for the three rels
* Define explicit constructor for dMdl_obj_c (needed for proper array creation in d_a_obj_klift00)
* Modify d_a_obj_bky_rock to account for new explicit constructor of dMdl_obj_c
* Specify weak func and/or vtable orders for rels in config.py