### PR TITLE
d_a_obj_waterGate matching + d_a_obj_lv3Water2 equivalent

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1924,7 +1924,7 @@ config.libs = [
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lv1Candle01"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lv3Candle"),
     ActorRel(NonMatching, "d_a_obj_lv3Water"),
-    ActorRel(NonMatching, "d_a_obj_lv3Water2"),
+    ActorRel(Equivalent, "d_a_obj_lv3Water2"), # weak func order
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lv3WaterB"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lv3saka00"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lv3waterEff"),
@@ -2084,7 +2084,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_obj_volcbom"),
     ActorRel(NonMatching, "d_a_obj_warp_kbrg"),
     ActorRel(NonMatching, "d_a_obj_warp_obrg"),
-    ActorRel(NonMatching, "d_a_obj_waterGate"),
+    ActorRel(MatchingFor("GZ2E01"), "d_a_obj_waterGate"),
     ActorRel(Equivalent, "d_a_obj_waterPillar"), # vtable order
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_waterfall"),
     ActorRel(NonMatching, "d_a_obj_wchain"),

--- a/include/JSystem/J3DGraphAnimator/J3DModelData.h
+++ b/include/JSystem/J3DGraphAnimator/J3DModelData.h
@@ -22,12 +22,13 @@ public:
     /* 80325E14 */ s32 newSharedDisplayList(u32);
     /* 80325EC8 */ void indexToPtr();
     /* 80325F94 */ void makeSharedDL();
-    /* 8032600C */ void simpleCalcMaterial(u16, f32 (*)[4]);
+    /* 8032600C */ void simpleCalcMaterial(u16, Mtx);
     /* 803260CC */ void syncJ3DSysPointers() const;
     /* 803260F8 */ void syncJ3DSysFlags() const;
 
     /* 8032617C */ virtual ~J3DModelData() {}
 
+    void simpleCalcMaterial(Mtx mtx) { simpleCalcMaterial(0, mtx); }
     J3DMaterialTable& getMaterialTable() { return mMaterialTable; }
     JUTNameTab* getMaterialName() const { return mMaterialTable.getMaterialName(); }
     J3DVertexData& getVertexData() { return mVertexData; }

--- a/include/d/actor/d_a_obj_lv3Water2.h
+++ b/include/d/actor/d_a_obj_lv3Water2.h
@@ -5,6 +5,10 @@
 #include "d/d_event_lib.h"
 #include "f_op/f_op_actor_mng.h"
 
+struct fakeLv3Water2Padding {
+    u8 a[8];
+};
+
 /**
  * @ingroup actors-objects
  * @class daLv3Water2_c
@@ -13,7 +17,7 @@
  * @details Water in the central room (where the boss entrance is). It can be raised twice.
  *
  */
-class daLv3Water2_c : public dBgS_MoveBgActor, public request_of_phase_process_class, public dEvLib_callback_c {
+class daLv3Water2_c : public dBgS_MoveBgActor, public fakeLv3Water2Padding, public dEvLib_callback_c {
 public:
     daLv3Water2_c() : dEvLib_callback_c(this) {}
     ~daLv3Water2_c() {}

--- a/include/d/actor/d_a_obj_lv3Water2.h
+++ b/include/d/actor/d_a_obj_lv3Water2.h
@@ -1,40 +1,101 @@
 #ifndef D_A_OBJ_LV3WATER2_H
 #define D_A_OBJ_LV3WATER2_H
 
+#include "d/d_bg_s_movebg_actor.h"
+#include "d/d_event_lib.h"
 #include "f_op/f_op_actor_mng.h"
 
 /**
  * @ingroup actors-objects
  * @class daLv3Water2_c
- * @brief Lakebed Temple Water 2
+ * @brief Lakebed Temple Central Room Water
  *
- * @details
+ * @details Water in the central room (where the boss entrance is). It can be raised twice.
  *
  */
-class daLv3Water2_c : public fopAc_ac_c {
+class daLv3Water2_c : public dBgS_MoveBgActor, public request_of_phase_process_class, public dEvLib_callback_c {
 public:
+    daLv3Water2_c() : dEvLib_callback_c(this) {}
+    ~daLv3Water2_c() {}
+
     /* 80C5A478 */ void setBaseMtx();
-    /* 80C5A4F8 */ void CreateHeap();
-    /* 80C5A5E4 */ void create();
-    /* 80C5A844 */ void Execute(f32 (**)[3][4]);
+    /* 80C5A4F8 */ int CreateHeap();
+    /* 80C5A5E4 */ cPhs__Step create();
+    /* 80C5A844 */ int Execute(Mtx**);
     /* 80C5AC10 */ void mode_proc_wait();
     /* 80C5ACB8 */ void mode_init_levelCtrl();
     /* 80C5ACE4 */ void mode_proc_levelCtrl();
-    /* 80C5ADA4 */ void Draw();
-    /* 80C5AEFC */ void Delete();
-    /* 80C5AF3C */ void eventStart();
-    /* 80C5B298 */ ~daLv3Water2_c();
+    /* 80C5ADA4 */ int Draw();
+    /* 80C5AEFC */ int Delete();
+    /* 80C5AF3C */ BOOL eventStart();
 
 private:
-    /* 0x568 */ u8 field_0x568[0x610 - 0x568];
+    /* 0x5B8 */ request_of_phase_process_class mPhase;
+    /* 0x5C0 */ J3DModel* mpModel;
+    /* 0x5C4 */ mDoExt_btkAnm mWaterSurfaceRefractionAnm;
+    /* 0x5DC */ u8 mMode;
+    /* 0x5DD */ u8 mResourceIndex;
+    /* 0x5E0 */ f32 mWaterLv;
+    /* 0x5E4 */ u8 mCurrentWaterLvFrame;
+    /* 0x5E5 */ u8 mWaterLvFrame;
+    /* 0x5E6 */ u8 mFullRatio;
+    /* 0x5E7 */ u8 mEastSwInitialStatus;    // East SW is the lever in the east-most room on 2F, which can only be pulled after raising the water level in that room by pulling the lever in 4F 
+    /* 0x5E8 */ u8 mWestSwInitialStatus;    // West SW is the lever in the west-most room on 2F, which can only be pulled after raising the water level in that room by pulling the lever in 4F 
+    /* 0x5E9 */ u8 mEastSwCurrentStatus;
+    /* 0x5EA */ u8 mWestSwCurrentStatus;
+    /* 0x5EB */ u8 mLevelControlWaitFrames;
+    /* 0x5EC */ f32 mBaseYPos;
+    /* 0x5F0 */ u32 mEastWaterParticles[4]; // If the central staircase isn't rotated to allow water from the east to flow down it, the water falls into the basin; these are the splash particles where the basin water and falling water meet
+    /* 0x600 */ u32 mWestWaterParticles[4]; // If the central staircase isn't rotated to allow water from the west to flow down it, the water falls into the basin; these are the splash particles where the basin water and falling water meet
+
+    enum Mode_e {
+        WAIT, LEVEL_CTRL
+    };
+
+    int getParamLevel1() {
+        return fopAcM_GetParamBit(this, 4, 12);
+    }
+
+    int getParamSw2() {
+        return (shape_angle.x & 0xFF00) >> 8;
+    }
+
+    int getParamSw1() {
+        return shape_angle.x & 0xFF;
+    }
+
+    u32 getParam(int shift, int bit) {
+        return fopAcM_GetParamBit(this, shift, bit);
+    }
+
+    int getParamEvent2() {
+        return fopAcM_GetParamBit(this, 24, 8);
+    }
+
+    int getParamEvent() {
+        return fopAcM_GetParamBit(this, 16, 8);
+    }
+
+    int getParamFrame2() {
+        return (shape_angle.z & 0xFF00) >> 8;
+    }
+
+    int getParamFrame1() {
+        return shape_angle.z & 0xFF;
+    }
 };
 
 STATIC_ASSERT(sizeof(daLv3Water2_c) == 0x610);
 
-class daLv3Water2_HIO_c {
-public:
+struct daLv3Water2_HIO_c : public mDoHIO_entry_c {
     /* 80C5A40C */ daLv3Water2_HIO_c();
-    /* 80C5B14C */ ~daLv3Water2_HIO_c();
+    /* 80C5B14C */ ~daLv3Water2_HIO_c() {}
+
+    #ifdef DEBUG
+    void genMessage(JORMContext*);
+    #endif
+
+    /* 0x04 */ u8 mLevelControlWaitFrames;
 };
 
 

--- a/include/d/actor/d_a_obj_waterGate.h
+++ b/include/d/actor/d_a_obj_waterGate.h
@@ -1,22 +1,26 @@
 #ifndef D_A_OBJ_WATERGATE_H
 #define D_A_OBJ_WATERGATE_H
 
-#include "f_op/f_op_actor_mng.h"
+#include "d/d_bg_s_movebg_actor.h"
+#include "m_Do/m_Do_hostIO.h"
+#include "SSystem/SComponent/c_phase.h"
 
 /**
  * @ingroup actors-objects
  * @class daWtGate_c
  * @brief Water Gate
  *
- * @details
+ * @details Sluice gate that player opens in 3F and 4F of Lakebed Temple.
+ * Object does not control the flow of water streams in the temple, it is purely aesthetic. 
  *
  */
-class daWtGate_c : public fopAc_ac_c {
+
+class daWtGate_c : public dBgS_MoveBgActor {
 public:
     /* 80D2BC0C */ void setBaseMtx();
-    /* 80D2BC94 */ void CreateHeap();
-    /* 80D2BD00 */ void create();
-    /* 80D2BE7C */ void Execute(f32 (**)[3][4]);
+    /* 80D2BC94 */ int CreateHeap();
+    /* 80D2BD00 */ cPhs__Step create();
+    /* 80D2BE7C */ int Execute(Mtx**);
     /* 80D2BECC */ void move();
     /* 80D2BF88 */ void init_modeWait();
     /* 80D2BF94 */ void modeWait();
@@ -26,19 +30,41 @@ public:
     /* 80D2C150 */ void modeClose();
     /* 80D2C250 */ void init_modeEnd();
     /* 80D2C25C */ void modeEnd();
-    /* 80D2C260 */ void Draw();
-    /* 80D2C304 */ void Delete();
+    /* 80D2C260 */ int Draw();
+    /* 80D2C304 */ int Delete();
 
 private:
-    /* 0x568 */ u8 field_0x568[0x5bc - 0x568];
+    /* 0x5A0 */ request_of_phase_process_class mPhase;
+    /* 0x5A8 */ J3DModel* mpModel;
+    /* 0x5AC */ u8 mMode;
+    /* 0x5AD */ u8 field_0x5AD; // Neither modified nor read; unused 
+    /* 0x5AE */ u8 mPrevSwitchState;
+    /* 0x5B0 */ f32 mOpenYOffset;
+    /* 0x5B4 */ f32 mClosedYPos;
+    /* 0x5B8 */ f32 mMaxMoveSpeed;
+
+    enum SwitchState_e {
+        CLOSED, OPENED
+    };
+
+    enum Mode_e {
+        WAIT, OPEN, CLOSE, END
+    };
 };
 
 STATIC_ASSERT(sizeof(daWtGate_c) == 0x5bc);
 
-class daWtGate_HIO_c {
-public:
+struct daWtGate_HIO_c : public mDoHIO_entry_c {
     /* 80D2BB8C */ daWtGate_HIO_c();
-    /* 80D2C3C0 */ ~daWtGate_HIO_c();
+    /* 80D2C3C0 */ ~daWtGate_HIO_c() {};
+
+    #ifdef DEBUG
+    void genMessage(JORMContext*);
+    #endif
+
+    /* 0x4 */ f32 mMaxSpeed;
+    /* 0x8 */ u8 field_0x8;    // Modified, but never read; unused?
+    /* 0x9 */ u8 field_0x9;    // Modified, but never read; unused?
 };
 
 

--- a/src/d/actor/d_a_obj_lv3Water2.cpp
+++ b/src/d/actor/d_a_obj_lv3Water2.cpp
@@ -4,157 +4,48 @@
 */
 
 #include "d/actor/d_a_obj_lv3Water2.h"
-#include "dol2asm.h"
+#include "d/d_com_inf_game.h"
+#include "f_op/f_op_msg_mng.h"
+#include "m_Do/m_Do_graphic.h"
 
+typedef void (daLv3Water2_c::*actionFunc)(void);
 
+static int daLv3Water2_Draw(daLv3Water2_c* i_this);
+static int daLv3Water2_Execute(daLv3Water2_c* i_this);
+static int daLv3Water2_Delete(daLv3Water2_c* i_this);
+static int daLv3Water2_Create(fopAc_ac_c* i_this);
 
-//
-// Forward References:
-//
+static daLv3Water2_HIO_c l_HIO;
 
-extern "C" void __ct__17daLv3Water2_HIO_cFv();
-extern "C" void __dt__14mDoHIO_entry_cFv();
-extern "C" void setBaseMtx__13daLv3Water2_cFv();
-extern "C" void CreateHeap__13daLv3Water2_cFv();
-extern "C" void create__13daLv3Water2_cFv();
-extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" void Execute__13daLv3Water2_cFPPA3_A4_f();
-extern "C" void mode_proc_wait__13daLv3Water2_cFv();
-extern "C" void mode_init_levelCtrl__13daLv3Water2_cFv();
-extern "C" void mode_proc_levelCtrl__13daLv3Water2_cFv();
-extern "C" void Draw__13daLv3Water2_cFv();
-extern "C" void Delete__13daLv3Water2_cFv();
-extern "C" void eventStart__13daLv3Water2_cFv();
-extern "C" static void daLv3Water2_Draw__FP13daLv3Water2_c();
-extern "C" static void daLv3Water2_Execute__FP13daLv3Water2_c();
-extern "C" static void daLv3Water2_Delete__FP13daLv3Water2_c();
-extern "C" static void daLv3Water2_Create__FP10fopAc_ac_c();
-extern "C" void __dt__17daLv3Water2_HIO_cFv();
-extern "C" void __sinit_d_a_obj_lv3Water2_cpp();
-extern "C" static void func_80C5B228();
-extern "C" static void func_80C5B230();
-extern "C" void __dt__17dEvLib_callback_cFv();
-extern "C" bool eventStart__17dEvLib_callback_cFv();
-extern "C" bool eventRun__17dEvLib_callback_cFv();
-extern "C" bool eventEnd__17dEvLib_callback_cFv();
-extern "C" void __dt__13daLv3Water2_cFv();
-extern "C" extern char const* const d_a_obj_lv3Water2__stringBase0;
+/* 80C5A40C-80C5A430 0000EC 0024+00 1/1 0/0 0/0 .text            __ct__17daLv3Water2_HIO_cFv */
+daLv3Water2_HIO_c::daLv3Water2_HIO_c() {
+    mLevelControlWaitFrames = 0;
+}
 
-//
-// External References:
-//
-
-extern "C" void mDoMtx_YrotM__FPA4_fs();
-extern "C" void play__14mDoExt_baseAnmFv();
-extern "C" void init__13mDoExt_btkAnmFP16J3DMaterialTableP19J3DAnmTextureSRTKeyiifss();
-extern "C" void entry__13mDoExt_btkAnmFP16J3DMaterialTablef();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void __dt__10fopAc_ac_cFv();
-extern "C" void fopMsgM_valueIncrease__FiiUc();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfGp_getReverb__Fi();
-extern "C" void isSwitch__10dSv_info_cCFii();
-extern "C" void getRes__14dRes_control_cFPCclP11dRes_info_ci();
-extern "C" void eventUpdate__17dEvLib_callback_cFv();
-extern "C" void orderEvent__17dEvLib_callback_cFiii();
-extern "C" void
-set__13dPa_control_cFUlUcUsPC4cXyzPC12dKy_tevstr_cPC5csXyzPC4cXyzUcP18dPa_levelEcallBackScPC8_GXColorPC8_GXColorPC4cXyzf();
-extern "C" void __ct__16dBgS_MoveBgActorFv();
-extern "C" bool Create__16dBgS_MoveBgActorFv();
-extern "C" bool IsDelete__16dBgS_MoveBgActorFv();
-extern "C" bool ToFore__16dBgS_MoveBgActorFv();
-extern "C" bool ToBack__16dBgS_MoveBgActorFv();
-extern "C" void
-MoveBGCreate__16dBgS_MoveBgActorFPCciPFP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz_vUlPA3_A4_f();
-extern "C" void MoveBGDelete__16dBgS_MoveBgActorFv();
-extern "C" void MoveBGExecute__16dBgS_MoveBgActorFv();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void seStart__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void __dl__FPv();
-extern "C" void setEffectMtx__13J3DTexMtxInfoFPA4_f();
-extern "C" void simpleCalcMaterial__12J3DModelDataFUsPA4_f();
-extern "C" void init__12J3DFrameCtrlFs();
-extern "C" void __ptmf_scall();
-extern "C" void _savegpr_27();
-extern "C" void _savegpr_28();
-extern "C" void _savegpr_29();
-extern "C" void _restgpr_27();
-extern "C" void _restgpr_28();
-extern "C" void _restgpr_29();
-extern "C" extern void* __vt__16dBgS_MoveBgActor[10];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
-extern "C" void __register_global_object();
-
-//
-// Declarations:
-//
-
-/* ############################################################################################## */
-/* 80C5B398-80C5B398 000034 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80C5B398 = "Kr03wat04";
-#pragma pop
+#ifdef DEBUG
+void daLv3Water2_HIO_c::genMessage(JORMContext* ctx) {
+    ctx->genSlider("wait time", &mLevelControlWaitFrames, 0, 255, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+}
+#endif
 
 /* 80C5B3A4-80C5B3B0 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80C5B3B0-80C5B3C4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
+UNK_REL_DATA;
 
 /* 80C5B3C4-80C5B3C8 -00001 0004+00 3/3 0/0 0/0 .data            l_resNameIdx */
-SECTION_DATA static void* l_resNameIdx = (void*)&d_a_obj_lv3Water2__stringBase0;
-
-/* 80C5B3C8-80C5B3D4 -00001 000C+00 0/1 0/0 0/0 .data            @3767 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* lit_3767[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)mode_proc_wait__13daLv3Water2_cFv,
-};
-#pragma pop
-
-/* 80C5B3D4-80C5B3E0 -00001 000C+00 0/1 0/0 0/0 .data            @3768 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* lit_3768[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)mode_proc_levelCtrl__13daLv3Water2_cFv,
-};
-#pragma pop
+static char* l_resNameIdx[] = {"Kr03wat04"};
 
 /* 80C5B3E0-80C5B3F8 00003C 0018+00 1/2 0/0 0/0 .data            l_mode_func */
-SECTION_DATA static u8 l_mode_func[24] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+static actionFunc l_mode_func[] = {
+    &daLv3Water2_c::mode_proc_wait, &daLv3Water2_c::mode_proc_levelCtrl 
 };
 
 /* 80C5B3F8-80C5B418 -00001 0020+00 1/0 0/0 0/0 .data            l_daLv3Water2_Method */
 static actor_method_class l_daLv3Water2_Method = {
-    (process_method_func)daLv3Water2_Create__FP10fopAc_ac_c,
-    (process_method_func)daLv3Water2_Delete__FP13daLv3Water2_c,
-    (process_method_func)daLv3Water2_Execute__FP13daLv3Water2_c,
+    (process_method_func)daLv3Water2_Create,
+    (process_method_func)daLv3Water2_Delete,
+    (process_method_func)daLv3Water2_Execute,
     0,
-    (process_method_func)daLv3Water2_Draw__FP13daLv3Water2_c,
+    (process_method_func)daLv3Water2_Draw,
 };
 
 /* 80C5B418-80C5B448 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_Lv3Water2 */
@@ -175,281 +66,243 @@ extern actor_process_profile_definition g_profile_Obj_Lv3Water2 = {
   fopAc_CULLBOX_CUSTOM_e, // cullType
 };
 
-/* 80C5B448-80C5B454 0000A4 000C+00 3/3 0/0 0/0 .data            __vt__12J3DFrameCtrl */
-SECTION_DATA extern void* __vt__12J3DFrameCtrl[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__12J3DFrameCtrlFv,
-};
-
-/* 80C5B454-80C5B46C 0000B0 0018+00 3/3 0/0 0/0 .data            __vt__17dEvLib_callback_c */
-SECTION_DATA extern void* __vt__17dEvLib_callback_c[6] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__17dEvLib_callback_cFv,
-    (void*)eventStart__17dEvLib_callback_cFv,
-    (void*)eventRun__17dEvLib_callback_cFv,
-    (void*)eventEnd__17dEvLib_callback_cFv,
-};
-
-/* 80C5B46C-80C5B4B4 0000C8 0048+00 2/2 0/0 0/0 .data            __vt__13daLv3Water2_c */
-SECTION_DATA extern void* __vt__13daLv3Water2_c[18] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)CreateHeap__13daLv3Water2_cFv,
-    (void*)Create__16dBgS_MoveBgActorFv,
-    (void*)Execute__13daLv3Water2_cFPPA3_A4_f,
-    (void*)Draw__13daLv3Water2_cFv,
-    (void*)Delete__13daLv3Water2_cFv,
-    (void*)IsDelete__16dBgS_MoveBgActorFv,
-    (void*)ToFore__16dBgS_MoveBgActorFv,
-    (void*)ToBack__16dBgS_MoveBgActorFv,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80C5B230,
-    (void*)func_80C5B228,
-    (void*)eventRun__17dEvLib_callback_cFv,
-    (void*)eventEnd__17dEvLib_callback_cFv,
-    (void*)__dt__13daLv3Water2_cFv,
-    (void*)eventStart__13daLv3Water2_cFv,
-};
-
-/* 80C5B4B4-80C5B4C0 000110 000C+00 2/2 0/0 0/0 .data            __vt__17daLv3Water2_HIO_c */
-SECTION_DATA extern void* __vt__17daLv3Water2_HIO_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__17daLv3Water2_HIO_cFv,
-};
-
-/* 80C5B4C0-80C5B4CC 00011C 000C+00 3/3 0/0 0/0 .data            __vt__14mDoHIO_entry_c */
-SECTION_DATA extern void* __vt__14mDoHIO_entry_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__14mDoHIO_entry_cFv,
-};
-
-/* 80C5A40C-80C5A430 0000EC 0024+00 1/1 0/0 0/0 .text            __ct__17daLv3Water2_HIO_cFv */
-daLv3Water2_HIO_c::daLv3Water2_HIO_c() {
-    // NONMATCHING
-}
-
-/* 80C5A430-80C5A478 000110 0048+00 1/0 0/0 0/0 .text            __dt__14mDoHIO_entry_cFv */
-// mDoHIO_entry_c::~mDoHIO_entry_c() {
-extern "C" void __dt__14mDoHIO_entry_cFv() {
-    // NONMATCHING
-}
-
 /* 80C5A478-80C5A4F8 000158 0080+00 2/2 0/0 0/0 .text            setBaseMtx__13daLv3Water2_cFv */
 void daLv3Water2_c::setBaseMtx() {
-    // NONMATCHING
+    mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
+    mDoMtx_stack_c::YrotM(shape_angle.y);
+
+    mpModel->setBaseScale(scale);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
 }
 
 /* ############################################################################################## */
 /* 80C5B364-80C5B368 000000 0004+00 3/3 0/0 0/0 .rodata          l_bmdIdx */
-SECTION_RODATA static u32 const l_bmdIdx = 0x00000005;
-COMPILER_STRIP_GATE(0x80C5B364, &l_bmdIdx);
+static const int l_bmdIdx[] = {5};
 
 /* 80C5B368-80C5B36C 000004 0004+00 1/1 0/0 0/0 .rodata          l_dzbIdx */
-SECTION_RODATA static u32 const l_dzbIdx = 0x0000000D;
-COMPILER_STRIP_GATE(0x80C5B368, &l_dzbIdx);
+static const int l_dzbIdx[] = {13};
 
 /* 80C5B36C-80C5B370 000008 0004+00 0/1 0/0 0/0 .rodata          l_btkIdx */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u32 const l_btkIdx = 0x00000009;
-COMPILER_STRIP_GATE(0x80C5B36C, &l_btkIdx);
-#pragma pop
-
-/* 80C5B370-80C5B374 00000C 0004+00 2/5 0/0 0/0 .rodata          @3682 */
-SECTION_RODATA static f32 const lit_3682 = 1.0f;
-COMPILER_STRIP_GATE(0x80C5B370, &lit_3682);
+static const int l_btkIdx[] = {9};
 
 /* 80C5A4F8-80C5A5E4 0001D8 00EC+00 1/0 0/0 0/0 .text            CreateHeap__13daLv3Water2_cFv */
-void daLv3Water2_c::CreateHeap() {
-    // NONMATCHING
+int daLv3Water2_c::CreateHeap() {
+    J3DModelData* modelData = static_cast<J3DModelData*>(dComIfG_getObjectRes(l_resNameIdx[mResourceIndex], l_bmdIdx[mResourceIndex]));
+    JUT_ASSERT(171, modelData != 0);
+    mpModel = mDoExt_J3DModel__create(modelData, (1 << 19), 0x19000284);
+    if(!mpModel)
+        return 0;
+
+    int res = mWaterSurfaceRefractionAnm.init(modelData, static_cast<J3DAnmTextureSRTKey*>(dComIfG_getObjectRes(l_resNameIdx[mResourceIndex], l_btkIdx[mResourceIndex])), 1, 2, 1.0f, 0, -1);
+    JUT_ASSERT(188, res == 1);
+
+    return 1;
 }
-
-/* ############################################################################################## */
-/* 80C5B374-80C5B37C 000010 0004+04 1/2 0/0 0/0 .rodata          @3747 */
-SECTION_RODATA static f32 const lit_3747[1 + 1 /* padding */] = {
-    5.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80C5B374, &lit_3747);
-
-/* 80C5B37C-80C5B384 000018 0008+00 1/2 0/0 0/0 .rodata          @3749 */
-SECTION_RODATA static u8 const lit_3749[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C5B37C, &lit_3749);
 
 /* 80C5A5E4-80C5A7FC 0002C4 0218+00 1/1 0/0 0/0 .text            create__13daLv3Water2_cFv */
-void daLv3Water2_c::create() {
-    // NONMATCHING
-}
+cPhs__Step daLv3Water2_c::create() {
+    fopAcM_SetupActor(this, daLv3Water2_c);
+    mResourceIndex = getParam(0, 4);
 
-/* 80C5A7FC-80C5A844 0004DC 0048+00 1/0 0/0 0/0 .text            __dt__12J3DFrameCtrlFv */
-// J3DFrameCtrl::~J3DFrameCtrl() {
-extern "C" void __dt__12J3DFrameCtrlFv() {
-    // NONMATCHING
+    cPhs__Step resPhase = static_cast<cPhs__Step>(dComIfG_resLoad(&mPhase, l_resNameIdx[mResourceIndex]));
+    if(resPhase == cPhs_COMPLEATE_e) {
+        if(MoveBGCreate(l_resNameIdx[mResourceIndex], l_dzbIdx[mResourceIndex], NULL, 0x2D00, NULL) == cPhs_ERROR_e)
+            return cPhs_ERROR_e;
+
+        mEastSwInitialStatus = fopAcM_isSwitch(this, getParamSw1());
+        mWestSwInitialStatus = fopAcM_isSwitch(this, getParamSw2());
+
+        setBaseMtx();
+        fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+
+        if(mEastSwInitialStatus)
+            current.pos.y = home.pos.y + getParamLevel1() * 5.0f;
+
+        if(mWestSwInitialStatus)
+            current.pos.y = home.pos.y + getParamLevel1() * 5.0f + getParamLevel1() * 5.0f;
+
+        mMode = WAIT;
+
+        // "LV3 Water surface (2SW)"
+        #ifdef DEBUG
+        l_HIO.entryHIO("ＬＶ３水面(2SW)");
+        #endif
+    }
+
+    return resPhase;
 }
 
 /* 80C5A844-80C5AC10 000524 03CC+00 1/0 0/0 0/0 .text            Execute__13daLv3Water2_cFPPA3_A4_f
  */
-void daLv3Water2_c::Execute(f32 (**param_0)[3][4]) {
-    // NONMATCHING
+int daLv3Water2_c::Execute(Mtx** i_mtx) {
+    mWaterSurfaceRefractionAnm.play();
+
+    eventUpdate();
+
+    mEastSwCurrentStatus = fopAcM_isSwitch(this, getParamSw1());
+    mWestSwCurrentStatus = fopAcM_isSwitch(this, getParamSw2());
+
+    (this->*l_mode_func[mMode])();
+
+    if(fopAcM_isSwitch(this, 0xE)) {
+        mEastWaterParticles[0] = dComIfGp_particle_set(mEastWaterParticles[0], 0x8AAC, &current.pos, NULL, NULL);
+        mEastWaterParticles[1] = dComIfGp_particle_set(mEastWaterParticles[1], 0x8AAD, &current.pos, NULL, NULL);
+        mEastWaterParticles[2] = dComIfGp_particle_set(mEastWaterParticles[2], 0x8AAE, &current.pos, NULL, NULL);
+        mEastWaterParticles[3] = dComIfGp_particle_set(mEastWaterParticles[3], 0x8AAF, &current.pos, NULL, NULL);
+    }
+
+    if(fopAcM_isSwitch(this, 0xF)) {
+        mWestWaterParticles[0] = dComIfGp_particle_set(mWestWaterParticles[0], 0x8AA8, &current.pos, NULL, NULL);
+        mWestWaterParticles[1] = dComIfGp_particle_set(mWestWaterParticles[1], 0x8AA9, &current.pos, NULL, NULL);
+        mWestWaterParticles[2] = dComIfGp_particle_set(mWestWaterParticles[2], 0x8AAA, &current.pos, NULL, NULL);
+        mWestWaterParticles[3] = dComIfGp_particle_set(mWestWaterParticles[3], 0x8AAB, &current.pos, NULL, NULL);
+    }
+
+    *i_mtx = &mpModel->getBaseTRMtx();
+    setBaseMtx();
+
+    return 1;
 }
 
 /* 80C5AC10-80C5ACB8 0008F0 00A8+00 1/0 0/0 0/0 .text            mode_proc_wait__13daLv3Water2_cFv
  */
 void daLv3Water2_c::mode_proc_wait() {
-    // NONMATCHING
+    if(mEastSwInitialStatus != mEastSwCurrentStatus) {
+        if(getParamEvent() != 0xFF)
+            orderEvent(getParamEvent(), 0xFF, 1);
+        else
+            eventStart();
+    }
+    else if(mWestSwInitialStatus != mWestSwCurrentStatus) {
+        if(getParamEvent2() != 0xFF)
+            orderEvent(getParamEvent2(), 0xFF, 1);
+        else
+            eventStart();
+    }
 }
-
-/* ############################################################################################## */
-/* 80C5B4D8-80C5B4E4 000008 000C+00 1/1 0/0 0/0 .bss             @3637 */
-static u8 lit_3637[12];
-
-/* 80C5B4E4-80C5B4EC 000014 0008+00 2/2 0/0 0/0 .bss             l_HIO */
-static u8 l_HIO[8];
 
 /* 80C5ACB8-80C5ACE4 000998 002C+00 1/1 0/0 0/0 .text mode_init_levelCtrl__13daLv3Water2_cFv */
 void daLv3Water2_c::mode_init_levelCtrl() {
-    // NONMATCHING
+    mCurrentWaterLvFrame = 0;
+    mLevelControlWaitFrames = l_HIO.mLevelControlWaitFrames;
+    mBaseYPos = current.pos.y;
+    mMode = LEVEL_CTRL;
 }
-
-/* ############################################################################################## */
-/* 80C5B384-80C5B38C 000020 0008+00 1/1 0/0 0/0 .rodata          @3899 */
-SECTION_RODATA static u8 const lit_3899[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C5B384, &lit_3899);
 
 /* 80C5ACE4-80C5ADA4 0009C4 00C0+00 1/0 0/0 0/0 .text mode_proc_levelCtrl__13daLv3Water2_cFv */
 void daLv3Water2_c::mode_proc_levelCtrl() {
-    // NONMATCHING
+    if(mLevelControlWaitFrames) {
+        mLevelControlWaitFrames--;
+    }
+    else {
+        f32 currentRatio = fopMsgM_valueIncrease(mWaterLvFrame, mCurrentWaterLvFrame, mFullRatio);
+
+        if(!mEastSwInitialStatus)
+            currentRatio = 1.0f - currentRatio;
+
+        mCurrentWaterLvFrame++;
+
+        if(mCurrentWaterLvFrame >= mWaterLvFrame) {
+            currentRatio = mFullRatio;
+            mMode = WAIT;
+        }
+
+        current.pos.y = mWaterLv * currentRatio + mBaseYPos;
+    }
 }
 
-/* ############################################################################################## */
-/* 80C5B38C-80C5B390 000028 0004+00 0/1 0/0 0/0 .rodata          @3951 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3951 = -1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80C5B38C, &lit_3951);
-#pragma pop
-
-/* 80C5B390-80C5B394 00002C 0004+00 0/1 0/0 0/0 .rodata          @3952 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3952[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80C5B390, &lit_3952);
-#pragma pop
-
 /* 80C5ADA4-80C5AEFC 000A84 0158+00 1/0 0/0 0/0 .text            Draw__13daLv3Water2_cFv */
-void daLv3Water2_c::Draw() {
-    // NONMATCHING
+int daLv3Water2_c::Draw() {
+    g_env_light.settingTevStruct(16, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpModel, &tevStr);
+
+    J3DModelData* modelData = mpModel->getModelData();
+    mWaterSurfaceRefractionAnm.entry(modelData);
+    J3DMaterial* const btkMaterial = modelData->getMaterialNodePointer(0);
+
+    dComIfGd_setListInvisisble();
+
+    if(btkMaterial->getTexGenBlock()->getTexMtx(0)) {
+        J3DTexMtxInfo* texMtxInfo = &btkMaterial->getTexGenBlock()->getTexMtx(0)->getTexMtxInfo();
+        if(texMtxInfo) {
+            Mtx lightProjMtx;
+            C_MTXLightPerspective(lightProjMtx, dComIfGd_getView()->fovy, dComIfGd_getView()->aspect, 1.0f, 1.0f, -0.01f, 0);
+
+            #ifdef DEBUG
+            mDoGph_gInf_c::setWideZoomLightProjection(lightProjMtx);
+            /* TODO: Handle screen capture perspective calculations */
+            #endif
+
+            texMtxInfo->setEffectMtx(lightProjMtx);
+            modelData->simpleCalcMaterial(const_cast<MtxP>(j3dDefaultMtx));
+        }
+    }
+
+    mDoExt_modelUpdateDL(mpModel);
+
+    dComIfGd_setList();
+
+    return 1;
 }
 
 /* 80C5AEFC-80C5AF3C 000BDC 0040+00 1/0 0/0 0/0 .text            Delete__13daLv3Water2_cFv */
-void daLv3Water2_c::Delete() {
-    // NONMATCHING
+int daLv3Water2_c::Delete() {
+    dComIfG_resDelete(&mPhase, l_resNameIdx[mResourceIndex]);
+
+    #ifdef DEBUG
+    l_HIO.removeHIO();
+    #endif
+
+    return 1;
 }
 
-/* ############################################################################################## */
-/* 80C5B394-80C5B398 000030 0004+00 0/1 0/0 0/0 .rodata          @3983 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3983 = -1.0f;
-COMPILER_STRIP_GATE(0x80C5B394, &lit_3983);
-#pragma pop
-
 /* 80C5AF3C-80C5B0C0 000C1C 0184+00 2/1 0/0 0/0 .text            eventStart__13daLv3Water2_cFv */
-void daLv3Water2_c::eventStart() {
-    // NONMATCHING
+BOOL daLv3Water2_c::eventStart() {
+    if(mEastSwInitialStatus != mEastSwCurrentStatus) {
+        mWaterLv = getParamLevel1() * 5.0f;
+        mWaterLvFrame = static_cast<u8>(getParamFrame1());
+        mFullRatio = mEastSwCurrentStatus;
+        mEastSwInitialStatus = mEastSwCurrentStatus;
+
+        mDoAud_seStart(Z2SE_ENV_FILL_UP_LV3WTR1, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+    }
+    else {
+        mWaterLv = getParamLevel1() * 5.0f;
+        mWaterLvFrame = static_cast<u8>(getParamFrame2());
+        mFullRatio = mWestSwCurrentStatus;
+        mWestSwInitialStatus = mWestSwCurrentStatus;
+
+        mDoAud_seStart(Z2SE_ENV_FILL_UP_LV3WTR2, &current.pos, 0, dComIfGp_getReverb(fopAcM_GetRoomNo(this)));
+    }
+
+    OS_REPORT("== mWaterLv %f mWaterLvFrame %d ==\n", mWaterLv, mWaterLvFrame);
+
+    mode_init_levelCtrl();
+
+    return TRUE;
 }
 
 /* 80C5B0C0-80C5B0EC 000DA0 002C+00 1/0 0/0 0/0 .text            daLv3Water2_Draw__FP13daLv3Water2_c
  */
-static void daLv3Water2_Draw(daLv3Water2_c* param_0) {
-    // NONMATCHING
+static int daLv3Water2_Draw(daLv3Water2_c* i_this) {
+    return i_this->MoveBGDraw();
 }
 
 /* 80C5B0EC-80C5B10C 000DCC 0020+00 1/0 0/0 0/0 .text daLv3Water2_Execute__FP13daLv3Water2_c */
-static void daLv3Water2_Execute(daLv3Water2_c* param_0) {
-    // NONMATCHING
+static int daLv3Water2_Execute(daLv3Water2_c* i_this) {
+    return i_this->MoveBGExecute();
 }
 
 /* 80C5B10C-80C5B12C 000DEC 0020+00 1/0 0/0 0/0 .text daLv3Water2_Delete__FP13daLv3Water2_c */
-static void daLv3Water2_Delete(daLv3Water2_c* param_0) {
-    // NONMATCHING
+static int daLv3Water2_Delete(daLv3Water2_c* i_this) {
+    const fpc_ProcID procID = fopAcM_GetID(i_this);
+    return i_this->MoveBGDelete();
 }
 
 /* 80C5B12C-80C5B14C 000E0C 0020+00 1/0 0/0 0/0 .text            daLv3Water2_Create__FP10fopAc_ac_c
  */
-static void daLv3Water2_Create(fopAc_ac_c* param_0) {
-    // NONMATCHING
+static int daLv3Water2_Create(fopAc_ac_c* i_this) {
+    daLv3Water2_c* const lv3Water2 = static_cast<daLv3Water2_c*>(i_this);
+    const fpc_ProcID procID = fopAcM_GetID(i_this);
+    return lv3Water2->create();
 }
-
-/* 80C5B14C-80C5B1A8 000E2C 005C+00 2/1 0/0 0/0 .text            __dt__17daLv3Water2_HIO_cFv */
-daLv3Water2_HIO_c::~daLv3Water2_HIO_c() {
-    // NONMATCHING
-}
-
-/* 80C5B1A8-80C5B228 000E88 0080+00 0/0 1/0 0/0 .text            __sinit_d_a_obj_lv3Water2_cpp */
-void __sinit_d_a_obj_lv3Water2_cpp() {
-    // NONMATCHING
-}
-
-#pragma push
-#pragma force_active on
-REGISTER_CTORS(0x80C5B1A8, __sinit_d_a_obj_lv3Water2_cpp);
-#pragma pop
-
-/* 80C5B228-80C5B230 000F08 0008+00 1/0 0/0 0/0 .text            @1448@eventStart__13daLv3Water2_cFv
- */
-static void func_80C5B228() {
-    // NONMATCHING
-}
-
-/* 80C5B230-80C5B238 000F10 0008+00 1/0 0/0 0/0 .text            @1448@__dt__13daLv3Water2_cFv */
-static void func_80C5B230() {
-    // NONMATCHING
-}
-
-/* 80C5B238-80C5B280 000F18 0048+00 1/0 0/0 0/0 .text            __dt__17dEvLib_callback_cFv */
-// dEvLib_callback_c::~dEvLib_callback_c() {
-extern "C" void __dt__17dEvLib_callback_cFv() {
-    // NONMATCHING
-}
-
-/* 80C5B280-80C5B288 000F60 0008+00 1/0 0/0 0/0 .text            eventStart__17dEvLib_callback_cFv
- */
-// bool dEvLib_callback_c::eventStart() {
-extern "C" bool eventStart__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C5B288-80C5B290 000F68 0008+00 2/0 0/0 0/0 .text            eventRun__17dEvLib_callback_cFv */
-// bool dEvLib_callback_c::eventRun() {
-extern "C" bool eventRun__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C5B290-80C5B298 000F70 0008+00 2/0 0/0 0/0 .text            eventEnd__17dEvLib_callback_cFv */
-// bool dEvLib_callback_c::eventEnd() {
-extern "C" bool eventEnd__17dEvLib_callback_cFv() {
-    return true;
-}
-
-/* 80C5B298-80C5B350 000F78 00B8+00 2/1 0/0 0/0 .text            __dt__13daLv3Water2_cFv */
-daLv3Water2_c::~daLv3Water2_c() {
-    // NONMATCHING
-}
-
-/* 80C5B398-80C5B398 000034 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */

--- a/src/d/actor/d_a_obj_waterGate.cpp
+++ b/src/d/actor/d_a_obj_waterGate.cpp
@@ -4,158 +4,237 @@
 */
 
 #include "d/actor/d_a_obj_waterGate.h"
-#include "dol2asm.h"
+#include "d/d_com_inf_game.h"
 
+typedef void (daWtGate_c::*actionFunc)();
 
-
-//
-// Forward References:
-//
-
-extern "C" void __ct__14daWtGate_HIO_cFv();
-extern "C" void __dt__14mDoHIO_entry_cFv();
-extern "C" void setBaseMtx__10daWtGate_cFv();
-extern "C" void CreateHeap__10daWtGate_cFv();
-extern "C" void create__10daWtGate_cFv();
-extern "C" void Execute__10daWtGate_cFPPA3_A4_f();
-extern "C" void move__10daWtGate_cFv();
-extern "C" void init_modeWait__10daWtGate_cFv();
-extern "C" void modeWait__10daWtGate_cFv();
-extern "C" void init_modeOpen__10daWtGate_cFv();
-extern "C" void modeOpen__10daWtGate_cFv();
-extern "C" void init_modeClose__10daWtGate_cFv();
-extern "C" void modeClose__10daWtGate_cFv();
-extern "C" void init_modeEnd__10daWtGate_cFv();
-extern "C" void modeEnd__10daWtGate_cFv();
-extern "C" void Draw__10daWtGate_cFv();
-extern "C" void Delete__10daWtGate_cFv();
-extern "C" static void daWtGate_Draw__FP10daWtGate_c();
-extern "C" static void daWtGate_Execute__FP10daWtGate_c();
-extern "C" static void daWtGate_Delete__FP10daWtGate_c();
-extern "C" static void daWtGate_Create__FP10fopAc_ac_c();
-extern "C" void __dt__14daWtGate_HIO_cFv();
-extern "C" void __sinit_d_a_obj_waterGate_cpp();
-extern "C" extern char const* const d_a_obj_waterGate__stringBase0;
-
-//
-// External References:
-//
-
-extern "C" void mDoMtx_ZXYrotM__FPA4_fsss();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void fopAcM_setCullSizeBox2__FP10fopAc_ac_cP12J3DModelData();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfGp_getReverb__Fi();
-extern "C" void isSwitch__10dSv_info_cCFii();
-extern "C" void getRes__14dRes_control_cFPCclP11dRes_info_ci();
-extern "C" void dBgS_MoveBGProc_TypicalRotY__FP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz();
-extern "C" void __ct__16dBgS_MoveBgActorFv();
-extern "C" bool Create__16dBgS_MoveBgActorFv();
-extern "C" bool IsDelete__16dBgS_MoveBgActorFv();
-extern "C" bool ToFore__16dBgS_MoveBgActorFv();
-extern "C" bool ToBack__16dBgS_MoveBgActorFv();
-extern "C" void
-MoveBGCreate__16dBgS_MoveBgActorFPCciPFP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz_vUlPA3_A4_f();
-extern "C" void MoveBGDelete__16dBgS_MoveBgActorFv();
-extern "C" void MoveBGExecute__16dBgS_MoveBgActorFv();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void cLib_addCalc__FPfffff();
-extern "C" void seStart__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void seStartLevel__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void __dl__FPv();
-extern "C" void __ptmf_scall();
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
-extern "C" void __register_global_object();
-
-//
-// Declarations:
-//
-
-/* ############################################################################################## */
-/* 80D2C46C-80D2C470 000000 0004+00 3/3 0/0 0/0 .rodata          @3625 */
-SECTION_RODATA static f32 const lit_3625 = 4.0f;
-COMPILER_STRIP_GATE(0x80D2C46C, &lit_3625);
+static int daWtGate_Draw(daWtGate_c*);
+static int daWtGate_Execute(daWtGate_c*);
+static int daWtGate_Delete(daWtGate_c*);
+static int daWtGate_Create(fopAc_ac_c*);
 
 /* 80D2C498-80D2C4A4 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
+UNK_REL_DATA
 
-/* 80D2C4A4-80D2C4B8 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
+/* 80D2C5BC-80D2C5C8 000014 000C+00 3/3 0/0 0/0 .bss             l_HIO */
+static daWtGate_HIO_c l_HIO;
 
-/* 80D2C4B8-80D2C4C4 -00001 000C+00 0/1 0/0 0/0 .data            @3728 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* lit_3728[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)modeWait__10daWtGate_cFv,
-};
-#pragma pop
+/* 80D2BB8C-80D2BBC4 0000EC 0038+00 1/1 0/0 0/0 .text            __ct__14daWtGate_HIO_cFv */
+daWtGate_HIO_c::daWtGate_HIO_c() {
+    mMaxSpeed = 4.0f;
+    field_0x8 = 30;
+    field_0x9 = 4;
+}
 
-/* 80D2C4C4-80D2C4D0 -00001 000C+00 0/1 0/0 0/0 .data            @3729 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* lit_3729[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)modeOpen__10daWtGate_cFv,
-};
-#pragma pop
+#ifdef DEBUG
+void daWtGate_HIO_c::genMessage(JORMContext* ctx) {
+    // "Maximum speed"
+    ctx->genSlider("最大速度", &mMaxSpeed, 0.1, 500.0, 0, NULL, 0xffff, 0xffff, 0x200, 0x18);
+}
+#endif
 
-/* 80D2C4D0-80D2C4DC -00001 000C+00 0/1 0/0 0/0 .data            @3730 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* lit_3730[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)modeClose__10daWtGate_cFv,
-};
-#pragma pop
+/* 80D2BC0C-80D2BC94 00016C 0088+00 2/2 0/0 0/0 .text            setBaseMtx__10daWtGate_cFv */
+void daWtGate_c::setBaseMtx() {
+    mDoMtx_stack_c::transS(current.pos.x, current.pos.y, current.pos.z);
+    mDoMtx_stack_c::ZXYrotM(shape_angle.x, shape_angle.y, shape_angle.z); 
+    mpModel->setBaseScale(scale);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+}
 
-/* 80D2C4DC-80D2C4E8 -00001 000C+00 0/1 0/0 0/0 .data            @3731 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* lit_3731[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)modeEnd__10daWtGate_cFv,
-};
-#pragma pop
+/* 80D2BC94-80D2BD00 0001F4 006C+00 1/0 0/0 0/0 .text            CreateHeap__10daWtGate_cFv */
+int daWtGate_c::CreateHeap() {
+    J3DModelData* const modelData = static_cast<J3DModelData*>(dComIfG_getObjectRes("S_Zsuimon", 4));
+    JUT_ASSERT(159, modelData != 0);
 
-/* 80D2C4E8-80D2C518 000050 0030+00 0/1 0/0 0/0 .data            mode_proc$3727 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 mode_proc[48] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-#pragma pop
+    mpModel = mDoExt_J3DModel__create(modelData, 0x80000, 0x11000084);
+
+    if(!mpModel)
+        return 0;
+    else
+        return 1;
+}
+
+/* 80D2BD00-80D2BE7C 000260 017C+00 1/1 0/0 0/0 .text            create__10daWtGate_cFv */
+cPhs__Step daWtGate_c::create() {
+    fopAcM_SetupActor(this, daWtGate_c);
+
+    const cPhs__Step resPhase = static_cast<cPhs__Step>(dComIfG_resLoad(&mPhase, "S_Zsuimon"));
+    if(resPhase == cPhs_COMPLEATE_e) {
+        if(MoveBGCreate("S_Zsuimon", 7, dBgS_MoveBGProc_TypicalRotY, 0xE00, NULL) == cPhs_ERROR_e)
+            return cPhs_ERROR_e;
+        
+        fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+        fopAcM_setCullSizeBox2(this, mpModel->getModelData());
+
+        mOpenYOffset = ((fopAcM_GetParam(this) & 0xFF00) >> 8) * 10.0f;
+
+        if(static_cast<u8>(fopAcM_GetParam(this)) == 0xFF) {
+            // Gate is never opened
+            current.pos.y -= mOpenYOffset;
+            init_modeEnd();
+        }
+        else {
+            mPrevSwitchState = fopAcM_isSwitch(this, static_cast<u8>(fopAcM_GetParam(this)));
+            mClosedYPos = current.pos.y;
+
+            // Place gate in open position if it was previously opened
+            if(mPrevSwitchState != CLOSED)
+                current.pos.y += mOpenYOffset;
+
+            init_modeWait();
+        }
+
+        setBaseMtx();
+
+
+        // "Sluice gate(Lv3)"
+        #ifdef DEBUG
+        l_HIO.entryHIO("水門(Lv3)");
+        #endif
+    }
+
+    return resPhase;
+}
+
+/* 80D2BE7C-80D2BECC 0003DC 0050+00 1/0 0/0 0/0 .text            Execute__10daWtGate_cFPPA3_A4_f */
+int daWtGate_c::Execute(Mtx** i_mtx) {
+    move();
+
+    *i_mtx = &mpModel->getBaseTRMtx();
+    setBaseMtx();
+
+    return 1;
+}
+
+/* 80D2BECC-80D2BF88 00042C 00BC+00 1/1 0/0 0/0 .text            move__10daWtGate_cFv */
+void daWtGate_c::move() {
+    static const actionFunc mode_proc[] = {
+        &daWtGate_c::modeWait, &daWtGate_c::modeOpen,
+        &daWtGate_c::modeClose, &daWtGate_c::modeEnd
+    };
+
+    (this->*mode_proc[mMode])();
+}
+
+/* 80D2BF88-80D2BF94 0004E8 000C+00 3/3 0/0 0/0 .text            init_modeWait__10daWtGate_cFv */
+void daWtGate_c::init_modeWait() {
+    mMode = WAIT;
+}
+
+/* 80D2BF94-80D2C010 0004F4 007C+00 1/0 0/0 0/0 .text            modeWait__10daWtGate_cFv */
+void daWtGate_c::modeWait() {
+    //  The state of the switch never actually changes in-game, so after a water gate opens,
+    //  it never closes. The aesthetic functionality of closing still works, though
+    u8 currentSwitchState = fopAcM_isSwitch(this, static_cast<u8>(fopAcM_GetParam(this))); 
+    if(currentSwitchState != mPrevSwitchState) {
+        if(currentSwitchState != CLOSED)
+            init_modeOpen();
+        else
+            init_modeClose();
+
+        mPrevSwitchState = currentSwitchState;
+    }
+}
+
+/* 80D2C010-80D2C02C 000570 001C+00 1/1 0/0 0/0 .text            init_modeOpen__10daWtGate_cFv */
+void daWtGate_c::init_modeOpen() {
+    mMaxMoveSpeed = l_HIO.mMaxSpeed;
+    mMode = OPEN;
+}
+
+/* 80D2C02C-80D2C134 00058C 0108+00 1/0 0/0 0/0 .text            modeOpen__10daWtGate_cFv */
+void daWtGate_c::modeOpen() {
+    const f32 currentAndOpenedYPosDiff = cLib_addCalc(&current.pos.y, mClosedYPos + mOpenYOffset, 1.0f / 5.0f, mMaxMoveSpeed, 1.0f);
+    if(currentAndOpenedYPosDiff == 0.0f) {
+        fopAcM_seStartCurrent(this, Z2SE_OBJ_OPEN_CHAIN_SW_DOOR, 0);
+        init_modeWait();
+    }
+    else {
+        fopAcM_seStartCurrentLevel(this, Z2SE_OBJ_WATERGATE_MOVE, 0);
+    }
+}
+
+/* 80D2C134-80D2C150 000694 001C+00 1/1 0/0 0/0 .text            init_modeClose__10daWtGate_cFv */
+void daWtGate_c::init_modeClose() {
+    mMaxMoveSpeed = l_HIO.mMaxSpeed;
+    mMode = CLOSE;
+}
+
+/* 80D2C150-80D2C250 0006B0 0100+00 1/0 0/0 0/0 .text            modeClose__10daWtGate_cFv */
+void daWtGate_c::modeClose() {
+    const f32 currentAndClosedYPosDiff = cLib_addCalc(&current.pos.y, mClosedYPos, 1.0f / 5.0f, mMaxMoveSpeed, 1.0f);
+    if(currentAndClosedYPosDiff == 0.0f) {
+        fopAcM_seStartCurrent(this, Z2SE_OBJ_OPEN_CHAIN_SW_DOOR, 0);
+        init_modeWait();
+    }
+    else {
+        fopAcM_seStartCurrentLevel(this, Z2SE_OBJ_WATERGATE_MOVE, 0);
+    }
+}
+
+/* 80D2C250-80D2C25C 0007B0 000C+00 1/1 0/0 0/0 .text            init_modeEnd__10daWtGate_cFv */
+void daWtGate_c::init_modeEnd() {
+    mMode = END;
+}
+
+/* 80D2C25C-80D2C260 0007BC 0004+00 1/0 0/0 0/0 .text            modeEnd__10daWtGate_cFv */
+void daWtGate_c::modeEnd() {
+    /* empty function */
+}
+
+/* 80D2C260-80D2C304 0007C0 00A4+00 1/0 0/0 0/0 .text            Draw__10daWtGate_cFv */
+int daWtGate_c::Draw() {
+    g_env_light.settingTevStruct(16, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpModel, &tevStr);
+
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+
+    return 1;
+}
+
+/* 80D2C304-80D2C334 000864 0030+00 1/0 0/0 0/0 .text            Delete__10daWtGate_cFv */
+int daWtGate_c::Delete() {
+    dComIfG_resDelete(&mPhase, "S_Zsuimon");
+
+    #ifdef DEBUG
+    l_HIO.removeHIO();
+    #endif
+
+    return 1;
+}
+
+/* 80D2C334-80D2C360 000894 002C+00 1/0 0/0 0/0 .text            daWtGate_Draw__FP10daWtGate_c */
+static int daWtGate_Draw(daWtGate_c* i_this) {
+    return i_this->MoveBGDraw();
+}
+
+/* 80D2C360-80D2C380 0008C0 0020+00 1/0 0/0 0/0 .text            daWtGate_Execute__FP10daWtGate_c */
+static int daWtGate_Execute(daWtGate_c* i_this) {
+    return i_this->MoveBGExecute();
+}
+
+/* 80D2C380-80D2C3A0 0008E0 0020+00 1/0 0/0 0/0 .text            daWtGate_Delete__FP10daWtGate_c */
+static int daWtGate_Delete(daWtGate_c* i_this) {
+    const fpc_ProcID procID = fopAcM_GetID(i_this);
+    return i_this->MoveBGDelete();
+}
+
+/* 80D2C3A0-80D2C3C0 000900 0020+00 1/0 0/0 0/0 .text            daWtGate_Create__FP10fopAc_ac_c */
+static int daWtGate_Create(fopAc_ac_c* i_this) {
+    daWtGate_c* const waterGate = static_cast<daWtGate_c*>(i_this);
+    const fpc_ProcID procID = fopAcM_GetID(i_this);
+    return waterGate->create();
+}
 
 /* 80D2C518-80D2C538 -00001 0020+00 1/0 0/0 0/0 .data            l_daWtGate_Method */
 static actor_method_class l_daWtGate_Method = {
-    (process_method_func)daWtGate_Create__FP10fopAc_ac_c,
-    (process_method_func)daWtGate_Delete__FP10daWtGate_c,
-    (process_method_func)daWtGate_Execute__FP10daWtGate_c,
+    (process_method_func)daWtGate_Create,
+    (process_method_func)daWtGate_Delete,
+    (process_method_func)daWtGate_Execute,
     0,
-    (process_method_func)daWtGate_Draw__FP10daWtGate_c,
+    (process_method_func)daWtGate_Draw,
 };
 
 /* 80D2C538-80D2C568 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_WtGate */
@@ -175,216 +254,3 @@ extern actor_process_profile_definition g_profile_Obj_WtGate = {
   fopAc_ACTOR_e,          // mActorType
   fopAc_CULLBOX_CUSTOM_e, // cullType
 };
-
-/* 80D2C568-80D2C590 0000D0 0028+00 1/1 0/0 0/0 .data            __vt__10daWtGate_c */
-SECTION_DATA extern void* __vt__10daWtGate_c[10] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)CreateHeap__10daWtGate_cFv,
-    (void*)Create__16dBgS_MoveBgActorFv,
-    (void*)Execute__10daWtGate_cFPPA3_A4_f,
-    (void*)Draw__10daWtGate_cFv,
-    (void*)Delete__10daWtGate_cFv,
-    (void*)IsDelete__16dBgS_MoveBgActorFv,
-    (void*)ToFore__16dBgS_MoveBgActorFv,
-    (void*)ToBack__16dBgS_MoveBgActorFv,
-};
-
-/* 80D2C590-80D2C59C 0000F8 000C+00 2/2 0/0 0/0 .data            __vt__14daWtGate_HIO_c */
-SECTION_DATA extern void* __vt__14daWtGate_HIO_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__14daWtGate_HIO_cFv,
-};
-
-/* 80D2C59C-80D2C5A8 000104 000C+00 3/3 0/0 0/0 .data            __vt__14mDoHIO_entry_c */
-SECTION_DATA extern void* __vt__14mDoHIO_entry_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__14mDoHIO_entry_cFv,
-};
-
-/* 80D2BB8C-80D2BBC4 0000EC 0038+00 1/1 0/0 0/0 .text            __ct__14daWtGate_HIO_cFv */
-daWtGate_HIO_c::daWtGate_HIO_c() {
-    // NONMATCHING
-}
-
-/* 80D2BBC4-80D2BC0C 000124 0048+00 1/0 0/0 0/0 .text            __dt__14mDoHIO_entry_cFv */
-// mDoHIO_entry_c::~mDoHIO_entry_c() {
-extern "C" void __dt__14mDoHIO_entry_cFv() {
-    // NONMATCHING
-}
-
-/* 80D2BC0C-80D2BC94 00016C 0088+00 2/2 0/0 0/0 .text            setBaseMtx__10daWtGate_cFv */
-void daWtGate_c::setBaseMtx() {
-    // NONMATCHING
-}
-
-/* ############################################################################################## */
-/* 80D2C48C-80D2C48C 000020 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80D2C48C = "S_Zsuimon";
-#pragma pop
-
-/* 80D2BC94-80D2BD00 0001F4 006C+00 1/0 0/0 0/0 .text            CreateHeap__10daWtGate_cFv */
-void daWtGate_c::CreateHeap() {
-    // NONMATCHING
-}
-
-/* ############################################################################################## */
-/* 80D2C470-80D2C474 000004 0004+00 1/1 0/0 0/0 .rodata          @3712 */
-SECTION_RODATA static f32 const lit_3712 = 10.0f;
-COMPILER_STRIP_GATE(0x80D2C470, &lit_3712);
-
-/* 80D2C474-80D2C47C 000008 0008+00 1/1 0/0 0/0 .rodata          @3714 */
-SECTION_RODATA static u8 const lit_3714[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80D2C474, &lit_3714);
-
-/* 80D2BD00-80D2BE7C 000260 017C+00 1/1 0/0 0/0 .text            create__10daWtGate_cFv */
-void daWtGate_c::create() {
-    // NONMATCHING
-}
-
-/* 80D2BE7C-80D2BECC 0003DC 0050+00 1/0 0/0 0/0 .text            Execute__10daWtGate_cFPPA3_A4_f */
-void daWtGate_c::Execute(f32 (**param_0)[3][4]) {
-    // NONMATCHING
-}
-
-/* ############################################################################################## */
-/* 80D2C5B0-80D2C5BC 000008 000C+00 1/1 0/0 0/0 .bss             @3619 */
-static u8 lit_3619[12];
-
-/* 80D2C5BC-80D2C5C8 000014 000C+00 3/3 0/0 0/0 .bss             l_HIO */
-static u8 l_HIO[12];
-
-/* 80D2C5C8-80D2C5CC 000020 0004+00 1/1 0/0 0/0 .bss             None */
-static u8 data_80D2C5C8[4];
-
-/* 80D2BECC-80D2BF88 00042C 00BC+00 1/1 0/0 0/0 .text            move__10daWtGate_cFv */
-void daWtGate_c::move() {
-    // NONMATCHING
-}
-
-/* 80D2BF88-80D2BF94 0004E8 000C+00 3/3 0/0 0/0 .text            init_modeWait__10daWtGate_cFv */
-void daWtGate_c::init_modeWait() {
-    // NONMATCHING
-}
-
-/* 80D2BF94-80D2C010 0004F4 007C+00 1/0 0/0 0/0 .text            modeWait__10daWtGate_cFv */
-void daWtGate_c::modeWait() {
-    // NONMATCHING
-}
-
-/* 80D2C010-80D2C02C 000570 001C+00 1/1 0/0 0/0 .text            init_modeOpen__10daWtGate_cFv */
-void daWtGate_c::init_modeOpen() {
-    // NONMATCHING
-}
-
-/* ############################################################################################## */
-/* 80D2C47C-80D2C480 000010 0004+00 0/2 0/0 0/0 .rodata          @3781 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3781 = 1.0f / 5.0f;
-COMPILER_STRIP_GATE(0x80D2C47C, &lit_3781);
-#pragma pop
-
-/* 80D2C480-80D2C484 000014 0004+00 0/2 0/0 0/0 .rodata          @3782 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3782 = 1.0f;
-COMPILER_STRIP_GATE(0x80D2C480, &lit_3782);
-#pragma pop
-
-/* 80D2C484-80D2C488 000018 0004+00 0/2 0/0 0/0 .rodata          @3783 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3783[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80D2C484, &lit_3783);
-#pragma pop
-
-/* 80D2C488-80D2C48C 00001C 0004+00 0/2 0/0 0/0 .rodata          @3784 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3784 = -1.0f;
-COMPILER_STRIP_GATE(0x80D2C488, &lit_3784);
-#pragma pop
-
-/* 80D2C02C-80D2C134 00058C 0108+00 1/0 0/0 0/0 .text            modeOpen__10daWtGate_cFv */
-void daWtGate_c::modeOpen() {
-    // NONMATCHING
-}
-
-/* 80D2C134-80D2C150 000694 001C+00 1/1 0/0 0/0 .text            init_modeClose__10daWtGate_cFv */
-void daWtGate_c::init_modeClose() {
-    // NONMATCHING
-}
-
-/* 80D2C150-80D2C250 0006B0 0100+00 1/0 0/0 0/0 .text            modeClose__10daWtGate_cFv */
-void daWtGate_c::modeClose() {
-    // NONMATCHING
-}
-
-/* 80D2C250-80D2C25C 0007B0 000C+00 1/1 0/0 0/0 .text            init_modeEnd__10daWtGate_cFv */
-void daWtGate_c::init_modeEnd() {
-    // NONMATCHING
-}
-
-/* 80D2C25C-80D2C260 0007BC 0004+00 1/0 0/0 0/0 .text            modeEnd__10daWtGate_cFv */
-void daWtGate_c::modeEnd() {
-    /* empty function */
-}
-
-/* 80D2C260-80D2C304 0007C0 00A4+00 1/0 0/0 0/0 .text            Draw__10daWtGate_cFv */
-void daWtGate_c::Draw() {
-    // NONMATCHING
-}
-
-/* 80D2C304-80D2C334 000864 0030+00 1/0 0/0 0/0 .text            Delete__10daWtGate_cFv */
-void daWtGate_c::Delete() {
-    // NONMATCHING
-}
-
-/* 80D2C334-80D2C360 000894 002C+00 1/0 0/0 0/0 .text            daWtGate_Draw__FP10daWtGate_c */
-static void daWtGate_Draw(daWtGate_c* param_0) {
-    // NONMATCHING
-}
-
-/* 80D2C360-80D2C380 0008C0 0020+00 1/0 0/0 0/0 .text            daWtGate_Execute__FP10daWtGate_c */
-static void daWtGate_Execute(daWtGate_c* param_0) {
-    // NONMATCHING
-}
-
-/* 80D2C380-80D2C3A0 0008E0 0020+00 1/0 0/0 0/0 .text            daWtGate_Delete__FP10daWtGate_c */
-static void daWtGate_Delete(daWtGate_c* param_0) {
-    // NONMATCHING
-}
-
-/* 80D2C3A0-80D2C3C0 000900 0020+00 1/0 0/0 0/0 .text            daWtGate_Create__FP10fopAc_ac_c */
-static void daWtGate_Create(fopAc_ac_c* param_0) {
-    // NONMATCHING
-}
-
-/* 80D2C3C0-80D2C41C 000920 005C+00 2/1 0/0 0/0 .text            __dt__14daWtGate_HIO_cFv */
-daWtGate_HIO_c::~daWtGate_HIO_c() {
-    // NONMATCHING
-}
-
-/* 80D2C41C-80D2C458 00097C 003C+00 0/0 1/0 0/0 .text            __sinit_d_a_obj_waterGate_cpp */
-void __sinit_d_a_obj_waterGate_cpp() {
-    // NONMATCHING
-}
-
-#pragma push
-#pragma force_active on
-REGISTER_CTORS(0x80D2C41C, __sinit_d_a_obj_waterGate_cpp);
-#pragma pop
-
-/* 80D2C48C-80D2C48C 000020 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */


### PR DESCRIPTION
* Add simpleCalcMaterial implicit inline to J3DModelData (seen in debug)
* Basic documentation for both actors
* WIP debug build implementations (note TODOs)
* Update configure.py and note weak ordering issues for lv3Water2