### PR TITLE
setMidnaBindEffect cleanup across various files; slight d_a_e_ym cleanup

### DIFF
--- a/src/d/actor/d_a_b_gg.cpp
+++ b/src/d/actor/d_a_b_gg.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -115,7 +116,6 @@ extern "C" void __dt__12daB_GG_HIO_cFv();
 extern "C" void __sinit_d_a_b_gg_cpp();
 extern "C" static void func_805ECBEC();
 extern "C" static void func_805ECBF4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_b_gg__stringBase0;
 
@@ -270,13 +270,11 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" extern u8 mBlureFlag__13mDoGph_gInf_c[4];
 extern "C" extern u8 struct_80450C98[4];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -285,61 +283,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 805ED060-805ED064 000000 0004+00 45/45 0/0 0/0 .rodata          @3911 */
-SECTION_RODATA static f32 const lit_3911 = 100.0f;
-COMPILER_STRIP_GATE(0x805ED060, &lit_3911);
-
-/* 805ED064-805ED068 000004 0004+00 8/44 0/0 0/0 .rodata          @3912 */
-SECTION_RODATA static u8 const lit_3912[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x805ED064, &lit_3912);
-
-/* 805ED068-805ED070 000008 0004+04 1/21 0/0 0/0 .rodata          @3913 */
-SECTION_RODATA static f32 const lit_3913[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x805ED068, &lit_3913);
-
-/* 805ED070-805ED078 000010 0008+00 0/13 0/0 0/0 .rodata          @3914 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3914[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x805ED070, &lit_3914);
-#pragma pop
-
-/* 805ED078-805ED080 000018 0008+00 0/13 0/0 0/0 .rodata          @3915 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3915[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x805ED078, &lit_3915);
-#pragma pop
-
-/* 805ED080-805ED088 000020 0008+00 0/13 0/0 0/0 .rodata          @3916 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3916[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x805ED080, &lit_3916);
-#pragma pop
-
-/* 805ED088-805ED08C 000028 0004+00 0/2 0/0 0/0 .rodata          @3917 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3917 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x805ED088, &lit_3917);
-#pragma pop
-
 /* 805ED08C-805ED090 00002C 0004+00 0/4 0/0 0/0 .rodata          @3932 */
 #pragma push
 #pragma force_active on
@@ -357,56 +300,6 @@ COMPILER_STRIP_GATE(0x805ED090, &lit_3933);
 /* 805ED094-805ED098 000034 0004+00 1/8 0/0 0/0 .rodata          @3934 */
 SECTION_RODATA static f32 const lit_3934 = 0.5f;
 COMPILER_STRIP_GATE(0x805ED094, &lit_3934);
-
-/* 805ED3F0-805ED3FC 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 805ED3FC-805ED410 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 805ED410-805ED418 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3790 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 805ED418-805ED420 000028 0008+00 0/1 0/0 0/0 .data            e_env$3791 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 805ED420-805ED428 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3799 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 805ED428-805ED47C -00001 0054+00 1/1 0/0 0/0 .data            @5037 */
 SECTION_DATA static void* lit_5037[21] = {
@@ -2383,13 +2276,6 @@ static void func_805ECBEC() {
 
 /* 805ECBF4-805ECBFC 00E8D4 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_805ECBF4() {
-    // NONMATCHING
-}
-
-/* 805ECBFC-805ED010 00E8DC 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_b_mgn.cpp
+++ b/src/d/actor/d_a_b_mgn.cpp
@@ -6,8 +6,8 @@
 #include "d/actor/d_a_b_mgn.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -94,7 +94,6 @@ extern "C" void __dt__13daB_MGN_HIO_cFv();
 extern "C" void __sinit_d_a_b_mgn_cpp();
 extern "C" static void func_8060F954();
 extern "C" static void func_8060F95C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" void checkNowWolf__9daPy_py_cFv();
 extern "C" extern char const* const d_a_b_mgn__stringBase0;
@@ -266,7 +265,6 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
@@ -281,61 +279,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8060FDE0-8060FDE4 000000 0004+00 30/30 0/0 0/0 .rodata          @3928 */
-SECTION_RODATA static f32 const lit_3928 = 100.0f;
-COMPILER_STRIP_GATE(0x8060FDE0, &lit_3928);
-
-/* 8060FDE4-8060FDE8 000004 0004+00 3/26 0/0 0/0 .rodata          @3929 */
-SECTION_RODATA static u8 const lit_3929[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8060FDE4, &lit_3929);
-
-/* 8060FDE8-8060FDF0 000008 0004+04 5/24 0/0 0/0 .rodata          @3930 */
-SECTION_RODATA static f32 const lit_3930[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8060FDE8, &lit_3930);
-
-/* 8060FDF0-8060FDF8 000010 0008+00 0/7 0/0 0/0 .rodata          @3931 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3931[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8060FDF0, &lit_3931);
-#pragma pop
-
-/* 8060FDF8-8060FE00 000018 0008+00 0/7 0/0 0/0 .rodata          @3932 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3932[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8060FDF8, &lit_3932);
-#pragma pop
-
-/* 8060FE00-8060FE08 000020 0008+00 0/7 0/0 0/0 .rodata          @3933 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3933[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8060FE00, &lit_3933);
-#pragma pop
-
-/* 8060FE08-8060FE0C 000028 0004+00 0/1 0/0 0/0 .rodata          @3934 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3934 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8060FE08, &lit_3934);
-#pragma pop
-
 /* 8060FE0C-8060FE10 00002C 0004+00 0/1 0/0 0/0 .rodata          @3949 */
 #pragma push
 #pragma force_active on
@@ -355,56 +298,6 @@ COMPILER_STRIP_GATE(0x8060FE10, &lit_3950);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3951 = 70.0f;
 COMPILER_STRIP_GATE(0x8060FE14, &lit_3951);
-#pragma pop
-
-/* 80610094-806100A0 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806100A0-806100B4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806100B4-806100BC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3807 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806100BC-806100C4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3808 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806100C4-806100CC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3816 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806100CC-8061010C 000038 0040+00 0/1 0/0 0/0 .data cc_sph_src__23@unnamed@d_a_b_mgn_cpp@ */
@@ -2002,13 +1895,6 @@ static void func_8060F954() {
 
 /* 8060F95C-8060F964 00A31C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8060F95C() {
-    // NONMATCHING
-}
-
-/* 8060F964-8060FD78 00A324 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_b_tn.cpp
+++ b/src/d/actor/d_a_b_tn.cpp
@@ -6,6 +6,8 @@
 #include "d/actor/d_a_b_tn.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 //
 // Forward References:
@@ -101,7 +103,6 @@ extern "C" void __dt__12daB_TN_HIO_cFv();
 extern "C" void __sinit_d_a_b_tn_cpp();
 extern "C" static void func_8062E16C();
 extern "C" static void func_8062E174();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" void checkNowWolf__9daPy_py_cFv();
@@ -279,7 +280,6 @@ extern "C" extern void* __vt__12cCcD_CpsAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
@@ -292,61 +292,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8062E634-8062E638 000000 0004+00 36/36 0/0 0/0 .rodata          @3920 */
-SECTION_RODATA static f32 const lit_3920 = 100.0f;
-COMPILER_STRIP_GATE(0x8062E634, &lit_3920);
-
-/* 8062E638-8062E63C 000004 0004+00 4/33 0/0 0/0 .rodata          @3921 */
-SECTION_RODATA static u8 const lit_3921[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8062E638, &lit_3921);
-
-/* 8062E63C-8062E644 000008 0004+04 5/27 0/0 0/0 .rodata          @3922 */
-SECTION_RODATA static f32 const lit_3922[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8062E63C, &lit_3922);
-
-/* 8062E644-8062E64C 000010 0008+00 0/4 0/0 0/0 .rodata          @3923 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3923[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8062E644, &lit_3923);
-#pragma pop
-
-/* 8062E64C-8062E654 000018 0008+00 0/4 0/0 0/0 .rodata          @3924 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3924[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8062E64C, &lit_3924);
-#pragma pop
-
-/* 8062E654-8062E65C 000020 0008+00 0/4 0/0 0/0 .rodata          @3925 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3925[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8062E654, &lit_3925);
-#pragma pop
-
-/* 8062E65C-8062E660 000028 0004+00 0/1 0/0 0/0 .rodata          @3926 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3926 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8062E65C, &lit_3926);
-#pragma pop
-
 /* 8062E660-8062E664 00002C 0004+00 0/1 0/0 0/0 .rodata          @3941 */
 #pragma push
 #pragma force_active on
@@ -401,56 +346,6 @@ COMPILER_STRIP_GATE(0x8062E678, &lit_3947);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3948 = 360.0f;
 COMPILER_STRIP_GATE(0x8062E67C, &lit_3948);
-#pragma pop
-
-/* 8062E904-8062E910 000000 000C+00 3/3 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8062E910-8062E924 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8062E924-8062E92C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3799 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8062E92C-8062E934 000028 0008+00 0/1 0/0 0/0 .data            e_env$3800 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8062E934-8062E93C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3808 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 8062E93C-8062E97C 000038 0040+00 0/1 0/0 0/0 .data            cc_tt_src__22@unnamed@d_a_b_tn_cpp@
@@ -2734,13 +2629,6 @@ static void func_8062E16C() {
 
 /* 8062E174-8062E17C 00F674 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8062E174() {
-    // NONMATCHING
-}
-
-/* 8062E17C-8062E590 00F67C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ai.cpp
+++ b/src/d/actor/d_a_e_ai.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_ai.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -54,7 +55,6 @@ extern "C" void __dt__12daE_AI_HIO_cFv();
 extern "C" void __sinit_d_a_e_ai_cpp();
 extern "C" static void func_8067BFC4();
 extern "C" static void func_8067BFCC();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_ai__stringBase0;
 
 //
@@ -162,12 +162,9 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -175,61 +172,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8067C3FC-8067C400 000000 0004+00 15/15 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static f32 const lit_3789 = 100.0f;
-COMPILER_STRIP_GATE(0x8067C3FC, &lit_3789);
-
-/* 8067C400-8067C404 000004 0004+00 2/13 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static u8 const lit_3790[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8067C400, &lit_3790);
-
-/* 8067C404-8067C40C 000008 0004+04 1/11 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static f32 const lit_3791[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8067C404, &lit_3791);
-
-/* 8067C40C-8067C414 000010 0008+00 0/3 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8067C40C, &lit_3792);
-#pragma pop
-
-/* 8067C414-8067C41C 000018 0008+00 0/3 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8067C414, &lit_3793);
-#pragma pop
-
-/* 8067C41C-8067C424 000020 0008+00 0/3 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8067C41C, &lit_3794);
-#pragma pop
-
-/* 8067C424-8067C428 000028 0004+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3795 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8067C424, &lit_3795);
-#pragma pop
-
 /* 8067C428-8067C42C 00002C 0004+00 0/1 0/0 0/0 .rodata          @3810 */
 #pragma push
 #pragma force_active on
@@ -256,56 +198,6 @@ COMPILER_STRIP_GATE(0x8067C430, &lit_3812);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3813 = 190.0f;
 COMPILER_STRIP_GATE(0x8067C434, &lit_3813);
-#pragma pop
-
-/* 8067C540-8067C54C 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8067C54C-8067C560 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8067C560-8067C568 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8067C568-8067C570 000028 0008+00 0/1 0/0 0/0 .data            e_env$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8067C570-8067C578 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3677 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 8067C578-8067C5BC 000038 0044+00 1/1 0/0 0/0 .data            cc_cyl_src$3819 */
@@ -898,13 +790,6 @@ static void func_8067BFC4() {
 
 /* 8067BFCC-8067BFD4 002F4C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8067BFCC() {
-    // NONMATCHING
-}
-
-/* 8067BFD4-8067C3E8 002F54 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_bi.cpp
+++ b/src/d/actor/d_a_e_bi.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_bi.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -48,7 +49,6 @@ extern "C" static void func_8068D368();
 extern "C" static void func_8068D370();
 extern "C" static void func_8068D378();
 extern "C" static void func_8068D380();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_bi__stringBase0;
 
@@ -169,10 +169,8 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
@@ -182,61 +180,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8068D7EC-8068D7F0 000000 0004+00 13/13 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static f32 const lit_3903 = 100.0f;
-COMPILER_STRIP_GATE(0x8068D7EC, &lit_3903);
-
-/* 8068D7F0-8068D7F4 000004 0004+00 2/13 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static u8 const lit_3904[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8068D7F0, &lit_3904);
-
-/* 8068D7F4-8068D7FC 000008 0004+04 1/10 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static f32 const lit_3905[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8068D7F4, &lit_3905);
-
-/* 8068D7FC-8068D804 000010 0008+00 0/5 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8068D7FC, &lit_3906);
-#pragma pop
-
-/* 8068D804-8068D80C 000018 0008+00 0/5 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8068D804, &lit_3907);
-#pragma pop
-
-/* 8068D80C-8068D814 000020 0008+00 0/5 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8068D80C, &lit_3908);
-#pragma pop
-
-/* 8068D814-8068D818 000028 0004+00 0/2 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3909 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8068D814, &lit_3909);
-#pragma pop
-
 /* 8068D818-8068D81C 00002C 0004+00 0/1 0/0 0/0 .rodata          @3924 */
 #pragma push
 #pragma force_active on
@@ -256,56 +199,6 @@ COMPILER_STRIP_GATE(0x8068D81C, &lit_3925);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3926 = 10.0f;
 COMPILER_STRIP_GATE(0x8068D820, &lit_3926);
-#pragma pop
-
-/* 8068D8EC-8068D8F8 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8068D8F8-8068D90C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8068D90C-8068D914 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8068D914-8068D91C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3783 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8068D91C-8068D924 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3791 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 8068D924-8068D930 000038 000A+02 1/1 0/0 0/0 .data            ex_eff_id$4336 */
@@ -1081,13 +974,6 @@ static void func_8068D378() {
 
 /* 8068D380-8068D388 002E80 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8068D380() {
-    // NONMATCHING
-}
-
-/* 8068D388-8068D79C 002E88 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_bs.cpp
+++ b/src/d/actor/d_a_e_bs.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_bs.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -47,7 +48,6 @@ extern "C" void __dt__12daE_BS_HIO_cFv();
 extern "C" void __sinit_d_a_e_bs_cpp();
 extern "C" static void func_806909A0();
 extern "C" static void func_806909A8();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_bs__stringBase0;
 
 //
@@ -164,10 +164,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -176,61 +174,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80690DD8-80690DDC 000000 0004+00 13/13 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x80690DD8, &lit_3788);
-
-/* 80690DDC-80690DE0 000004 0004+00 3/13 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80690DDC, &lit_3789);
-
-/* 80690DE0-80690DE8 000008 0004+04 2/13 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80690DE0, &lit_3790);
-
-/* 80690DE8-80690DF0 000010 0008+00 0/1 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80690DE8, &lit_3791);
-#pragma pop
-
-/* 80690DF0-80690DF8 000018 0008+00 0/1 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80690DF0, &lit_3792);
-#pragma pop
-
-/* 80690DF8-80690E00 000020 0008+00 0/1 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80690DF8, &lit_3793);
-#pragma pop
-
-/* 80690E00-80690E04 000028 0004+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80690E00, &lit_3794);
-#pragma pop
-
 /* 80690E04-80690E08 00002C 0004+00 0/3 0/0 0/0 .rodata          @3809 */
 #pragma push
 #pragma force_active on
@@ -257,56 +200,6 @@ COMPILER_STRIP_GATE(0x80690E0C, &lit_3811);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3812 = 200.0f;
 COMPILER_STRIP_GATE(0x80690E10, &lit_3812);
-#pragma pop
-
-/* 80690EC4-80690ED0 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80690ED0-80690EE4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80690EE4-80690EEC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80690EEC-80690EF4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80690EF4-80690EFC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80690EFC-80690F00 000038 0004+00 1/1 0/0 0/0 .data            ap_name$3966 */
@@ -948,13 +841,6 @@ static void func_806909A0() {
 
 /* 806909A8-806909B0 002968 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806909A8() {
-    // NONMATCHING
-}
-
-/* 806909B0-80690DC4 002970 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_bu.cpp
+++ b/src/d/actor/d_a_e_bu.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_bu.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -47,7 +48,6 @@ extern "C" void __dt__12daE_BU_HIO_cFv();
 extern "C" void __sinit_d_a_e_bu_cpp();
 extern "C" static void func_80694258();
 extern "C" static void func_80694260();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_bu__stringBase0;
 
 //
@@ -149,11 +149,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 mParticleTracePCB__13dPa_control_c[4 + 4 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
@@ -163,61 +161,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80694690-80694694 000000 0004+00 17/17 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x80694690, &lit_3788);
-
-/* 80694694-80694698 000004 0004+00 1/13 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80694694, &lit_3789);
-
-/* 80694698-806946A0 000008 0004+04 2/13 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80694698, &lit_3790);
-
-/* 806946A0-806946A8 000010 0008+00 0/2 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806946A0, &lit_3791);
-#pragma pop
-
-/* 806946A8-806946B0 000018 0008+00 0/2 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806946A8, &lit_3792);
-#pragma pop
-
-/* 806946B0-806946B8 000020 0008+00 0/2 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806946B0, &lit_3793);
-#pragma pop
-
-/* 806946B8-806946BC 000028 0004+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806946B8, &lit_3794);
-#pragma pop
-
 /* 806946BC-806946C0 00002C 0004+00 0/2 0/0 0/0 .rodata          @3809 */
 #pragma push
 #pragma force_active on
@@ -244,56 +187,6 @@ COMPILER_STRIP_GATE(0x806946C4, &lit_3811);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3812 = 40.0f;
 COMPILER_STRIP_GATE(0x806946C8, &lit_3812);
-#pragma pop
-
-/* 8069477C-80694788 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80694788-8069479C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8069479C-806947A4 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806947A4-806947AC 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806947AC-806947B4 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806947B4-806947E8 -00001 0034+00 1/1 0/0 0/0 .data            @4457 */
@@ -942,13 +835,6 @@ static void func_80694258() {
 
 /* 80694260-80694268 0031A0 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80694260() {
-    // NONMATCHING
-}
-
-/* 80694268-8069467C 0031A8 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_cr.cpp
+++ b/src/d/actor/d_a_e_cr.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_cr.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -40,7 +41,6 @@ extern "C" void __dt__12daE_CR_HIO_cFv();
 extern "C" void __sinit_d_a_e_cr_cpp();
 extern "C" static void func_80699878();
 extern "C" static void func_80699880();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_cr__stringBase0;
 
 //
@@ -129,10 +129,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -141,61 +139,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80699CB0-80699CB4 000000 0004+00 8/8 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x80699CB0, &lit_3788);
-
-/* 80699CB4-80699CB8 000004 0004+00 2/7 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80699CB4, &lit_3789);
-
-/* 80699CB8-80699CC0 000008 0004+04 2/7 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80699CB8, &lit_3790);
-
-/* 80699CC0-80699CC8 000010 0008+00 0/1 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80699CC0, &lit_3791);
-#pragma pop
-
-/* 80699CC8-80699CD0 000018 0008+00 0/1 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80699CC8, &lit_3792);
-#pragma pop
-
-/* 80699CD0-80699CD8 000020 0008+00 0/1 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80699CD0, &lit_3793);
-#pragma pop
-
-/* 80699CD8-80699CDC 000028 0004+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80699CD8, &lit_3794);
-#pragma pop
-
 /* 80699CDC-80699CE0 00002C 0004+00 0/2 0/0 0/0 .rodata          @3809 */
 #pragma push
 #pragma force_active on
@@ -212,56 +155,6 @@ COMPILER_STRIP_GATE(0x80699CE0, &lit_3810);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3811 = 400.0f;
 COMPILER_STRIP_GATE(0x80699CE4, &lit_3811);
-#pragma pop
-
-/* 80699D4C-80699D58 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80699D58-80699D6C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80699D6C-80699D74 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80699D74-80699D7C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80699D7C-80699D84 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80699D84-80699DC4 000038 0040+00 1/1 0/0 0/0 .data            cc_sph_src$4251 */
@@ -679,13 +572,6 @@ static void func_80699878() {
 
 /* 80699880-80699888 001960 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80699880() {
-    // NONMATCHING
-}
-
-/* 80699888-80699C9C 001968 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_db.cpp
+++ b/src/d/actor/d_a_e_db.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_db.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -58,7 +59,6 @@ extern "C" void __dt__12daE_DB_HIO_cFv();
 extern "C" void __sinit_d_a_e_db_cpp();
 extern "C" static void func_806A145C();
 extern "C" static void func_806A1464();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_db__stringBase0;
@@ -206,10 +206,8 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mGndCheck__11fopAcM_gc_c[84];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
@@ -219,61 +217,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806A190C-806A1910 000000 0004+00 23/23 0/0 0/0 .rodata          @3902 */
-SECTION_RODATA static f32 const lit_3902 = 100.0f;
-COMPILER_STRIP_GATE(0x806A190C, &lit_3902);
-
-/* 806A1910-806A1914 000004 0004+00 3/22 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static u8 const lit_3903[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806A1910, &lit_3903);
-
-/* 806A1914-806A191C 000008 0004+04 1/20 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static f32 const lit_3904[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806A1914, &lit_3904);
-
-/* 806A191C-806A1924 000010 0008+00 0/6 0/0 0/0 .rodata          @3905 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3905[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A191C, &lit_3905);
-#pragma pop
-
-/* 806A1924-806A192C 000018 0008+00 0/6 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A1924, &lit_3906);
-#pragma pop
-
-/* 806A192C-806A1934 000020 0008+00 0/6 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A192C, &lit_3907);
-#pragma pop
-
-/* 806A1934-806A1938 000028 0004+00 0/1 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3908 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806A1934, &lit_3908);
-#pragma pop
-
 /* 806A1938-806A193C 00002C 0004+00 0/6 0/0 0/0 .rodata          @3923 */
 #pragma push
 #pragma force_active on
@@ -286,56 +229,6 @@ COMPILER_STRIP_GATE(0x806A1938, &lit_3923);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3924 = 6.0f / 5.0f;
 COMPILER_STRIP_GATE(0x806A193C, &lit_3924);
-#pragma pop
-
-/* 806A1A74-806A1A80 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806A1A80-806A1A94 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806A1A94-806A1A9C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3781 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806A1A9C-806A1AA4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806A1AA4-806A1AAC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3790 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806A1AAC-806A1AB0 000038 0004+00 1/1 0/0 0/0 .data            l_color$3961 */
@@ -1381,13 +1274,6 @@ static void func_806A145C() {
 
 /* 806A1464-806A146C 006A64 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806A1464() {
-    // NONMATCHING
-}
-
-/* 806A146C-806A1880 006A6C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_dd.cpp
+++ b/src/d/actor/d_a_e_dd.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_dd.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -55,7 +56,6 @@ extern "C" void __dt__12daE_DD_HIO_cFv();
 extern "C" void __sinit_d_a_e_dd_cpp();
 extern "C" static void func_806A6D8C();
 extern "C" static void func_806A6D94();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_dd__stringBase0;
 
 //
@@ -183,10 +183,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
@@ -196,61 +194,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806A71C4-806A71C8 000000 0004+00 22/22 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static f32 const lit_3903 = 100.0f;
-COMPILER_STRIP_GATE(0x806A71C4, &lit_3903);
-
-/* 806A71C8-806A71CC 000004 0004+00 2/20 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static u8 const lit_3904[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806A71C8, &lit_3904);
-
-/* 806A71CC-806A71D4 000008 0004+04 1/17 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static f32 const lit_3905[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806A71CC, &lit_3905);
-
-/* 806A71D4-806A71DC 000010 0008+00 0/4 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A71D4, &lit_3906);
-#pragma pop
-
-/* 806A71DC-806A71E4 000018 0008+00 0/4 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A71DC, &lit_3907);
-#pragma pop
-
-/* 806A71E4-806A71EC 000020 0008+00 0/4 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A71E4, &lit_3908);
-#pragma pop
-
-/* 806A71EC-806A71F0 000028 0004+00 0/1 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3909 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806A71EC, &lit_3909);
-#pragma pop
-
 /* 806A71F0-806A71F4 00002C 0004+00 0/1 0/0 0/0 .rodata          @3924 */
 #pragma push
 #pragma force_active on
@@ -291,56 +234,6 @@ COMPILER_STRIP_GATE(0x806A7200, &lit_3928);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3929 = 1.5f;
 COMPILER_STRIP_GATE(0x806A7204, &lit_3929);
-#pragma pop
-
-/* 806A72C0-806A72CC 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806A72CC-806A72E0 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806A72E0-806A72E8 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806A72E8-806A72F0 000028 0008+00 0/1 0/0 0/0 .data            e_env$3783 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806A72F0-806A72F8 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3791 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806A72F8-806A7324 -00001 002C+00 1/1 0/0 0/0 .data            @5001 */
@@ -1095,13 +988,6 @@ static void func_806A6D8C() {
 
 /* 806A6D94-806A6D9C 004C14 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806A6D94() {
-    // NONMATCHING
-}
-
-/* 806A6D9C-806A71B0 004C1C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_df.cpp
+++ b/src/d/actor/d_a_e_df.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_df.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -56,7 +57,6 @@ extern "C" static void daE_DF_Create__FP10fopAc_ac_c();
 extern "C" void __dt__10cCcD_GSttsFv();
 extern "C" void __dt__12daE_DF_HIO_cFv();
 extern "C" void __sinit_d_a_e_df_cpp();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_df__stringBase0;
 
 //
@@ -149,7 +149,6 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
@@ -161,69 +160,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806A9F30-806A9F34 000000 0004+00 11/11 0/0 0/0 .rodata          @3916 */
-SECTION_RODATA static f32 const lit_3916 = 100.0f;
-COMPILER_STRIP_GATE(0x806A9F30, &lit_3916);
-
-/* 806A9F34-806A9F38 000004 0004+00 2/12 0/0 0/0 .rodata          @3917 */
-SECTION_RODATA static u8 const lit_3917[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806A9F34, &lit_3917);
-
-/* 806AA004-806AA010 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806AA010-806AA024 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806AA024-806AA02C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3795 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806AA02C-806AA034 000028 0008+00 0/1 0/0 0/0 .data            e_env$3796 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806AA034-806AA03C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3804 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
-
 /* 806AA03C-806AA05C -00001 0020+00 1/0 0/0 0/0 .data            l_daE_DF_Method */
 static actor_method_class l_daE_DF_Method = {
     (process_method_func)daE_DF_Create__FP10fopAc_ac_c,
@@ -292,14 +228,6 @@ daE_DF_HIO_c::daE_DF_HIO_c() {
 }
 
 /* ############################################################################################## */
-/* 806A9F38-806A9F40 000008 0004+04 2/10 0/0 0/0 .rodata          @3918 */
-SECTION_RODATA static f32 const lit_3918[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806A9F38, &lit_3918);
-
 /* 806A9FFC-806A9FFC 0000CC 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
 #pragma push
 #pragma force_active on
@@ -317,40 +245,6 @@ static void useHeapInit(fopAc_ac_c* param_0) {
 }
 
 /* ############################################################################################## */
-/* 806A9F40-806A9F48 000010 0008+00 0/3 0/0 0/0 .rodata          @3919 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3919[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A9F40, &lit_3919);
-#pragma pop
-
-/* 806A9F48-806A9F50 000018 0008+00 0/3 0/0 0/0 .rodata          @3920 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3920[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A9F48, &lit_3920);
-#pragma pop
-
-/* 806A9F50-806A9F58 000020 0008+00 0/3 0/0 0/0 .rodata          @3921 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3921[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806A9F50, &lit_3921);
-#pragma pop
-
-/* 806A9F58-806A9F5C 000028 0004+00 0/1 0/0 0/0 .rodata          @3922 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3922 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806A9F58, &lit_3922);
-#pragma pop
-
 /* 806A9F5C-806A9FA0 00002C 0044+00 1/1 0/0 0/0 .rodata          ccCylSrc$3961 */
 const static dCcD_SrcCyl ccCylSrc = {
     {
@@ -727,12 +621,5 @@ void __sinit_d_a_e_df_cpp() {
 #pragma force_active on
 REGISTER_CTORS(0x806A9ACC, __sinit_d_a_e_df_cpp);
 #pragma pop
-
-/* 806A9B08-806A9F1C 002508 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
-    // NONMATCHING
-}
 
 /* 806A9FFC-806A9FFC 0000CC 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */

--- a/src/d/actor/d_a_e_dn.cpp
+++ b/src/d/actor/d_a_e_dn.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_dn.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -81,7 +82,6 @@ extern "C" static void func_804EE428();
 extern "C" static void func_804EE430();
 extern "C" static void func_804EE438();
 extern "C" static void func_804EE440();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" extern char const* const d_a_e_dn__stringBase0;
 
@@ -226,13 +226,10 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -240,61 +237,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 804EE8AC-804EE8B0 000000 0004+00 35/35 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static f32 const lit_3789 = 100.0f;
-COMPILER_STRIP_GATE(0x804EE8AC, &lit_3789);
-
-/* 804EE8B0-804EE8B4 000004 0004+00 2/29 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static u8 const lit_3790[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x804EE8B0, &lit_3790);
-
-/* 804EE8B4-804EE8BC 000008 0004+04 2/22 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static f32 const lit_3791[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x804EE8B4, &lit_3791);
-
-/* 804EE8BC-804EE8C4 000010 0008+00 0/5 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x804EE8BC, &lit_3792);
-#pragma pop
-
-/* 804EE8C4-804EE8CC 000018 0008+00 0/5 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x804EE8C4, &lit_3793);
-#pragma pop
-
-/* 804EE8CC-804EE8D4 000020 0008+00 0/5 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x804EE8CC, &lit_3794);
-#pragma pop
-
-/* 804EE8D4-804EE8D8 000028 0004+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3795 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x804EE8D4, &lit_3795);
-#pragma pop
-
 /* 804EE8D8-804EE8DC 00002C 0004+00 0/2 0/0 0/0 .rodata          @3810 */
 #pragma push
 #pragma force_active on
@@ -325,56 +267,6 @@ COMPILER_STRIP_GATE(0x804EE8E4, &lit_3813);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3814 = 350.0f;
 COMPILER_STRIP_GATE(0x804EE8E8, &lit_3814);
-#pragma pop
-
-/* 804EEA40-804EEA4C 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 804EEA4C-804EEA60 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 804EEA60-804EEA68 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 804EEA68-804EEA70 000028 0008+00 0/1 0/0 0/0 .data            e_env$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 804EEA70-804EEA78 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3677 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 804EEA78-804EEAA4 -00001 002C+00 1/1 0/0 0/0 .data            @4546 */
@@ -1787,13 +1679,6 @@ static void func_804EE438() {
 
 /* 804EE440-804EE448 009380 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_804EE440() {
-    // NONMATCHING
-}
-
-/* 804EE448-804EE85C 009388 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_gb.cpp
+++ b/src/d/actor/d_a_e_gb.cpp
@@ -8,7 +8,8 @@
 #include "dol2asm.h"
 #include "d/d_camera.h"
 #include "d/actor/d_a_obj_smallkey.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -59,7 +60,6 @@ extern "C" void __dt__12daE_GB_HIO_cFv();
 extern "C" void __sinit_d_a_e_gb_cpp();
 extern "C" static void func_806C701C();
 extern "C" static void func_806C7024();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" void setPos__7daKey_cF4cXyz();
@@ -204,7 +204,6 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
@@ -217,114 +216,9 @@ extern "C" void actionWaitInit__7daKey_cFv();
 //
 
 /* ############################################################################################## */
-/* 806C74E8-806C74EC 000000 0004+00 20/20 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static f32 const lit_3906 = 100.0f;
-COMPILER_STRIP_GATE(0x806C74E8, &lit_3906);
-
-/* 806C74EC-806C74F0 000004 0004+00 4/24 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static u8 const lit_3907[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806C74EC, &lit_3907);
-
-/* 806C74F0-806C74F8 000008 0004+04 3/18 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static f32 const lit_3908[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806C74F0, &lit_3908);
-
-/* 806C74F8-806C7500 000010 0008+00 0/5 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806C74F8, &lit_3909);
-#pragma pop
-
-/* 806C7500-806C7508 000018 0008+00 0/5 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806C7500, &lit_3910);
-#pragma pop
-
-/* 806C7508-806C7510 000020 0008+00 0/5 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806C7508, &lit_3911);
-#pragma pop
-
-/* 806C7510-806C7514 000028 0004+00 0/1 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3912 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806C7510, &lit_3912);
-#pragma pop
-
 /* 806C7514-806C7518 00002C 0004+00 1/1 0/0 0/0 .rodata          @3927 */
 SECTION_RODATA static f32 const lit_3927 = 65.0f;
 COMPILER_STRIP_GATE(0x806C7514, &lit_3927);
-
-/* 806C76C4-806C76D0 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806C76D0-806C76E4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806C76E4-806C76EC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3785 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806C76EC-806C76F4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3786 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806C76F4-806C76FC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3794 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 806C76FC-806C7700 000038 0004+00 1/1 0/0 0/0 .data            eno$4381 */
 SECTION_DATA static u8 eno_4381[4] = {
@@ -1581,13 +1475,6 @@ static void func_806C701C() {
 
 /* 806C7024-806C702C 005424 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806C7024() {
-    // NONMATCHING
-}
-
-/* 806C702C-806C7440 00542C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ge.cpp
+++ b/src/d/actor/d_a_e_ge.cpp
@@ -6,6 +6,8 @@
 #include "d/actor/d_a_e_ge.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 //
 // Forward References:
@@ -65,7 +67,6 @@ extern "C" void __dt__12daE_GE_HIO_cFv();
 extern "C" void __sinit_d_a_e_ge_cpp();
 extern "C" static void func_806CCBC8();
 extern "C" static void func_806CCBD0();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_ge__stringBase0;
 extern "C" u8 l_actionmenu__8daE_GE_c[108];
 
@@ -183,7 +184,6 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
@@ -194,61 +194,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806CD000-806CD004 000000 0004+00 18/18 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static f32 const lit_3904 = 100.0f;
-COMPILER_STRIP_GATE(0x806CD000, &lit_3904);
-
-/* 806CD004-806CD008 000004 0004+00 4/18 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static u8 const lit_3905[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806CD004, &lit_3905);
-
-/* 806CD008-806CD010 000008 0004+04 2/15 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static f32 const lit_3906[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806CD008, &lit_3906);
-
-/* 806CD010-806CD018 000010 0008+00 0/8 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806CD010, &lit_3907);
-#pragma pop
-
-/* 806CD018-806CD020 000018 0008+00 0/8 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806CD018, &lit_3908);
-#pragma pop
-
-/* 806CD020-806CD028 000020 0008+00 0/8 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806CD020, &lit_3909);
-#pragma pop
-
-/* 806CD028-806CD02C 000028 0004+00 0/1 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3910 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806CD028, &lit_3910);
-#pragma pop
-
 /* 806CD02C-806CD030 00002C 0004+00 0/4 0/0 0/0 .rodata          @3925 */
 #pragma push
 #pragma force_active on
@@ -300,56 +245,6 @@ COMPILER_STRIP_GATE(0x806CD044, &lit_3931);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3932 = 110.0f;
 COMPILER_STRIP_GATE(0x806CD048, &lit_3932);
-#pragma pop
-
-/* 806CD118-806CD124 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806CD124-806CD138 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806CD138-806CD140 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3783 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806CD140-806CD148 000028 0008+00 0/1 0/0 0/0 .data            e_env$3784 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806CD148-806CD150 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3792 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806CD150-806CD17C -00001 002C+00 1/1 0/0 0/0 .data            @5071 */
@@ -1189,13 +1084,6 @@ static void func_806CCBC8() {
 
 /* 806CCBD0-806CCBD8 005270 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806CCBD0() {
-    // NONMATCHING
-}
-
-/* 806CCBD8-806CCFEC 005278 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_gi.cpp
+++ b/src/d/actor/d_a_e_gi.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_gi.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -60,7 +61,6 @@ extern "C" void __dt__12daE_GI_HIO_cFv();
 extern "C" void __sinit_d_a_e_gi_cpp();
 extern "C" static void func_806D0A10();
 extern "C" static void func_806D0A18();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void checkNowWolf__9daPy_py_cFv();
 extern "C" extern char const* const d_a_e_gi__stringBase0;
 
@@ -184,7 +184,6 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 m_cpadInfo__8mDoCPd_c[256];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
@@ -195,61 +194,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806D0E60-806D0E64 000000 0004+00 15/15 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static f32 const lit_3907 = 100.0f;
-COMPILER_STRIP_GATE(0x806D0E60, &lit_3907);
-
-/* 806D0E64-806D0E68 000004 0004+00 2/15 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static u8 const lit_3908[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806D0E64, &lit_3908);
-
-/* 806D0E68-806D0E70 000008 0004+04 3/14 0/0 0/0 .rodata          @3909 */
-SECTION_RODATA static f32 const lit_3909[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806D0E68, &lit_3909);
-
-/* 806D0E70-806D0E78 000010 0008+00 0/2 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806D0E70, &lit_3910);
-#pragma pop
-
-/* 806D0E78-806D0E80 000018 0008+00 0/1 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806D0E78, &lit_3911);
-#pragma pop
-
-/* 806D0E80-806D0E88 000020 0008+00 0/1 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3912[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806D0E80, &lit_3912);
-#pragma pop
-
-/* 806D0E88-806D0E8C 000028 0004+00 0/1 0/0 0/0 .rodata          @3913 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3913 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806D0E88, &lit_3913);
-#pragma pop
-
 /* 806D0E8C-806D0E90 00002C 0004+00 0/1 0/0 0/0 .rodata          @3928 */
 #pragma push
 #pragma force_active on
@@ -308,56 +252,6 @@ COMPILER_STRIP_GATE(0x806D0EA8, &lit_3935);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3936 = 35.0f;
 COMPILER_STRIP_GATE(0x806D0EAC, &lit_3936);
-#pragma pop
-
-/* 806D0F84-806D0F90 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806D0F90-806D0FA4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806D0FA4-806D0FAC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3786 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806D0FAC-806D0FB4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806D0FB4-806D0FBC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3795 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806D0FBC-806D0FFC 000038 0040+00 1/1 0/0 0/0 .data            cc_gi_src__22@unnamed@d_a_e_gi_cpp@
@@ -1091,13 +985,6 @@ static void func_806D0A10() {
 
 /* 806D0A18-806D0A20 003678 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806D0A18() {
-    // NONMATCHING
-}
-
-/* 806D0A20-806D0E34 003680 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_gm.cpp
+++ b/src/d/actor/d_a_e_gm.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_gm.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -63,7 +64,6 @@ extern "C" void __dt__12daE_GM_HIO_cFv();
 extern "C" void __sinit_d_a_e_gm_cpp();
 extern "C" static void func_806D74F0();
 extern "C" static void func_806D74F8();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_gm__stringBase0;
@@ -174,11 +174,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -187,61 +185,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806D79A0-806D79A4 000000 0004+00 26/26 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static f32 const lit_3906 = 100.0f;
-COMPILER_STRIP_GATE(0x806D79A0, &lit_3906);
-
-/* 806D79A4-806D79A8 000004 0004+00 1/23 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static u8 const lit_3907[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806D79A4, &lit_3907);
-
-/* 806D79A8-806D79B0 000008 0004+04 4/24 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static f32 const lit_3908[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806D79A8, &lit_3908);
-
-/* 806D79B0-806D79B8 000010 0008+00 0/6 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806D79B0, &lit_3909);
-#pragma pop
-
-/* 806D79B8-806D79C0 000018 0008+00 0/6 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806D79B8, &lit_3910);
-#pragma pop
-
-/* 806D79C0-806D79C8 000020 0008+00 0/6 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806D79C0, &lit_3911);
-#pragma pop
-
-/* 806D79C8-806D79CC 000028 0004+00 0/1 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3912 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806D79C8, &lit_3912);
-#pragma pop
-
 /* 806D79CC-806D79D0 00002C 0004+00 0/2 0/0 0/0 .rodata          @4055 */
 #pragma push
 #pragma force_active on
@@ -279,56 +222,6 @@ COMPILER_STRIP_GATE(0x806D79DC, &lit_4059);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_4060 = 300.0f;
 COMPILER_STRIP_GATE(0x806D79E0, &lit_4060);
-#pragma pop
-
-/* 806D7AFC-806D7B08 000000 000C+00 8/8 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806D7B08-806D7B1C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806D7B1C-806D7B24 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3785 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806D7B24-806D7B2C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3786 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806D7B2C-806D7B34 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3794 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806D7B34-806D7B38 000038 0004+00 2/3 0/0 0/0 .data l_hitActorID__22@unnamed@d_a_e_gm_cpp@ */
@@ -1698,13 +1591,6 @@ static void func_806D74F0() {
 
 /* 806D74F8-806D7500 006378 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806D74F8() {
-    // NONMATCHING
-}
-
-/* 806D7500-806D7914 006380 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_hb.cpp
+++ b/src/d/actor/d_a_e_hb.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_hb.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -53,7 +54,6 @@ extern "C" void __dt__12daE_HB_HIO_cFv();
 extern "C" void __sinit_d_a_e_hb_cpp();
 extern "C" static void func_80500654();
 extern "C" static void func_8050065C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_hb__stringBase0;
@@ -184,13 +184,10 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mGndCheck__11fopAcM_gc_c[84];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -198,114 +195,9 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80500B04-80500B08 000000 0004+00 16/16 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x80500B04, &lit_3788);
-
-/* 80500B08-80500B0C 000004 0004+00 4/18 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80500B08, &lit_3789);
-
-/* 80500B0C-80500B14 000008 0004+04 3/15 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80500B0C, &lit_3790);
-
-/* 80500B14-80500B1C 000010 0008+00 0/5 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80500B14, &lit_3791);
-#pragma pop
-
-/* 80500B1C-80500B24 000018 0008+00 0/5 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80500B1C, &lit_3792);
-#pragma pop
-
-/* 80500B24-80500B2C 000020 0008+00 0/5 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80500B24, &lit_3793);
-#pragma pop
-
-/* 80500B2C-80500B30 000028 0004+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80500B2C, &lit_3794);
-#pragma pop
-
 /* 80500B30-80500B34 00002C 0004+00 1/4 0/0 0/0 .rodata          @3809 */
 SECTION_RODATA static f32 const lit_3809 = 0.5f;
 COMPILER_STRIP_GATE(0x80500B30, &lit_3809);
-
-/* 80500C3C-80500C48 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80500C48-80500C5C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80500C5C-80500C64 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80500C64-80500C6C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80500C6C-80500C74 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 80500C74-80500C78 000038 0004+00 1/1 0/0 0/0 .data            l_color$3841 */
 SECTION_DATA static u8 l_color[4] = {
@@ -1174,13 +1066,6 @@ static void func_80500654() {
 
 /* 8050065C-80500664 0049DC 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8050065C() {
-    // NONMATCHING
-}
-
-/* 80500664-80500A78 0049E4 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_hm.cpp
+++ b/src/d/actor/d_a_e_hm.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_hm.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -84,7 +85,6 @@ extern "C" void __dt__12daE_HM_HIO_cFv();
 extern "C" void __sinit_d_a_e_hm_cpp();
 extern "C" static void func_806E54AC();
 extern "C" static void func_806E54B4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_hm__stringBase0;
 
@@ -201,12 +201,10 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -214,61 +212,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806E5920-806E5924 000000 0004+00 32/32 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static f32 const lit_3791 = 100.0f;
-COMPILER_STRIP_GATE(0x806E5920, &lit_3791);
-
-/* 806E5924-806E5928 000004 0004+00 1/26 0/0 0/0 .rodata          @3792 */
-SECTION_RODATA static u8 const lit_3792[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806E5924, &lit_3792);
-
-/* 806E5928-806E5930 000008 0004+04 4/22 0/0 0/0 .rodata          @3793 */
-SECTION_RODATA static f32 const lit_3793[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806E5928, &lit_3793);
-
-/* 806E5930-806E5938 000010 0008+00 0/7 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806E5930, &lit_3794);
-#pragma pop
-
-/* 806E5938-806E5940 000018 0008+00 0/7 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3795[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806E5938, &lit_3795);
-#pragma pop
-
-/* 806E5940-806E5948 000020 0008+00 0/7 0/0 0/0 .rodata          @3796 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3796[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806E5940, &lit_3796);
-#pragma pop
-
-/* 806E5948-806E594C 000028 0004+00 0/1 0/0 0/0 .rodata          @3797 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3797 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806E5948, &lit_3797);
-#pragma pop
-
 /* 806E594C-806E5950 00002C 0004+00 0/1 0/0 0/0 .rodata          @3812 */
 #pragma push
 #pragma force_active on
@@ -302,56 +245,6 @@ COMPILER_STRIP_GATE(0x806E5958, &lit_3815);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3816 = 11.0f / 10.0f;
 COMPILER_STRIP_GATE(0x806E595C, &lit_3816);
-#pragma pop
-
-/* 806E5A7C-806E5A88 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806E5A88-806E5A9C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806E5A9C-806E5AA4 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3670 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806E5AA4-806E5AAC 000028 0008+00 0/1 0/0 0/0 .data            e_env$3671 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806E5AAC-806E5AB4 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3679 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806E5AB4-806E5AD8 -00001 0024+00 1/1 0/0 0/0 .data            @4028 */
@@ -1363,13 +1256,6 @@ static void func_806E54AC() {
 
 /* 806E54B4-806E54BC 0051B4 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806E54B4() {
-    // NONMATCHING
-}
-
-/* 806E54BC-806E58D0 0051BC 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_hp.cpp
+++ b/src/d/actor/d_a_e_hp.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_hp.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -56,7 +57,6 @@ extern "C" void __dt__12daE_HP_HIO_cFv();
 extern "C" void __sinit_d_a_e_hp_cpp();
 extern "C" static void func_806E9DBC();
 extern "C" static void func_806E9DC4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_hp__stringBase0;
 
 //
@@ -199,11 +199,9 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
@@ -213,114 +211,9 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806EA1F4-806EA1F8 000000 0004+00 13/13 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static f32 const lit_3905 = 100.0f;
-COMPILER_STRIP_GATE(0x806EA1F4, &lit_3905);
-
-/* 806EA1F8-806EA1FC 000004 0004+00 2/14 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static u8 const lit_3906[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806EA1F8, &lit_3906);
-
-/* 806EA1FC-806EA204 000008 0004+04 1/10 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static f32 const lit_3907[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806EA1FC, &lit_3907);
-
-/* 806EA204-806EA20C 000010 0008+00 0/8 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806EA204, &lit_3908);
-#pragma pop
-
-/* 806EA20C-806EA214 000018 0008+00 0/8 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806EA20C, &lit_3909);
-#pragma pop
-
-/* 806EA214-806EA21C 000020 0008+00 0/8 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806EA214, &lit_3910);
-#pragma pop
-
-/* 806EA21C-806EA220 000028 0004+00 0/1 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3911 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806EA21C, &lit_3911);
-#pragma pop
-
 /* 806EA220-806EA224 00002C 0004+00 1/1 0/0 0/0 .rodata          @3926 */
 SECTION_RODATA static f32 const lit_3926 = 6.0f / 5.0f;
 COMPILER_STRIP_GATE(0x806EA220, &lit_3926);
-
-/* 806EA2E8-806EA2F4 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806EA2F4-806EA308 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806EA308-806EA310 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3784 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806EA310-806EA318 000028 0008+00 0/1 0/0 0/0 .data            e_env$3785 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806EA318-806EA320 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3793 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 806EA320-806EA364 000038 0044+00 0/1 0/0 0/0 .data            cc_hp_src__22@unnamed@d_a_e_hp_cpp@
  */
@@ -1008,13 +901,6 @@ static void func_806E9DBC() {
 
 /* 806E9DC4-806E9DCC 0040C4 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806E9DC4() {
-    // NONMATCHING
-}
-
-/* 806E9DCC-806EA1E0 0040CC 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_hz.cpp
+++ b/src/d/actor/d_a_e_hz.cpp
@@ -8,7 +8,8 @@
 #include "dol2asm.h"
 #include "d/d_camera.h"
 #include "d/actor/d_a_obj_carry.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -78,7 +79,6 @@ extern "C" void __dt__12daE_HZ_HIO_cFv();
 extern "C" void __sinit_d_a_e_hz_cpp();
 extern "C" static void func_806F03EC();
 extern "C" static void func_806F03F4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_hz__stringBase0;
 
@@ -230,61 +230,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806F0860-806F0864 000000 0004+00 29/29 0/0 0/0 .rodata          @3966 */
-SECTION_RODATA static f32 const lit_3966 = 100.0f;
-COMPILER_STRIP_GATE(0x806F0860, &lit_3966);
-
-/* 806F0864-806F0868 000004 0004+00 2/23 0/0 0/0 .rodata          @3967 */
-SECTION_RODATA static u8 const lit_3967[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806F0864, &lit_3967);
-
-/* 806F0868-806F0870 000008 0004+04 2/17 0/0 0/0 .rodata          @3968 */
-SECTION_RODATA static f32 const lit_3968[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806F0868, &lit_3968);
-
-/* 806F0870-806F0878 000010 0008+00 0/5 0/0 0/0 .rodata          @3969 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3969[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806F0870, &lit_3969);
-#pragma pop
-
-/* 806F0878-806F0880 000018 0008+00 0/5 0/0 0/0 .rodata          @3970 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3970[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806F0878, &lit_3970);
-#pragma pop
-
-/* 806F0880-806F0888 000020 0008+00 0/5 0/0 0/0 .rodata          @3971 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3971[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806F0880, &lit_3971);
-#pragma pop
-
-/* 806F0888-806F088C 000028 0004+00 0/1 0/0 0/0 .rodata          @3972 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3972 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806F0888, &lit_3972);
-#pragma pop
-
 /* 806F088C-806F0890 00002C 0004+00 0/2 0/0 0/0 .rodata          @3987 */
 #pragma push
 #pragma force_active on
@@ -353,56 +298,6 @@ COMPILER_STRIP_GATE(0x806F08AC, &lit_3995);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3996 = 50.0f;
 COMPILER_STRIP_GATE(0x806F08B0, &lit_3996);
-#pragma pop
-
-/* 806F0974-806F0980 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806F0980-806F0994 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806F0994-806F099C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3845 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806F099C-806F09A4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3846 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806F09A4-806F09AC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3854 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806F09AC-806F09B0 000038 0004+00 1/1 0/0 0/0 .data            d_HZ_JUMP_EFFECT_ID$4653 */
@@ -1301,13 +1196,6 @@ static void func_806F03EC() {
 
 /* 806F03F4-806F03FC 005ED4 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806F03F4() {
-    // NONMATCHING
-}
-
-/* 806F03FC-806F0810 005EDC 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_kg.cpp
+++ b/src/d/actor/d_a_e_kg.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_kg.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -44,7 +45,6 @@ extern "C" void __dt__12daE_KG_HIO_cFv();
 extern "C" void __sinit_d_a_e_kg_cpp();
 extern "C" static void func_806F9F6C();
 extern "C" static void func_806F9F74();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_kg__stringBase0;
 
 //
@@ -139,10 +139,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -151,61 +149,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806FA3A4-806FA3A8 000000 0004+00 13/13 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x806FA3A4, &lit_3788);
-
-/* 806FA3A8-806FA3AC 000004 0004+00 2/10 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806FA3A8, &lit_3789);
-
-/* 806FA3AC-806FA3B4 000008 0004+04 1/10 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806FA3AC, &lit_3790);
-
-/* 806FA3B4-806FA3BC 000010 0008+00 0/1 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806FA3B4, &lit_3791);
-#pragma pop
-
-/* 806FA3BC-806FA3C4 000018 0008+00 0/1 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806FA3BC, &lit_3792);
-#pragma pop
-
-/* 806FA3C4-806FA3CC 000020 0008+00 0/1 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806FA3C4, &lit_3793);
-#pragma pop
-
-/* 806FA3CC-806FA3D0 000028 0004+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806FA3CC, &lit_3794);
-#pragma pop
-
 /* 806FA3D0-806FA3D4 00002C 0004+00 0/1 0/0 0/0 .rodata          @3809 */
 #pragma push
 #pragma force_active on
@@ -225,56 +168,6 @@ COMPILER_STRIP_GATE(0x806FA3D4, &lit_3810);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3811 = 600.0f;
 COMPILER_STRIP_GATE(0x806FA3D8, &lit_3811);
-#pragma pop
-
-/* 806FA474-806FA480 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806FA480-806FA494 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806FA494-806FA49C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806FA49C-806FA4A4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806FA4A4-806FA4AC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806FA4AC-806FA4D8 -00001 002C+00 1/1 0/0 0/0 .data            @4276 */
@@ -822,13 +715,6 @@ static void func_806F9F6C() {
 
 /* 806F9F74-806F9F7C 002174 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806F9F74() {
-    // NONMATCHING
-}
-
-/* 806F9F7C-806FA390 00217C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_kk.cpp
+++ b/src/d/actor/d_a_e_kk.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_kk.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -63,7 +64,6 @@ extern "C" void __dt__12daE_KK_HIO_cFv();
 extern "C" void __sinit_d_a_e_kk_cpp();
 extern "C" static void func_806FF174();
 extern "C" static void func_806FF17C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_kk__stringBase0;
 
@@ -187,12 +187,9 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -201,61 +198,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 806FF5E8-806FF5EC 000000 0004+00 21/21 0/0 0/0 .rodata          @3792 */
-SECTION_RODATA static f32 const lit_3792 = 100.0f;
-COMPILER_STRIP_GATE(0x806FF5E8, &lit_3792);
-
-/* 806FF5EC-806FF5F0 000004 0004+00 2/17 0/0 0/0 .rodata          @3793 */
-SECTION_RODATA static u8 const lit_3793[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x806FF5EC, &lit_3793);
-
-/* 806FF5F0-806FF5F8 000008 0004+04 2/17 0/0 0/0 .rodata          @3794 */
-SECTION_RODATA static f32 const lit_3794[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x806FF5F0, &lit_3794);
-
-/* 806FF5F8-806FF600 000010 0008+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3795[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806FF5F8, &lit_3795);
-#pragma pop
-
-/* 806FF600-806FF608 000018 0008+00 0/1 0/0 0/0 .rodata          @3796 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3796[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806FF600, &lit_3796);
-#pragma pop
-
-/* 806FF608-806FF610 000020 0008+00 0/1 0/0 0/0 .rodata          @3797 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3797[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x806FF608, &lit_3797);
-#pragma pop
-
-/* 806FF610-806FF614 000028 0004+00 0/1 0/0 0/0 .rodata          @3798 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3798 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x806FF610, &lit_3798);
-#pragma pop
-
 /* 806FF614-806FF618 00002C 0004+00 0/1 0/0 0/0 .rodata          @3813 */
 #pragma push
 #pragma force_active on
@@ -275,56 +217,6 @@ COMPILER_STRIP_GATE(0x806FF618, &lit_3814);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3815 = 1000.0f;
 COMPILER_STRIP_GATE(0x806FF61C, &lit_3815);
-#pragma pop
-
-/* 806FF6C4-806FF6D0 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 806FF6D0-806FF6E4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 806FF6E4-806FF6EC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3671 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 806FF6EC-806FF6F4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3672 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 806FF6F4-806FF6FC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3680 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 806FF6FC-806FF740 000038 0044+00 1/1 0/0 0/0 .data            cc_kk_src__22@unnamed@d_a_e_kk_cpp@
@@ -990,13 +882,6 @@ static void func_806FF174() {
 
 /* 806FF17C-806FF184 004B5C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_806FF17C() {
-    // NONMATCHING
-}
-
-/* 806FF184-806FF598 004B64 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_kr.cpp
+++ b/src/d/actor/d_a_e_kr.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_kr.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -55,7 +56,6 @@ extern "C" void __dt__18fOpAcm_HIO_entry_cFv();
 extern "C" void __dt__14mDoHIO_entry_cFv();
 extern "C" static void func_80705684();
 extern "C" static void func_8070568C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_kr__stringBase0;
 
@@ -172,11 +172,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -190,61 +188,6 @@ static void nodeCallBack(J3DJoint* param_0, int param_1) {
 }
 
 /* ############################################################################################## */
-/* 80705AF8-80705AFC 000000 0004+00 19/19 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static f32 const lit_3903 = 100.0f;
-COMPILER_STRIP_GATE(0x80705AF8, &lit_3903);
-
-/* 80705AFC-80705B00 000004 0004+00 3/16 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static u8 const lit_3904[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80705AFC, &lit_3904);
-
-/* 80705B00-80705B08 000008 0004+04 1/14 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static f32 const lit_3905[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80705B00, &lit_3905);
-
-/* 80705B08-80705B10 000010 0008+00 0/3 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80705B08, &lit_3906);
-#pragma pop
-
-/* 80705B10-80705B18 000018 0008+00 0/3 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80705B10, &lit_3907);
-#pragma pop
-
-/* 80705B18-80705B20 000020 0008+00 0/3 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80705B18, &lit_3908);
-#pragma pop
-
-/* 80705B20-80705B24 000028 0004+00 0/2 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3909 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80705B20, &lit_3909);
-#pragma pop
-
 /* 80705B24-80705B28 00002C 0004+00 1/1 0/0 0/0 .rodata          @4043 */
 SECTION_RODATA static f32 const lit_4043 = -1.0f;
 COMPILER_STRIP_GATE(0x80705B24, &lit_4043);
@@ -586,56 +529,6 @@ SECTION_RODATA static u8 const lit_4843[8] = {
     0x43, 0x30, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
 };
 COMPILER_STRIP_GATE(0x80705BC0, &lit_4843);
-#pragma pop
-
-/* 80705C54-80705C60 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80705C60-80705C74 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80705C74-80705C7C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80705C7C-80705C84 000028 0008+00 0/1 0/0 0/0 .data            e_env$3783 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80705C84-80705C8C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3791 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80705C8C-80705D1C -00001 0090+00 1/1 0/0 0/0 .data            @4842 */
@@ -1303,13 +1196,6 @@ static void func_80705684() {
 
 /* 8070568C-80705694 005DCC 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8070568C() {
-    // NONMATCHING
-}
-
-/* 80705694-80705AA8 005DD4 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_mf.cpp
+++ b/src/d/actor/d_a_e_mf.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_mf.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -79,7 +80,6 @@ extern "C" static void func_807134F0();
 extern "C" static void func_807134F8();
 extern "C" static void func_80713500();
 extern "C" static void func_80713508();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" extern char const* const d_a_e_mf__stringBase0;
 
@@ -225,13 +225,10 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -239,61 +236,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80713974-80713978 000000 0004+00 33/33 0/0 0/0 .rodata          @3828 */
-SECTION_RODATA static f32 const lit_3828 = 100.0f;
-COMPILER_STRIP_GATE(0x80713974, &lit_3828);
-
-/* 80713978-8071397C 000004 0004+00 2/27 0/0 0/0 .rodata          @3829 */
-SECTION_RODATA static u8 const lit_3829[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80713978, &lit_3829);
-
-/* 8071397C-80713984 000008 0004+04 2/20 0/0 0/0 .rodata          @3830 */
-SECTION_RODATA static f32 const lit_3830[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8071397C, &lit_3830);
-
-/* 80713984-8071398C 000010 0008+00 0/5 0/0 0/0 .rodata          @3831 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3831[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80713984, &lit_3831);
-#pragma pop
-
-/* 8071398C-80713994 000018 0008+00 0/5 0/0 0/0 .rodata          @3832 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3832[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8071398C, &lit_3832);
-#pragma pop
-
-/* 80713994-8071399C 000020 0008+00 0/5 0/0 0/0 .rodata          @3833 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3833[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80713994, &lit_3833);
-#pragma pop
-
-/* 8071399C-807139A0 000028 0004+00 0/1 0/0 0/0 .rodata          @3834 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3834 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8071399C, &lit_3834);
-#pragma pop
-
 /* 807139A0-807139A4 00002C 0004+00 0/1 0/0 0/0 .rodata          @3849 */
 #pragma push
 #pragma force_active on
@@ -327,56 +269,6 @@ COMPILER_STRIP_GATE(0x807139AC, &lit_3852);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3853 = 350.0f;
 COMPILER_STRIP_GATE(0x807139B0, &lit_3853);
-#pragma pop
-
-/* 80713B08-80713B14 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80713B14-80713B28 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80713B28-80713B30 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3707 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80713B30-80713B38 000028 0008+00 0/1 0/0 0/0 .data            e_env$3708 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80713B38-80713B40 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3716 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80713B40-80713B6C -00001 002C+00 1/1 0/0 0/0 .data            @4569 */
@@ -1733,13 +1625,6 @@ static void func_80713500() {
 
 /* 80713508-80713510 008EE8 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80713508() {
-    // NONMATCHING
-}
-
-/* 80713510-80713924 008EF0 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_mm.cpp
+++ b/src/d/actor/d_a_e_mm.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_mm.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -45,7 +46,6 @@ extern "C" void __dt__12daE_MM_HIO_cFv();
 extern "C" void __sinit_d_a_e_mm_cpp();
 extern "C" static void func_80722804();
 extern "C" static void func_8072280C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_mm__stringBase0;
 
 //
@@ -154,9 +154,7 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -165,61 +163,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80722C3C-80722C40 000000 0004+00 14/14 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static f32 const lit_3789 = 100.0f;
-COMPILER_STRIP_GATE(0x80722C3C, &lit_3789);
-
-/* 80722C40-80722C44 000004 0004+00 1/12 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static u8 const lit_3790[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80722C40, &lit_3790);
-
-/* 80722C44-80722C4C 000008 0004+04 3/13 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static f32 const lit_3791[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80722C44, &lit_3791);
-
-/* 80722C4C-80722C54 000010 0008+00 0/1 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80722C4C, &lit_3792);
-#pragma pop
-
-/* 80722C54-80722C5C 000018 0008+00 0/1 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80722C54, &lit_3793);
-#pragma pop
-
-/* 80722C5C-80722C64 000020 0008+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80722C5C, &lit_3794);
-#pragma pop
-
-/* 80722C64-80722C68 000028 0004+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3795 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80722C64, &lit_3795);
-#pragma pop
-
 /* 80722C68-80722C6C 00002C 0004+00 0/1 0/0 0/0 .rodata          @3810 */
 #pragma push
 #pragma force_active on
@@ -264,56 +207,6 @@ COMPILER_STRIP_GATE(0x80722C7C, &lit_3815);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3816 = 10.0f;
 COMPILER_STRIP_GATE(0x80722C80, &lit_3816);
-#pragma pop
-
-/* 80722CF4-80722D00 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80722D00-80722D14 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80722D14-80722D1C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80722D1C-80722D24 000028 0008+00 0/1 0/0 0/0 .data            e_env$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80722D24-80722D2C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3677 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80722D2C-80722D34 000038 0008+00 1/1 0/0 0/0 .data            mDropEff$4000 */
@@ -802,13 +695,6 @@ static void func_80722804() {
 
 /* 8072280C-80722814 002F2C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8072280C() {
-    // NONMATCHING
-}
-
-/* 80722814-80722C28 002F34 0414+00 2/2 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_mm_mt.cpp
+++ b/src/d/actor/d_a_e_mm_mt.cpp
@@ -6,6 +6,8 @@
 #include "d/actor/d_a_e_mm_mt.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -33,7 +35,6 @@ extern "C" void __dt__12dBgS_AcchCirFv();
 extern "C" void __dt__10cCcD_GSttsFv();
 extern "C" static void func_8072542C();
 extern "C" static void func_80725434();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_mm_mt__stringBase0;
 
 //
@@ -133,12 +134,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 
 //
@@ -146,64 +144,6 @@ extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 //
 
 /* ############################################################################################## */
-/* 80725858-8072585C 000000 0004+00 9/9 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static f32 const lit_3789 = 100.0f;
-COMPILER_STRIP_GATE(0x80725858, &lit_3789);
-
-/* 8072585C-80725860 000004 0004+00 1/9 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static u8 const lit_3790[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8072585C, &lit_3790);
-
-/* 80725860-80725868 000008 0004+04 0/6 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3791[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80725860, &lit_3791);
-#pragma pop
-
-/* 80725868-80725870 000010 0008+00 0/1 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80725868, &lit_3792);
-#pragma pop
-
-/* 80725870-80725878 000018 0008+00 0/1 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80725870, &lit_3793);
-#pragma pop
-
-/* 80725878-80725880 000020 0008+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80725878, &lit_3794);
-#pragma pop
-
-/* 80725880-80725884 000028 0004+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3795 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80725880, &lit_3795);
-#pragma pop
-
 /* 80725884-80725888 00002C 0004+00 0/1 0/0 0/0 .rodata          @3829 */
 #pragma push
 #pragma force_active on
@@ -573,56 +513,6 @@ SECTION_RODATA static f32 const lit_4897 = 65535.0f;
 COMPILER_STRIP_GATE(0x80725928, &lit_4897);
 #pragma pop
 
-/* 80725934-80725940 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80725940-80725954 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80725954-8072595C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8072595C-80725964 000028 0008+00 0/1 0/0 0/0 .data            e_env$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80725964-8072596C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3677 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
-
 /* 8072596C-807259AC 000038 0040+00 1/1 0/0 0/0 .data            cc_sph_src$4792 */
 static dCcD_SrcSph cc_sph_src = {
     {
@@ -772,13 +662,6 @@ static void func_8072542C() {
 
 /* 80725434-8072543C 002534 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80725434() {
-    // NONMATCHING
-}
-
-/* 8072543C-80725850 00253C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ms.cpp
+++ b/src/d/actor/d_a_e_ms.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_ms.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -49,7 +50,6 @@ extern "C" void __dt__12daE_MS_HIO_cFv();
 extern "C" void __sinit_d_a_e_ms_cpp();
 extern "C" static void func_80729090();
 extern "C" static void func_80729098();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_ms__stringBase0;
 
@@ -167,11 +167,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -179,61 +176,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80729504-80729508 000000 0004+00 14/14 0/0 0/0 .rodata          @3800 */
-SECTION_RODATA static f32 const lit_3800 = 100.0f;
-COMPILER_STRIP_GATE(0x80729504, &lit_3800);
-
-/* 80729508-8072950C 000004 0004+00 2/13 0/0 0/0 .rodata          @3801 */
-SECTION_RODATA static u8 const lit_3801[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80729508, &lit_3801);
-
-/* 8072950C-80729514 000008 0004+04 3/13 0/0 0/0 .rodata          @3802 */
-SECTION_RODATA static f32 const lit_3802[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8072950C, &lit_3802);
-
-/* 80729514-8072951C 000010 0008+00 0/3 0/0 0/0 .rodata          @3803 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3803[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80729514, &lit_3803);
-#pragma pop
-
-/* 8072951C-80729524 000018 0008+00 0/3 0/0 0/0 .rodata          @3804 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3804[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8072951C, &lit_3804);
-#pragma pop
-
-/* 80729524-8072952C 000020 0008+00 0/3 0/0 0/0 .rodata          @3805 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3805[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80729524, &lit_3805);
-#pragma pop
-
-/* 8072952C-80729530 000028 0004+00 0/1 0/0 0/0 .rodata          @3806 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3806 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8072952C, &lit_3806);
-#pragma pop
-
 /* 80729530-80729534 00002C 0004+00 0/2 0/0 0/0 .rodata          @3821 */
 #pragma push
 #pragma force_active on
@@ -260,56 +202,6 @@ COMPILER_STRIP_GATE(0x80729538, &lit_3823);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3824 = 450.0f;
 COMPILER_STRIP_GATE(0x8072953C, &lit_3824);
-#pragma pop
-
-/* 80729610-8072961C 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8072961C-80729630 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80729630-80729638 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3679 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80729638-80729640 000028 0008+00 0/1 0/0 0/0 .data            e_env$3680 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80729640-80729648 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3688 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id_3688[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80729648-80729674 -00001 002C+00 1/1 0/0 0/0 .data            @4628 */
@@ -1098,13 +990,6 @@ static void func_80729090() {
 
 /* 80729098-807290A0 0035F8 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80729098() {
-    // NONMATCHING
-}
-
-/* 807290A0-807294B4 003600 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_nz.cpp
+++ b/src/d/actor/d_a_e_nz.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_nz.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -39,7 +40,6 @@ extern "C" void __dt__12daE_NZ_HIO_cFv();
 extern "C" void __sinit_d_a_e_nz_cpp();
 extern "C" static void func_8072BD0C();
 extern "C" static void func_8072BD14();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_nz__stringBase0;
 
@@ -150,8 +150,6 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -160,61 +158,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8072C180-8072C184 000000 0004+00 8/8 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static f32 const lit_3789 = 100.0f;
-COMPILER_STRIP_GATE(0x8072C180, &lit_3789);
-
-/* 8072C184-8072C188 000004 0004+00 2/9 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static u8 const lit_3790[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8072C184, &lit_3790);
-
-/* 8072C188-8072C190 000008 0004+04 2/9 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static f32 const lit_3791[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8072C188, &lit_3791);
-
-/* 8072C190-8072C198 000010 0008+00 0/2 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8072C190, &lit_3792);
-#pragma pop
-
-/* 8072C198-8072C1A0 000018 0008+00 0/2 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8072C198, &lit_3793);
-#pragma pop
-
-/* 8072C1A0-8072C1A8 000020 0008+00 0/2 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8072C1A0, &lit_3794);
-#pragma pop
-
-/* 8072C1A8-8072C1AC 000028 0004+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3795 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8072C1A8, &lit_3795);
-#pragma pop
-
 /* 8072C1AC-8072C1B0 00002C 0004+00 0/1 0/0 0/0 .rodata          @3810 */
 #pragma push
 #pragma force_active on
@@ -246,56 +189,6 @@ COMPILER_STRIP_GATE(0x8072C1B8, &lit_3813);
 /* 8072C1BC-8072C1C0 00003C 0004+00 1/4 0/0 0/0 .rodata          @3814 */
 SECTION_RODATA static f32 const lit_3814 = 30.0f;
 COMPILER_STRIP_GATE(0x8072C1BC, &lit_3814);
-
-/* 8072C24C-8072C258 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8072C258-8072C26C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8072C26C-8072C274 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8072C274-8072C27C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8072C27C-8072C284 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3677 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id_3677[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 8072C284-8072C28C 000038 0008+00 5/5 0/0 0/0 .data            stick_bit */
 SECTION_DATA static u8 stick_bit[8] = {
@@ -893,13 +786,6 @@ static void func_8072BD0C() {
 
 /* 8072BD14-8072BD1C 002414 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8072BD14() {
-    // NONMATCHING
-}
-
-/* 8072BD1C-8072C130 00241C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ot.cpp
+++ b/src/d/actor/d_a_e_ot.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_ot.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -51,7 +52,6 @@ extern "C" void __dt__12daE_OT_HIO_cFv();
 extern "C" void __sinit_d_a_e_ot_cpp();
 extern "C" static void func_8073CA34();
 extern "C" static void func_8073CA3C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_ot__stringBase0;
 
@@ -162,10 +162,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -174,61 +172,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8073CEA8-8073CEAC 000000 0004+00 14/14 0/0 0/0 .rodata          @3910 */
-SECTION_RODATA static f32 const lit_3910 = 100.0f;
-COMPILER_STRIP_GATE(0x8073CEA8, &lit_3910);
-
-/* 8073CEAC-8073CEB0 000004 0004+00 1/11 0/0 0/0 .rodata          @3911 */
-SECTION_RODATA static u8 const lit_3911[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8073CEAC, &lit_3911);
-
-/* 8073CEB0-8073CEB8 000008 0004+04 4/13 0/0 0/0 .rodata          @3912 */
-SECTION_RODATA static f32 const lit_3912[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8073CEB0, &lit_3912);
-
-/* 8073CEB8-8073CEC0 000010 0008+00 0/2 0/0 0/0 .rodata          @3913 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3913[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8073CEB8, &lit_3913);
-#pragma pop
-
-/* 8073CEC0-8073CEC8 000018 0008+00 0/2 0/0 0/0 .rodata          @3914 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3914[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8073CEC0, &lit_3914);
-#pragma pop
-
-/* 8073CEC8-8073CED0 000020 0008+00 0/2 0/0 0/0 .rodata          @3915 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3915[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8073CEC8, &lit_3915);
-#pragma pop
-
-/* 8073CED0-8073CED4 000028 0004+00 0/2 0/0 0/0 .rodata          @3916 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3916 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8073CED0, &lit_3916);
-#pragma pop
-
 /* 8073CED4-8073CED8 00002C 0004+00 0/2 0/0 0/0 .rodata          @3932 */
 #pragma push
 #pragma force_active on
@@ -246,56 +189,6 @@ COMPILER_STRIP_GATE(0x8073CED8, &lit_3933);
 /* 8073CEDC-8073CEE0 000034 0004+00 1/6 0/0 0/0 .rodata          @3934 */
 SECTION_RODATA static f32 const lit_3934 = 20.0f;
 COMPILER_STRIP_GATE(0x8073CEDC, &lit_3934);
-
-/* 8073CF74-8073CF80 000000 000C+00 3/3 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8073CF80-8073CF94 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8073CF94-8073CF9C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3789 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8073CF9C-8073CFA4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3790 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8073CFA4-8073CFAC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3798 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 8073CFAC-8073CFBC 000038 0010+00 0/1 0/0 0/0 .data rand_speed__22@unnamed@d_a_e_ot_cpp@ */
 #pragma push
@@ -1065,13 +958,6 @@ static void func_8073CA34() {
 
 /* 8073CA3C-8073CA44 00285C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8073CA3C() {
-    // NONMATCHING
-}
-
-/* 8073CA44-8073CE58 002864 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_po.cpp
+++ b/src/d/actor/d_a_e_po.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -65,7 +66,6 @@ extern "C" void __dt__12daE_PO_HIO_cFv();
 extern "C" void __sinit_d_a_e_po_cpp();
 extern "C" static void func_80756E6C();
 extern "C" static void func_80756E74();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" void cancelOriginalDemo__9daPy_py_cFv();
@@ -264,12 +264,10 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" u8 mParticleTracePCB__13dPa_control_c[4 + 4 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -278,61 +276,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807576FC-80757700 000000 0004+00 20/20 0/0 0/0 .rodata          @3917 */
-SECTION_RODATA static f32 const lit_3917 = 100.0f;
-COMPILER_STRIP_GATE(0x807576FC, &lit_3917);
-
-/* 80757700-80757704 000004 0004+00 2/19 0/0 0/0 .rodata          @3918 */
-SECTION_RODATA static u8 const lit_3918[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80757700, &lit_3918);
-
-/* 80757704-8075770C 000008 0004+04 2/19 0/0 0/0 .rodata          @3919 */
-SECTION_RODATA static f32 const lit_3919[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80757704, &lit_3919);
-
-/* 8075770C-80757714 000010 0008+00 0/5 0/0 0/0 .rodata          @3920 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3920[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8075770C, &lit_3920);
-#pragma pop
-
-/* 80757714-8075771C 000018 0008+00 0/5 0/0 0/0 .rodata          @3921 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3921[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80757714, &lit_3921);
-#pragma pop
-
-/* 8075771C-80757724 000020 0008+00 0/5 0/0 0/0 .rodata          @3922 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3922[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8075771C, &lit_3922);
-#pragma pop
-
-/* 80757724-80757728 000028 0004+00 0/1 0/0 0/0 .rodata          @3923 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3923 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80757724, &lit_3923);
-#pragma pop
-
 /* 80757728-8075772C 00002C 0004+00 0/1 0/0 0/0 .rodata          @3938 */
 #pragma push
 #pragma force_active on
@@ -366,48 +309,6 @@ COMPILER_STRIP_GATE(0x80757734, &lit_3941);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3942 = 700.0f;
 COMPILER_STRIP_GATE(0x80757738, &lit_3942);
-#pragma pop
-
-/* 80757AA4-80757AB0 000000 000C+00 4/4 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80757AB0-80757AC4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80757AC4-80757ACC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3796 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80757ACC-80757AD4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3797 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80757AD4-80757ADA 000030 0006+00 0/1 0/0 0/0 .data            eff_id$3805 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6] = {
-    0x02, 0x9D, 0x02, 0x9E, 0x02, 0x9F,
-};
 #pragma pop
 
 /* 80757ADA-80757ADC 000036 0002+00 6/7 0/0 0/0 .data            mAttackNo */
@@ -2700,19 +2601,6 @@ static void e_po_holl_demo(e_po_class* param_0) {
     // NONMATCHING
 }
 
-/* 807549C0-807549F4 008560 0034+00 1/1 0/0 0/0 .text            dComIfGp_particle_getEmitter__FUl
- */
-static void dComIfGp_particle_getEmitter(u32 param_0) {
-    // NONMATCHING
-}
-
-/* 807549F4-80754A74 008594 0080+00 1/1 0/0 0/0 .text
- * dComIfGp_particle_set__FUlUsPC4cXyzPC5csXyzPC4cXyz           */
-static void dComIfGp_particle_set(u32 param_0, u16 param_1, cXyz const* param_2,
-                                      csXyz const* param_3, cXyz const* param_4) {
-    // NONMATCHING
-}
-
 /* 80754A74-80754AA8 008614 0034+00 1/1 0/0 0/0 .text            fopAcM_isSwitch__FPC10fopAc_ac_ci
  */
 // static void fopAcM_isSwitch(fopAc_ac_c const* param_0, int param_1) {
@@ -3022,13 +2910,6 @@ static void func_80756E74() {
     // NONMATCHING
 }
 
-/* 80756E7C-80757290 00AA1C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
-    // NONMATCHING
-}
-
 /* 80757290-807572CC 00AE30 003C+00 1/1 0/0 0/0 .text            __dt__5csXyzFv */
 // csXyz::~csXyz() {
 extern "C" void __dt__5csXyzFv() {
@@ -3047,11 +2928,6 @@ extern "C" void cancelOriginalDemo__9daPy_py_cFv() {
     // NONMATCHING
 }
 
-/* 8075731C-80757348 00AEBC 002C+00 1/1 0/0 0/0 .text            dComIfGp_event_reset__Fv */
-static void dComIfGp_event_reset() {
-    // NONMATCHING
-}
-
 /* 80757348-8075737C 00AEE8 0034+00 1/1 0/0 0/0 .text            __apl__4cXyzFRC3Vec */
 // void cXyz::operator+=(Vec const& param_0) {
 extern "C" void __apl__4cXyzFRC3Vec() {
@@ -3062,11 +2938,6 @@ extern "C" void __apl__4cXyzFRC3Vec() {
  */
 // static void fopAcM_onSwitch(fopAc_ac_c const* param_0, int param_1) {
 extern "C" void fopAcM_onSwitch__FPC10fopAc_ac_ci() {
-    // NONMATCHING
-}
-
-/* 807573B0-807573C0 00AF50 0010+00 1/1 0/0 0/0 .text            dComIfGp_getVibration__Fv */
-static void dComIfGp_getVibration() {
     // NONMATCHING
 }
 
@@ -3146,11 +3017,6 @@ extern "C" void changeOriginalDemo__9daPy_py_cFv() {
     // NONMATCHING
 }
 
-/* 807575E4-807575F4 00B184 0010+00 1/1 0/0 0/0 .text            daPy_getPlayerActorClass__Fv */
-static void daPy_getPlayerActorClass() {
-    // NONMATCHING
-}
-
 /* 807575F4-80757604 00B194 0010+00 1/1 0/0 0/0 .text            Fovy__9dCamera_cFv */
 // void dCamera_c::Fovy() {
 extern "C" void Fovy__9dCamera_cFv() {
@@ -3190,16 +3056,6 @@ extern "C" void __ct__4cXyzFRC4cXyz() {
 /* 8075768C-8075769C 00B22C 0010+00 1/1 0/0 0/0 .text            __ct__4cXyzFfff */
 // cXyz::cXyz(f32 param_0, f32 param_1, f32 param_2) {
 extern "C" void __ct__4cXyzFfff() {
-    // NONMATCHING
-}
-
-/* 8075769C-807576B4 00B23C 0018+00 1/1 0/0 0/0 .text            dComIfGp_getCamera__Fi */
-static void dComIfGp_getCamera(int param_0) {
-    // NONMATCHING
-}
-
-/* 807576B4-807576D0 00B254 001C+00 1/1 0/0 0/0 .text            dComIfGp_getPlayerCameraID__Fi */
-static void dComIfGp_getPlayerCameraID(int param_0) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_pz.cpp
+++ b/src/d/actor/d_a_e_pz.cpp
@@ -6,6 +6,8 @@
 #include "d/actor/d_a_e_pz.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -62,7 +64,6 @@ extern "C" void __dt__12daE_PZ_HIO_cFv();
 extern "C" void __sinit_d_a_e_pz_cpp();
 extern "C" static void func_80760CE4();
 extern "C" static void func_80760CEC();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" void changeDemoMoveAngle__9daPy_py_cFs(fopAc_ac_c* param_0, u16 param_1);
 extern "C" void zero__4cXyzFv();
@@ -225,7 +226,6 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" extern u8 struct_80450C98[4];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
@@ -237,61 +237,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807614FC-80761500 000000 0004+00 16/16 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static f32 const lit_3906 = 100.0f;
-COMPILER_STRIP_GATE(0x807614FC, &lit_3906);
-
-/* 80761500-80761504 000004 0004+00 5/17 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static u8 const lit_3907[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80761500, &lit_3907);
-
-/* 80761504-8076150C 000008 0004+04 4/16 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static f32 const lit_3908[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80761504, &lit_3908);
-
-/* 8076150C-80761514 000010 0008+00 0/2 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8076150C, &lit_3909);
-#pragma pop
-
-/* 80761514-8076151C 000018 0008+00 0/2 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80761514, &lit_3910);
-#pragma pop
-
-/* 8076151C-80761524 000020 0008+00 0/2 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8076151C, &lit_3911);
-#pragma pop
-
-/* 80761524-80761528 000028 0004+00 0/1 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3912 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80761524, &lit_3912);
-#pragma pop
-
 /* 80761528-8076152C 00002C 0004+00 0/6 0/0 0/0 .rodata          @3927 */
 #pragma push
 #pragma force_active on
@@ -309,56 +254,6 @@ COMPILER_STRIP_GATE(0x8076152C, &lit_3928);
 /* 80761530-80761534 000034 0004+00 1/8 0/0 0/0 .rodata          @3929 */
 SECTION_RODATA static f32 const lit_3929 = 3.0f;
 COMPILER_STRIP_GATE(0x80761530, &lit_3929);
-
-/* 807617BC-807617C8 000000 000C+00 3/3 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807617C8-807617DC 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807617DC-807617E4 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3785 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807617E4-807617EC 000028 0008+00 0/1 0/0 0/0 .data            e_env$3786 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807617EC-807617F4 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3794 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 807617F4-80761838 000038 0044+00 0/1 0/0 0/0 .data            cc_pz_src__22@unnamed@d_a_e_pz_cpp@
  */
@@ -2378,13 +2273,6 @@ static void func_80760CEC() {
     // NONMATCHING
 }
 
-/* 80760CF4-80761108 008874 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
-    // NONMATCHING
-}
-
 /* 80761108-80761144 008C88 003C+00 3/3 0/0 0/0 .text            __dt__4cXyzFv */
 // cXyz::~cXyz() {
 extern "C" void __dt__4cXyzFv() {
@@ -2401,13 +2289,6 @@ extern "C" void changeDemoMoveAngle__9daPy_py_cFs(fopAc_ac_c* param_0, u16 param
 /* 8076114C-80761164 008CCC 0018+00 1/1 0/0 0/0 .text            zero__4cXyzFv */
 // void cXyz::zero() {
 extern "C" void zero__4cXyzFv() {
-    // NONMATCHING
-}
-
-/* 80761164-807611D8 008CE4 0074+00 1/1 0/0 0/0 .text
- * dComIfGp_particle_set__FUsPC4cXyzPC5csXyzPC4cXyz             */
-static void dComIfGp_particle_set(u16 param_0, cXyz const* param_1, csXyz const* param_2,
-                                      cXyz const* param_3) {
     // NONMATCHING
 }
 
@@ -2480,11 +2361,6 @@ extern "C" void changeOriginalDemo__9daPy_py_cFv() {
     // NONMATCHING
 }
 
-/* 80761444-80761454 008FC4 0010+00 1/1 0/0 0/0 .text            daPy_getPlayerActorClass__Fv */
-static void daPy_getPlayerActorClass() {
-    // NONMATCHING
-}
-
 /* 80761454-80761470 008FD4 001C+00 1/1 0/0 0/0 .text            __as__4cXyzFRC4cXyz */
 // void cXyz::operator=(cXyz const& param_0) {
 extern "C" void __as__4cXyzFRC4cXyz() {
@@ -2494,16 +2370,6 @@ extern "C" void __as__4cXyzFRC4cXyz() {
 /* 80761470-80761488 008FF0 0018+00 1/1 0/0 0/0 .text            dComIfGp_getPlayer__Fi */
 // static void dComIfGp_getPlayer(int param_0) {
 extern "C" void dComIfGp_getPlayer__Fi() {
-    // NONMATCHING
-}
-
-/* 80761488-807614A0 009008 0018+00 1/1 0/0 0/0 .text            dComIfGp_getCamera__Fi */
-static void dComIfGp_getCamera(int param_0) {
-    // NONMATCHING
-}
-
-/* 807614A0-807614BC 009020 001C+00 1/1 0/0 0/0 .text            dComIfGp_getPlayerCameraID__Fi */
-static void dComIfGp_getPlayerCameraID(int param_0) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_rb.cpp
+++ b/src/d/actor/d_a_e_rb.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_rb.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -48,7 +49,6 @@ extern "C" static void func_807648C4();
 extern "C" static void func_807648CC();
 extern "C" static void func_807648D4();
 extern "C" static void func_807648DC();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_rb__stringBase0;
 
 //
@@ -152,10 +152,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -164,61 +162,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80764D0C-80764D10 000000 0004+00 13/13 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x80764D0C, &lit_3788);
-
-/* 80764D10-80764D14 000004 0004+00 1/9 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80764D10, &lit_3789);
-
-/* 80764D14-80764D1C 000008 0004+04 1/10 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80764D14, &lit_3790);
-
-/* 80764D1C-80764D24 000010 0008+00 0/1 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80764D1C, &lit_3791);
-#pragma pop
-
-/* 80764D24-80764D2C 000018 0008+00 0/1 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80764D24, &lit_3792);
-#pragma pop
-
-/* 80764D2C-80764D34 000020 0008+00 0/1 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80764D2C, &lit_3793);
-#pragma pop
-
-/* 80764D34-80764D38 000028 0004+00 0/2 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80764D34, &lit_3794);
-#pragma pop
-
 /* 80764D38-80764D3C 00002C 0004+00 1/2 0/0 0/0 .rodata          @3809 */
 SECTION_RODATA static f32 const lit_3809 = 1.5f;
 COMPILER_STRIP_GATE(0x80764D38, &lit_3809);
@@ -226,56 +169,6 @@ COMPILER_STRIP_GATE(0x80764D38, &lit_3809);
 /* 80764D3C-80764D40 000030 0004+00 1/1 0/0 0/0 .rodata          @3810 */
 SECTION_RODATA static f32 const lit_3810 = -5.0f;
 COMPILER_STRIP_GATE(0x80764D3C, &lit_3810);
-
-/* 80764DDC-80764DE8 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80764DE8-80764DFC 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80764DFC-80764E04 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80764E04-80764E0C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80764E0C-80764E14 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 80764E14-80764E40 -00001 002C+00 1/1 0/0 0/0 .data            @4166 */
 SECTION_DATA static void* lit_4166[11] = {
@@ -860,13 +753,6 @@ static void func_807648D4() {
 
 /* 807648DC-807648E4 00263C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807648DC() {
-    // NONMATCHING
-}
-
-/* 807648E4-80764CF8 002644 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_rd.cpp
+++ b/src/d/actor/d_a_e_rd.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -135,7 +136,6 @@ extern "C" static void func_805180C4();
 extern "C" static void func_805180CC();
 extern "C" static void func_805180D4();
 extern "C" static void func_805180DC();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_rd__stringBase0;
@@ -330,16 +330,13 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern u32 g_blackColor;
 extern "C" extern u8 mBlureFlag__13mDoGph_gInf_c[4];
 extern "C" extern u8 struct_80450C98[4];
 extern "C" u8 mParticleTracePCB__13dPa_control_c[4 + 4 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 extern "C" void BreakSet__13daObjH_Saku_cFv();
@@ -349,61 +346,6 @@ extern "C" void BreakSet__13daObjH_Saku_cFv();
 //
 
 /* ############################################################################################## */
-/* 80518584-80518588 000000 0004+00 61/61 0/0 0/0 .rodata          @4208 */
-SECTION_RODATA static f32 const lit_4208 = 100.0f;
-COMPILER_STRIP_GATE(0x80518584, &lit_4208);
-
-/* 80518588-8051858C 000004 0004+00 7/53 0/0 0/0 .rodata          @4209 */
-SECTION_RODATA static u8 const lit_4209[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80518588, &lit_4209);
-
-/* 8051858C-80518594 000008 0004+04 3/41 0/0 0/0 .rodata          @4210 */
-SECTION_RODATA static f32 const lit_4210[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8051858C, &lit_4210);
-
-/* 80518594-8051859C 000010 0008+00 0/9 0/0 0/0 .rodata          @4211 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4211[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80518594, &lit_4211);
-#pragma pop
-
-/* 8051859C-805185A4 000018 0008+00 0/9 0/0 0/0 .rodata          @4212 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4212[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8051859C, &lit_4212);
-#pragma pop
-
-/* 805185A4-805185AC 000020 0008+00 0/9 0/0 0/0 .rodata          @4213 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4213[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x805185A4, &lit_4213);
-#pragma pop
-
-/* 805185AC-805185B0 000028 0004+00 0/1 0/0 0/0 .rodata          @4214 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4214 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x805185AC, &lit_4214);
-#pragma pop
-
 /* 805185B0-805185B4 00002C 0004+00 0/1 0/0 0/0 .rodata          @4229 */
 #pragma push
 #pragma force_active on
@@ -490,56 +432,6 @@ COMPILER_STRIP_GATE(0x805185DC, &lit_4240);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_4241 = 33.0f;
 COMPILER_STRIP_GATE(0x805185E0, &lit_4241);
-#pragma pop
-
-/* 805189A8-805189B4 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 805189B4-805189C8 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 805189C8-805189D0 000020 0008+00 0/1 0/0 0/0 .data            e_prim$4087 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 805189D0-805189D8 000028 0008+00 0/1 0/0 0/0 .data            e_env$4088 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 805189D8-805189E0 000030 0006+02 0/1 0/0 0/0 .data            eff_id$4096 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 805189E0-80518A48 -00001 0068+00 1/1 0/0 0/0 .data            @5576 */
@@ -3591,13 +3483,6 @@ static void func_805180D4() {
 
 /* 805180DC-805180E4 01375C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_805180DC() {
-    // NONMATCHING
-}
-
-/* 805180E4-805184F8 013764 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_rdb.cpp
+++ b/src/d/actor/d_a_e_rdb.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -55,7 +56,6 @@ extern "C" void __dt__13daE_RDB_HIO_cFv();
 extern "C" void __sinit_d_a_e_rdb_cpp();
 extern "C" static void func_8076AFE8();
 extern "C" static void func_8076AFF0();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_rdb__stringBase0;
 
@@ -218,11 +218,9 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern u32 g_blackColor;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
@@ -232,114 +230,9 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8076B45C-8076B460 000000 0004+00 17/17 0/0 0/0 .rodata          @4007 */
-SECTION_RODATA static f32 const lit_4007 = 100.0f;
-COMPILER_STRIP_GATE(0x8076B45C, &lit_4007);
-
-/* 8076B460-8076B464 000004 0004+00 2/17 0/0 0/0 .rodata          @4008 */
-SECTION_RODATA static u8 const lit_4008[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8076B460, &lit_4008);
-
-/* 8076B464-8076B46C 000008 0004+04 1/13 0/0 0/0 .rodata          @4009 */
-SECTION_RODATA static f32 const lit_4009[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8076B464, &lit_4009);
-
-/* 8076B46C-8076B474 000010 0008+00 0/2 0/0 0/0 .rodata          @4010 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4010[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8076B46C, &lit_4010);
-#pragma pop
-
-/* 8076B474-8076B47C 000018 0008+00 0/2 0/0 0/0 .rodata          @4011 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4011[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8076B474, &lit_4011);
-#pragma pop
-
-/* 8076B47C-8076B484 000020 0008+00 0/2 0/0 0/0 .rodata          @4012 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4012[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8076B47C, &lit_4012);
-#pragma pop
-
-/* 8076B484-8076B488 000028 0004+00 0/1 0/0 0/0 .rodata          @4013 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4013 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8076B484, &lit_4013);
-#pragma pop
-
 /* 8076B488-8076B48C 00002C 0004+00 1/3 0/0 0/0 .rodata          @4028 */
 SECTION_RODATA static f32 const lit_4028 = 31.0f / 20.0f;
 COMPILER_STRIP_GATE(0x8076B488, &lit_4028);
-
-/* 8076B6F8-8076B704 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8076B704-8076B718 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8076B718-8076B720 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3886 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8076B720-8076B728 000028 0008+00 0/1 0/0 0/0 .data            e_env$3887 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8076B728-8076B730 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3895 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 8076B730-8076B738 000038 0006+02 1/1 0/0 0/0 .data            ap_name$4291 */
 SECTION_DATA static u8 ap_name_4291[6 + 2 /* padding */] = {
@@ -2069,13 +1962,6 @@ static void func_8076AFE8() {
 
 /* 8076AFF0-8076AFF8 006010 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8076AFF0() {
-    // NONMATCHING
-}
-
-/* 8076AFF8-8076B40C 006018 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_rdy.cpp
+++ b/src/d/actor/d_a_e_rdy.cpp
@@ -7,6 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -93,7 +95,6 @@ extern "C" static void func_80779928();
 extern "C" static void func_80779930();
 extern "C" static void func_80779938();
 extern "C" static void func_80779940();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" void changeDemoMode__9daPy_py_cFUliis();
@@ -279,11 +280,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern u32 g_blackColor;
 extern "C" u8 mParticleTracePCB__13dPa_control_c[4 + 4 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
@@ -294,61 +293,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80779DFC-80779E00 000000 0004+00 43/43 0/0 0/0 .rodata          @4018 */
-SECTION_RODATA static f32 const lit_4018 = 100.0f;
-COMPILER_STRIP_GATE(0x80779DFC, &lit_4018);
-
-/* 80779E00-80779E04 000004 0004+00 2/34 0/0 0/0 .rodata          @4019 */
-SECTION_RODATA static u8 const lit_4019[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80779E00, &lit_4019);
-
-/* 80779E04-80779E0C 000008 0004+04 1/28 0/0 0/0 .rodata          @4020 */
-SECTION_RODATA static f32 const lit_4020[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80779E04, &lit_4020);
-
-/* 80779E0C-80779E14 000010 0008+00 0/6 0/0 0/0 .rodata          @4021 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4021[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80779E0C, &lit_4021);
-#pragma pop
-
-/* 80779E14-80779E1C 000018 0008+00 0/6 0/0 0/0 .rodata          @4022 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4022[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80779E14, &lit_4022);
-#pragma pop
-
-/* 80779E1C-80779E24 000020 0008+00 0/6 0/0 0/0 .rodata          @4023 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4023[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80779E1C, &lit_4023);
-#pragma pop
-
-/* 80779E24-80779E28 000028 0004+00 0/1 0/0 0/0 .rodata          @4024 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4024 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80779E24, &lit_4024);
-#pragma pop
-
 /* 80779E28-80779E2C 00002C 0004+00 0/1 0/0 0/0 .rodata          @4039 */
 #pragma push
 #pragma force_active on
@@ -435,56 +379,6 @@ COMPILER_STRIP_GATE(0x80779E54, &lit_4050);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_4051 = 33.0f;
 COMPILER_STRIP_GATE(0x80779E58, &lit_4051);
-#pragma pop
-
-/* 8077A0DC-8077A0E8 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8077A0E8-8077A0FC 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8077A0FC-8077A104 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3897 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8077A104-8077A10C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3898 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8077A10C-8077A114 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3906 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 8077A114-8077A17C -00001 0068+00 1/1 0/0 0/0 .data            @5017 */
@@ -2657,13 +2551,6 @@ static void func_80779938() {
 
 /* 80779940-80779948 00DC60 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80779940() {
-    // NONMATCHING
-}
-
-/* 80779948-80779D5C 00DC68 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_sf.cpp
+++ b/src/d/actor/d_a_e_sf.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -56,7 +57,6 @@ extern "C" void __dt__12daE_SF_HIO_cFv();
 extern "C" void __sinit_d_a_e_sf_cpp();
 extern "C" static void func_80789800();
 extern "C" static void func_80789808();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_sf__stringBase0;
 
 //
@@ -194,12 +194,10 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -207,61 +205,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80789C38-80789C3C 000000 0004+00 19/19 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static f32 const lit_3908 = 100.0f;
-COMPILER_STRIP_GATE(0x80789C38, &lit_3908);
-
-/* 80789C3C-80789C40 000004 0004+00 4/18 0/0 0/0 .rodata          @3909 */
-SECTION_RODATA static u8 const lit_3909[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80789C3C, &lit_3909);
-
-/* 80789C40-80789C48 000008 0004+04 3/16 0/0 0/0 .rodata          @3910 */
-SECTION_RODATA static f32 const lit_3910[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80789C40, &lit_3910);
-
-/* 80789C48-80789C50 000010 0008+00 0/1 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80789C48, &lit_3911);
-#pragma pop
-
-/* 80789C50-80789C58 000018 0008+00 0/1 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3912[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80789C50, &lit_3912);
-#pragma pop
-
-/* 80789C58-80789C60 000020 0008+00 0/1 0/0 0/0 .rodata          @3913 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3913[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80789C58, &lit_3913);
-#pragma pop
-
-/* 80789C60-80789C64 000028 0004+00 0/1 0/0 0/0 .rodata          @3914 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3914 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80789C60, &lit_3914);
-#pragma pop
-
 /* 80789C64-80789C68 00002C 0004+00 0/1 0/0 0/0 .rodata          @3929 */
 #pragma push
 #pragma force_active on
@@ -302,56 +245,6 @@ COMPILER_STRIP_GATE(0x80789C74, &lit_3933);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3934 = 300.0f;
 COMPILER_STRIP_GATE(0x80789C78, &lit_3934);
-#pragma pop
-
-/* 80789D90-80789D9C 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80789D9C-80789DB0 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80789DB0-80789DB8 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80789DB8-80789DC0 000028 0008+00 0/1 0/0 0/0 .data            e_env$3788 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80789DC0-80789DC8 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3796 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80789DC8-80789E00 -00001 0038+00 1/1 0/0 0/0 .data            @4353 */
@@ -1378,13 +1271,6 @@ static void func_80789800() {
 
 /* 80789808-80789810 0047C8 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80789808() {
-    // NONMATCHING
-}
-
-/* 80789810-80789C24 0047D0 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_sh.cpp
+++ b/src/d/actor/d_a_e_sh.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_sh.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -45,7 +46,6 @@ extern "C" void __dt__12daE_SH_HIO_cFv();
 extern "C" void __sinit_d_a_e_sh_cpp();
 extern "C" static void func_80791938();
 extern "C" static void func_80791940();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_sh__stringBase0;
 
 //
@@ -157,10 +157,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
 
@@ -169,61 +167,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80791D70-80791D74 000000 0004+00 13/13 0/0 0/0 .rodata          @3902 */
-SECTION_RODATA static f32 const lit_3902 = 100.0f;
-COMPILER_STRIP_GATE(0x80791D70, &lit_3902);
-
-/* 80791D74-80791D78 000004 0004+00 2/11 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static u8 const lit_3903[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80791D74, &lit_3903);
-
-/* 80791D78-80791D80 000008 0004+04 2/13 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static f32 const lit_3904[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80791D78, &lit_3904);
-
-/* 80791D80-80791D88 000010 0008+00 0/3 0/0 0/0 .rodata          @3905 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3905[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80791D80, &lit_3905);
-#pragma pop
-
-/* 80791D88-80791D90 000018 0008+00 0/3 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80791D88, &lit_3906);
-#pragma pop
-
-/* 80791D90-80791D98 000020 0008+00 0/3 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80791D90, &lit_3907);
-#pragma pop
-
-/* 80791D98-80791D9C 000028 0004+00 0/1 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3908 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80791D98, &lit_3908);
-#pragma pop
-
 /* 80791D9C-80791DA0 00002C 0004+00 0/1 0/0 0/0 .rodata          @3923 */
 #pragma push
 #pragma force_active on
@@ -278,56 +221,6 @@ COMPILER_STRIP_GATE(0x80791DB4, &lit_3929);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3930 = 500.0f;
 COMPILER_STRIP_GATE(0x80791DB8, &lit_3930);
-#pragma pop
-
-/* 80791EC8-80791ED4 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80791ED4-80791EE8 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80791EE8-80791EF0 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3781 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80791EF0-80791EF8 000028 0008+00 0/1 0/0 0/0 .data            e_env$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80791EF8-80791F00 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3790 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80791F00-80791F08 000038 0006+02 1/1 0/0 0/0 .data            ap_name$4188 */
@@ -1135,13 +1028,6 @@ static void func_80791938() {
 
 /* 80791940-80791948 0036E0 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80791940() {
-    // NONMATCHING
-}
-
-/* 80791948-80791D5C 0036E8 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_sm.cpp
+++ b/src/d/actor/d_a_e_sm.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -77,7 +78,6 @@ extern "C" void __dt__12daE_Sm_HIO_cFv();
 extern "C" void __sinit_d_a_e_sm_cpp();
 extern "C" static void func_8079816C();
 extern "C" static void func_80798174();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" extern char const* const d_a_e_sm__stringBase0;
 
@@ -210,7 +210,6 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
@@ -221,114 +220,9 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807985E0-807985E4 000000 0004+00 25/25 0/0 0/0 .rodata          @3920 */
-SECTION_RODATA static f32 const lit_3920 = 100.0f;
-COMPILER_STRIP_GATE(0x807985E0, &lit_3920);
-
-/* 807985E4-807985E8 000004 0004+00 3/25 0/0 0/0 .rodata          @3921 */
-SECTION_RODATA static u8 const lit_3921[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807985E4, &lit_3921);
-
-/* 807985E8-807985F0 000008 0004+04 3/23 0/0 0/0 .rodata          @3922 */
-SECTION_RODATA static f32 const lit_3922[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807985E8, &lit_3922);
-
-/* 807985F0-807985F8 000010 0008+00 0/2 0/0 0/0 .rodata          @3923 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3923[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807985F0, &lit_3923);
-#pragma pop
-
-/* 807985F8-80798600 000018 0008+00 0/2 0/0 0/0 .rodata          @3924 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3924[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807985F8, &lit_3924);
-#pragma pop
-
-/* 80798600-80798608 000020 0008+00 0/2 0/0 0/0 .rodata          @3925 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3925[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80798600, &lit_3925);
-#pragma pop
-
-/* 80798608-8079860C 000028 0004+00 0/7 0/0 0/0 .rodata          @3926 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3926 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80798608, &lit_3926);
-#pragma pop
-
 /* 8079860C-80798610 00002C 0004+00 1/7 0/0 0/0 .rodata          @3941 */
 SECTION_RODATA static f32 const lit_3941 = 1000.0f;
 COMPILER_STRIP_GATE(0x8079860C, &lit_3941);
-
-/* 8079878C-80798798 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80798798-807987AC 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807987AC-807987B4 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3799 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807987B4-807987BC 000028 0008+00 0/1 0/0 0/0 .data            e_env$3800 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807987BC-807987C4 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3808 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 807987C4-80798818 -00001 0054+00 1/1 0/0 0/0 .data            @5019 */
 SECTION_DATA static void* lit_5019[21] = {
@@ -1548,13 +1442,6 @@ static void func_8079816C() {
 
 /* 80798174-8079817C 006034 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80798174() {
-    // NONMATCHING
-}
-
-/* 8079817C-80798590 00603C 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_sm2.cpp
+++ b/src/d/actor/d_a_e_sm2.cpp
@@ -6,6 +6,8 @@
 #include "d/actor/d_a_e_sm2.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 //
 // Forward References:
@@ -56,7 +58,6 @@ extern "C" static void func_8079D0F0();
 extern "C" static void func_8079D0F8();
 extern "C" static void func_8079D100();
 extern "C" static void func_8079D108();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_sm2__stringBase0;
@@ -190,11 +191,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" extern u8 g_Counter[12 + 4 /* padding */];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" void __register_global_object();
@@ -204,56 +203,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8079D734-8079D740 000000 000C+00 5/5 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 8079D740-8079D754 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8079D754-8079D75C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 8079D75C-8079D764 000028 0008+00 0/1 0/0 0/0 .data            e_env$3670 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8079D764-8079D76C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3678 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
-
 /* 8079D76C-8079D780 000038 0014+00 1/1 0/0 0/0 .data            sc_d$4052 */
 SECTION_DATA static u8 sc_d[20] = {
     0x3E, 0x80, 0x00, 0x00, 0x3E, 0xC0, 0x00, 0x00, 0x3F, 0x00,
@@ -727,61 +676,6 @@ static void nodeCallBack(J3DJoint* param_0, int param_1) {
 }
 
 /* ############################################################################################## */
-/* 8079D5B0-8079D5B4 000000 0004+00 17/17 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790 = 100.0f;
-COMPILER_STRIP_GATE(0x8079D5B0, &lit_3790);
-
-/* 8079D5B4-8079D5B8 000004 0004+00 1/11 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static u8 const lit_3791[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x8079D5B4, &lit_3791);
-
-/* 8079D5B8-8079D5C0 000008 0004+04 3/14 0/0 0/0 .rodata          @3792 */
-SECTION_RODATA static f32 const lit_3792[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8079D5B8, &lit_3792);
-
-/* 8079D5C0-8079D5C8 000010 0008+00 0/2 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8079D5C0, &lit_3793);
-#pragma pop
-
-/* 8079D5C8-8079D5D0 000018 0008+00 0/2 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8079D5C8, &lit_3794);
-#pragma pop
-
-/* 8079D5D0-8079D5D8 000020 0008+00 0/3 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3795[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8079D5D0, &lit_3795);
-#pragma pop
-
-/* 8079D5D8-8079D5DC 000028 0004+00 0/5 0/0 0/0 .rodata          @3796 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3796 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x8079D5D8, &lit_3796);
-#pragma pop
-
 /* 8079D5DC-8079D5E0 00002C 0004+00 0/1 0/0 0/0 .rodata          @4040 */
 #pragma push
 #pragma force_active on
@@ -1723,13 +1617,6 @@ static void func_8079D100() {
 
 /* 8079D108-8079D110 0046A8 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8079D108() {
-    // NONMATCHING
-}
-
-/* 8079D110-8079D524 0046B0 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_st.cpp
+++ b/src/d/actor/d_a_e_st.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_st.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -84,7 +85,6 @@ extern "C" static void func_807A6384();
 extern "C" static void func_807A638C();
 extern "C" static void func_807A6394();
 extern "C" static void func_807A639C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" void getHeadTopPos__9daPy_py_cCFv();
 extern "C" extern char const* const d_a_e_st__stringBase0;
@@ -227,14 +227,11 @@ extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 m_cpadInfo__8mDoCPd_c[256];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mGndCheck__11fopAcM_gc_c[84];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -242,61 +239,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807A6824-807A6828 000000 0004+00 40/40 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static f32 const lit_3903 = 100.0f;
-COMPILER_STRIP_GATE(0x807A6824, &lit_3903);
-
-/* 807A6828-807A682C 000004 0004+00 3/36 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static u8 const lit_3904[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807A6828, &lit_3904);
-
-/* 807A682C-807A6834 000008 0004+04 1/30 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static f32 const lit_3905[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807A682C, &lit_3905);
-
-/* 807A6834-807A683C 000010 0008+00 0/1 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807A6834, &lit_3906);
-#pragma pop
-
-/* 807A683C-807A6844 000018 0008+00 0/1 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807A683C, &lit_3907);
-#pragma pop
-
-/* 807A6844-807A684C 000020 0008+00 0/1 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807A6844, &lit_3908);
-#pragma pop
-
-/* 807A684C-807A6850 000028 0004+00 0/1 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3909 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807A684C, &lit_3909);
-#pragma pop
-
 /* 807A6850-807A6854 00002C 0004+00 0/2 0/0 0/0 .rodata          @3924 */
 #pragma push
 #pragma force_active on
@@ -325,56 +267,6 @@ COMPILER_STRIP_GATE(0x807A685C, &lit_3927);
 /* 807A6860-807A6864 00003C 0004+00 1/3 0/0 0/0 .rodata          @3928 */
 SECTION_RODATA static f32 const lit_3928 = -1.0f;
 COMPILER_STRIP_GATE(0x807A6860, &lit_3928);
-
-/* 807A69EC-807A69F8 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807A69F8-807A6A0C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807A6A0C-807A6A14 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807A6A14-807A6A1C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3783 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807A6A1C-807A6A24 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3791 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 807A6A24-807A6A40 -00001 001C+00 1/1 0/0 0/0 .data            @5044 */
 SECTION_DATA static void* lit_5044[7] = {
@@ -1840,13 +1732,6 @@ static void func_807A6394() {
 
 /* 807A639C-807A63A4 00869C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807A639C() {
-    // NONMATCHING
-}
-
-/* 807A63A4-807A67B8 0086A4 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_sw.cpp
+++ b/src/d/actor/d_a_e_sw.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_sw.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -88,7 +89,6 @@ extern "C" void __dt__12daE_SW_HIO_cFv();
 extern "C" void __sinit_d_a_e_sw_cpp();
 extern "C" static void func_807AF8F4();
 extern "C" static void func_807AF8FC();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_sw__stringBase0;
 
 //
@@ -210,7 +210,6 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mGndCheck__11fopAcM_gc_c[84];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
@@ -222,61 +221,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807AFD2C-807AFD30 000000 0004+00 38/38 0/0 0/0 .rodata          @3909 */
-SECTION_RODATA static f32 const lit_3909 = 100.0f;
-COMPILER_STRIP_GATE(0x807AFD2C, &lit_3909);
-
-/* 807AFD30-807AFD34 000004 0004+00 1/33 0/0 0/0 .rodata          @3910 */
-SECTION_RODATA static u8 const lit_3910[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807AFD30, &lit_3910);
-
-/* 807AFD34-807AFD3C 000008 0004+04 7/38 0/0 0/0 .rodata          @3911 */
-SECTION_RODATA static f32 const lit_3911[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807AFD34, &lit_3911);
-
-/* 807AFD3C-807AFD44 000010 0008+00 0/15 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3912[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807AFD3C, &lit_3912);
-#pragma pop
-
-/* 807AFD44-807AFD4C 000018 0008+00 0/15 0/0 0/0 .rodata          @3913 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3913[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807AFD44, &lit_3913);
-#pragma pop
-
-/* 807AFD4C-807AFD54 000020 0008+00 0/15 0/0 0/0 .rodata          @3914 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3914[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807AFD4C, &lit_3914);
-#pragma pop
-
-/* 807AFD54-807AFD58 000028 0004+00 0/1 0/0 0/0 .rodata          @3915 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3915 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807AFD54, &lit_3915);
-#pragma pop
-
 /* 807AFD58-807AFD5C 00002C 0004+00 0/4 0/0 0/0 .rodata          @3930 */
 #pragma push
 #pragma force_active on
@@ -303,56 +247,6 @@ COMPILER_STRIP_GATE(0x807AFD60, &lit_3932);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3933 = 1000.0f;
 COMPILER_STRIP_GATE(0x807AFD64, &lit_3933);
-#pragma pop
-
-/* 807AFE7C-807AFE88 000000 000C+00 5/5 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807AFE88-807AFE9C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807AFE9C-807AFEA4 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3788 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807AFEA4-807AFEAC 000028 0008+00 0/1 0/0 0/0 .data            e_env$3789 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807AFEAC-807AFEB4 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3797 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 807AFEB4-807AFEF4 000038 0040+00 1/1 0/0 0/0 .data cc_sph_src__22@unnamed@d_a_e_sw_cpp@ */
@@ -1753,13 +1647,6 @@ static void func_807AF8F4() {
 
 /* 807AF8FC-807AF904 0085DC 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807AF8FC() {
-    // NONMATCHING
-}
-
-/* 807AF904-807AFD18 0085E4 0414+00 2/2 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_th.cpp
+++ b/src/d/actor/d_a_e_th.cpp
@@ -7,7 +7,8 @@
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
 #include "d/d_camera.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -58,7 +59,6 @@ extern "C" void __dt__12daE_TH_HIO_cFv();
 extern "C" void __sinit_d_a_e_th_cpp();
 extern "C" static void func_807B4028();
 extern "C" static void func_807B4030();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_th__stringBase0;
 
@@ -191,7 +191,6 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" extern u8 struct_80450C98[4];
@@ -204,61 +203,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807B449C-807B44A0 000000 0004+00 16/16 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static f32 const lit_3906 = 100.0f;
-COMPILER_STRIP_GATE(0x807B449C, &lit_3906);
-
-/* 807B44A0-807B44A4 000004 0004+00 1/13 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static u8 const lit_3907[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807B44A0, &lit_3907);
-
-/* 807B44A4-807B44AC 000008 0004+04 1/11 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static f32 const lit_3908[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807B44A4, &lit_3908);
-
-/* 807B44AC-807B44B4 000010 0008+00 0/1 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807B44AC, &lit_3909);
-#pragma pop
-
-/* 807B44B4-807B44BC 000018 0008+00 0/1 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807B44B4, &lit_3910);
-#pragma pop
-
-/* 807B44BC-807B44C4 000020 0008+00 0/1 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807B44BC, &lit_3911);
-#pragma pop
-
-/* 807B44C4-807B44C8 000028 0004+00 0/1 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3912 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807B44C4, &lit_3912);
-#pragma pop
-
 /* 807B44C8-807B44CC 00002C 0004+00 0/1 0/0 0/0 .rodata          @3927 */
 #pragma push
 #pragma force_active on
@@ -271,56 +215,6 @@ COMPILER_STRIP_GATE(0x807B44C8, &lit_3927);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3928 = 700.0f;
 COMPILER_STRIP_GATE(0x807B44CC, &lit_3928);
-#pragma pop
-
-/* 807B464C-807B4658 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807B4658-807B466C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807B466C-807B4674 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3785 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807B4674-807B467C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3786 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807B467C-807B4684 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3794 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 807B4684-807B4688 000038 0004+00 1/1 0/0 0/0 .data            l_color$4083 */
@@ -1383,13 +1277,6 @@ static void func_807B4028() {
 
 /* 807B4030-807B4038 003D90 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807B4030() {
-    // NONMATCHING
-}
-
-/* 807B4038-807B444C 003D98 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_tt.cpp
+++ b/src/d/actor/d_a_e_tt.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_tt.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -64,7 +65,6 @@ extern "C" static void func_807C1B34();
 extern "C" static void func_807C1B3C();
 extern "C" static void func_807C1B44();
 extern "C" static void func_807C1B4C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_tt__stringBase0;
 
@@ -183,7 +183,6 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mWaterCheck__11fopAcM_wt_c[84 + 4 /* padding */];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
@@ -196,61 +195,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807C1FB8-807C1FBC 000000 0004+00 19/19 0/0 0/0 .rodata          @3908 */
-SECTION_RODATA static f32 const lit_3908 = 100.0f;
-COMPILER_STRIP_GATE(0x807C1FB8, &lit_3908);
-
-/* 807C1FBC-807C1FC0 000004 0004+00 1/17 0/0 0/0 .rodata          @3909 */
-SECTION_RODATA static u8 const lit_3909[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807C1FBC, &lit_3909);
-
-/* 807C1FC0-807C1FC8 000008 0004+04 3/13 0/0 0/0 .rodata          @3910 */
-SECTION_RODATA static f32 const lit_3910[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807C1FC0, &lit_3910);
-
-/* 807C1FC8-807C1FD0 000010 0008+00 0/5 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3911[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807C1FC8, &lit_3911);
-#pragma pop
-
-/* 807C1FD0-807C1FD8 000018 0008+00 0/5 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3912[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807C1FD0, &lit_3912);
-#pragma pop
-
-/* 807C1FD8-807C1FE0 000020 0008+00 0/5 0/0 0/0 .rodata          @3913 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3913[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807C1FD8, &lit_3913);
-#pragma pop
-
-/* 807C1FE0-807C1FE4 000028 0004+00 0/1 0/0 0/0 .rodata          @3914 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3914 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807C1FE0, &lit_3914);
-#pragma pop
-
 /* 807C1FE4-807C1FE8 00002C 0004+00 2/3 0/0 0/0 .rodata          @3929 */
 SECTION_RODATA static f32 const lit_3929 = 3.0f / 5.0f;
 COMPILER_STRIP_GATE(0x807C1FE4, &lit_3929);
@@ -274,56 +218,6 @@ COMPILER_STRIP_GATE(0x807C1FEC, &lit_3931);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3932 = 8192.0f;
 COMPILER_STRIP_GATE(0x807C1FF0, &lit_3932);
-#pragma pop
-
-/* 807C20C8-807C20D4 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807C20D4-807C20E8 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807C20E8-807C20F0 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807C20F0-807C20F8 000028 0008+00 0/1 0/0 0/0 .data            e_env$3788 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807C20F8-807C2100 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3796 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 807C2100-807C2140 000038 0040+00 1/1 0/0 0/0 .data            cc_tt_src__22@unnamed@d_a_e_tt_cpp@
@@ -1315,13 +1209,6 @@ static void func_807C1B44() {
 
 /* 807C1B4C-807C1B54 00448C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807C1B4C() {
-    // NONMATCHING
-}
-
-/* 807C1B54-807C1F68 004494 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ws.cpp
+++ b/src/d/actor/d_a_e_ws.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_ws.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -54,7 +55,6 @@ extern "C" void __dt__12daE_WS_HIO_cFv();
 extern "C" void __sinit_d_a_e_ws_cpp();
 extern "C" static void func_807E6EC8();
 extern "C" static void func_807E6ED0();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" extern char const* const d_a_e_ws__stringBase0;
 
 //
@@ -166,10 +166,8 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -177,61 +175,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807E7300-807E7304 000000 0004+00 15/15 0/0 0/0 .rodata          @3802 */
-SECTION_RODATA static f32 const lit_3802 = 100.0f;
-COMPILER_STRIP_GATE(0x807E7300, &lit_3802);
-
-/* 807E7304-807E7308 000004 0004+00 3/16 0/0 0/0 .rodata          @3803 */
-SECTION_RODATA static u8 const lit_3803[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807E7304, &lit_3803);
-
-/* 807E7308-807E7310 000008 0004+04 1/7 0/0 0/0 .rodata          @3804 */
-SECTION_RODATA static f32 const lit_3804[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807E7308, &lit_3804);
-
-/* 807E7310-807E7318 000010 0008+00 0/4 0/0 0/0 .rodata          @3805 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3805[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807E7310, &lit_3805);
-#pragma pop
-
-/* 807E7318-807E7320 000018 0008+00 0/4 0/0 0/0 .rodata          @3806 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3806[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807E7318, &lit_3806);
-#pragma pop
-
-/* 807E7320-807E7328 000020 0008+00 0/4 0/0 0/0 .rodata          @3807 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3807[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807E7320, &lit_3807);
-#pragma pop
-
-/* 807E7328-807E732C 000028 0004+00 0/1 0/0 0/0 .rodata          @3808 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3808 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807E7328, &lit_3808);
-#pragma pop
-
 /* 807E732C-807E7330 00002C 0004+00 0/2 0/0 0/0 .rodata          @3823 */
 #pragma push
 #pragma force_active on
@@ -276,56 +219,6 @@ COMPILER_STRIP_GATE(0x807E7340, &lit_3828);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3829 = 10.0f;
 COMPILER_STRIP_GATE(0x807E7344, &lit_3829);
-#pragma pop
-
-/* 807E7410-807E741C 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807E741C-807E7430 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807E7430-807E7438 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3681 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807E7438-807E7440 000028 0008+00 0/1 0/0 0/0 .data            e_env$3682 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807E7440-807E7448 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3690 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 807E7448-807E7488 000038 0040+00 1/1 0/0 0/0 .data            cc_ws_src__22@unnamed@d_a_e_ws_cpp@
@@ -1013,13 +906,6 @@ static void func_807E6EC8() {
 
 /* 807E6ED0-807E6ED8 0035B0 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807E6ED0() {
-    // NONMATCHING
-}
-
-/* 807E6ED8-807E72EC 0035B8 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ww.cpp
+++ b/src/d/actor/d_a_e_ww.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_ww.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -77,7 +78,6 @@ extern "C" static void func_807EF2D4();
 extern "C" static void func_807EF2DC();
 extern "C" static void func_807EF2E4();
 extern "C" static void func_807EF2EC();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" void checkNowWolf__9daPy_py_cFv();
 extern "C" extern char const* const d_a_e_ww__stringBase0;
@@ -203,7 +203,6 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
@@ -215,61 +214,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807EF770-807EF774 000000 0004+00 30/30 0/0 0/0 .rodata          @3905 */
-SECTION_RODATA static f32 const lit_3905 = 100.0f;
-COMPILER_STRIP_GATE(0x807EF770, &lit_3905);
-
-/* 807EF774-807EF778 000004 0004+00 1/23 0/0 0/0 .rodata          @3906 */
-SECTION_RODATA static u8 const lit_3906[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807EF774, &lit_3906);
-
-/* 807EF778-807EF780 000008 0004+04 2/12 0/0 0/0 .rodata          @3907 */
-SECTION_RODATA static f32 const lit_3907[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807EF778, &lit_3907);
-
-/* 807EF780-807EF788 000010 0008+00 0/12 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3908[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807EF780, &lit_3908);
-#pragma pop
-
-/* 807EF788-807EF790 000018 0008+00 0/12 0/0 0/0 .rodata          @3909 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3909[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807EF788, &lit_3909);
-#pragma pop
-
-/* 807EF790-807EF798 000020 0008+00 0/12 0/0 0/0 .rodata          @3910 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3910[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807EF790, &lit_3910);
-#pragma pop
-
-/* 807EF798-807EF79C 000028 0004+00 0/1 0/0 0/0 .rodata          @3911 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3911 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807EF798, &lit_3911);
-#pragma pop
-
 /* 807EF79C-807EF7A0 00002C 0004+00 0/3 0/0 0/0 .rodata          @3926 */
 #pragma push
 #pragma force_active on
@@ -303,56 +247,6 @@ COMPILER_STRIP_GATE(0x807EF7A8, &lit_3929);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3930 = 25.0f;
 COMPILER_STRIP_GATE(0x807EF7AC, &lit_3930);
-#pragma pop
-
-/* 807EF8CC-807EF8D8 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807EF8D8-807EF8EC 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807EF8EC-807EF8F4 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3784 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807EF8F4-807EF8FC 000028 0008+00 0/1 0/0 0/0 .data            e_env$3785 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807EF8FC-807EF904 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3793 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 807EF904-807EF944 000038 0040+00 1/1 0/0 0/0 .data            cc_ww_src__22@unnamed@d_a_e_ww_cpp@
@@ -1559,13 +1453,6 @@ static void func_807EF2E4() {
 
 /* 807EF2EC-807EF2F4 007CEC 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807EF2EC() {
-    // NONMATCHING
-}
-
-/* 807EF2F4-807EF708 007CF4 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_yd.cpp
+++ b/src/d/actor/d_a_e_yd.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_yd.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -55,7 +56,6 @@ extern "C" void __dt__12daE_YD_HIO_cFv();
 extern "C" void __sinit_d_a_e_yd_cpp();
 extern "C" static void func_807F7550();
 extern "C" static void func_807F7558();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_yd__stringBase0;
@@ -188,13 +188,10 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mGndCheck__11fopAcM_gc_c[84];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -203,114 +200,9 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807F7A00-807F7A04 000000 0004+00 17/17 0/0 0/0 .rodata          @3788 */
-SECTION_RODATA static f32 const lit_3788 = 100.0f;
-COMPILER_STRIP_GATE(0x807F7A00, &lit_3788);
-
-/* 807F7A04-807F7A08 000004 0004+00 4/18 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static u8 const lit_3789[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807F7A04, &lit_3789);
-
-/* 807F7A08-807F7A10 000008 0004+04 3/15 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static f32 const lit_3790[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807F7A08, &lit_3790);
-
-/* 807F7A10-807F7A18 000010 0008+00 0/5 0/0 0/0 .rodata          @3791 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3791[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807F7A10, &lit_3791);
-#pragma pop
-
-/* 807F7A18-807F7A20 000018 0008+00 0/5 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807F7A18, &lit_3792);
-#pragma pop
-
-/* 807F7A20-807F7A28 000020 0008+00 0/5 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807F7A20, &lit_3793);
-#pragma pop
-
-/* 807F7A28-807F7A2C 000028 0004+00 0/1 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3794 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807F7A28, &lit_3794);
-#pragma pop
-
 /* 807F7A2C-807F7A30 00002C 0004+00 1/4 0/0 0/0 .rodata          @3809 */
 SECTION_RODATA static f32 const lit_3809 = 0.5f;
 COMPILER_STRIP_GATE(0x807F7A2C, &lit_3809);
-
-/* 807F7B38-807F7B44 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807F7B44-807F7B58 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807F7B58-807F7B60 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3667 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807F7B60-807F7B68 000028 0008+00 0/1 0/0 0/0 .data            e_env$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807F7B68-807F7B70 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3676 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 807F7B70-807F7B74 000038 0004+00 1/1 0/0 0/0 .data            l_color$3890 */
 SECTION_DATA static u8 l_color[4] = {
@@ -1201,13 +1093,6 @@ static void func_807F7550() {
 
 /* 807F7558-807F7560 004A18 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807F7558() {
-    // NONMATCHING
-}
-
-/* 807F7560-807F7974 004A20 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_yg.cpp
+++ b/src/d/actor/d_a_e_yg.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_yg.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 
@@ -55,7 +56,6 @@ extern "C" void __dt__12daE_YG_HIO_cFv();
 extern "C" void __sinit_d_a_e_yg_cpp();
 extern "C" static void func_807FC804();
 extern "C" static void func_807FC80C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_yg__stringBase0;
@@ -191,12 +191,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -205,61 +202,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 807FCCB4-807FCCB8 000000 0004+00 20/20 0/0 0/0 .rodata          @3801 */
-SECTION_RODATA static f32 const lit_3801 = 100.0f;
-COMPILER_STRIP_GATE(0x807FCCB4, &lit_3801);
-
-/* 807FCCB8-807FCCBC 000004 0004+00 2/17 0/0 0/0 .rodata          @3802 */
-SECTION_RODATA static u8 const lit_3802[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x807FCCB8, &lit_3802);
-
-/* 807FCCBC-807FCCC4 000008 0004+04 3/15 0/0 0/0 .rodata          @3803 */
-SECTION_RODATA static f32 const lit_3803[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x807FCCBC, &lit_3803);
-
-/* 807FCCC4-807FCCCC 000010 0008+00 0/3 0/0 0/0 .rodata          @3804 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3804[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807FCCC4, &lit_3804);
-#pragma pop
-
-/* 807FCCCC-807FCCD4 000018 0008+00 0/3 0/0 0/0 .rodata          @3805 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3805[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807FCCCC, &lit_3805);
-#pragma pop
-
-/* 807FCCD4-807FCCDC 000020 0008+00 0/3 0/0 0/0 .rodata          @3806 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3806[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x807FCCD4, &lit_3806);
-#pragma pop
-
-/* 807FCCDC-807FCCE0 000028 0004+00 0/1 0/0 0/0 .rodata          @3807 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3807 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x807FCCDC, &lit_3807);
-#pragma pop
-
 /* 807FCCE0-807FCCE4 00002C 0004+00 0/3 0/0 0/0 .rodata          @3822 */
 #pragma push
 #pragma force_active on
@@ -286,56 +228,6 @@ COMPILER_STRIP_GATE(0x807FCCE8, &lit_3824);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3825 = 450.0f;
 COMPILER_STRIP_GATE(0x807FCCEC, &lit_3825);
-#pragma pop
-
-/* 807FCDFC-807FCE08 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 807FCE08-807FCE1C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 807FCE1C-807FCE24 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3680 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 807FCE24-807FCE2C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3681 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 807FCE2C-807FCE34 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3689 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id_3689[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 807FCE34-807FCE94 -00001 0060+00 1/1 0/0 0/0 .data            @4282 */
@@ -1485,13 +1377,6 @@ static void func_807FC804() {
 
 /* 807FC80C-807FC814 0045AC 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_807FC80C() {
-    // NONMATCHING
-}
-
-/* 807FC814-807FCC28 0045B4 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_yh.cpp
+++ b/src/d/actor/d_a_e_yh.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_yh.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -60,7 +61,6 @@ extern "C" void __dt__12daE_YH_HIO_cFv();
 extern "C" void __sinit_d_a_e_yh_cpp();
 extern "C" static void func_80803DCC();
 extern "C" static void func_80803DD4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__5csXyzFv();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_yh__stringBase0;
@@ -210,10 +210,8 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
 extern "C" u8 mGndCheck__11fopAcM_gc_c[84];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" f32 mGroundY__11fopAcM_gc_c;
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
@@ -224,61 +222,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 8080427C-80804280 000000 0004+00 24/24 0/0 0/0 .rodata          @3902 */
-SECTION_RODATA static f32 const lit_3902 = 100.0f;
-COMPILER_STRIP_GATE(0x8080427C, &lit_3902);
-
-/* 80804280-80804284 000004 0004+00 3/22 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static u8 const lit_3903[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80804280, &lit_3903);
-
-/* 80804284-8080428C 000008 0004+04 2/22 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static f32 const lit_3904[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80804284, &lit_3904);
-
-/* 8080428C-80804294 000010 0008+00 0/6 0/0 0/0 .rodata          @3905 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3905[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8080428C, &lit_3905);
-#pragma pop
-
-/* 80804294-8080429C 000018 0008+00 0/6 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80804294, &lit_3906);
-#pragma pop
-
-/* 8080429C-808042A4 000020 0008+00 0/6 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x8080429C, &lit_3907);
-#pragma pop
-
-/* 808042A4-808042A8 000028 0004+00 0/1 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3908 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x808042A4, &lit_3908);
-#pragma pop
-
 /* 808042A8-808042AC 00002C 0004+00 0/6 0/0 0/0 .rodata          @3923 */
 #pragma push
 #pragma force_active on
@@ -291,56 +234,6 @@ COMPILER_STRIP_GATE(0x808042A8, &lit_3923);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3924 = 6.0f / 5.0f;
 COMPILER_STRIP_GATE(0x808042AC, &lit_3924);
-#pragma pop
-
-/* 808043E8-808043F4 000000 000C+00 2/2 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 808043F4-80804408 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80804408-80804410 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3781 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80804410-80804418 000028 0008+00 0/1 0/0 0/0 .data            e_env$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80804418-80804420 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3790 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80804420-80804424 000038 0004+00 1/1 0/0 0/0 .data            l_color$4007 */
@@ -1411,13 +1304,6 @@ static void func_80803DCC() {
 
 /* 80803DD4-80803DDC 0069F4 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80803DD4() {
-    // NONMATCHING
-}
-
-/* 80803DDC-808041F0 0069FC 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_ym.cpp
+++ b/src/d/actor/d_a_e_ym.cpp
@@ -8,7 +8,8 @@
 #include "SSystem/SComponent/c_math.h"
 #include "d/d_com_inf_game.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -102,7 +103,6 @@ extern "C" void __dt__12daE_YM_HIO_cFv();
 extern "C" void __sinit_d_a_e_ym_cpp();
 extern "C" static void func_808154DC();
 extern "C" static void func_808154E4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" void getLeftHandPos__9daPy_py_cCFv();
 extern "C" void getPos__13daTag_FWall_cFUc();
@@ -266,154 +266,6 @@ extern "C" void checkNextPath__8daKago_cF4cXyz();
 //
 
 /* ############################################################################################## */
-/* 80815994-80815998 000000 0004+00 48/48 0/0 0/0 .rodata          @3925 */
-SECTION_RODATA static f32 const lit_3925 = 100.0f;
-COMPILER_STRIP_GATE(0x80815994, &lit_3925);
-
-/* 80815998-8081599C 000004 0004+00 3/41 0/0 0/0 .rodata          @3926 */
-SECTION_RODATA static u8 const lit_3926[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80815998, &lit_3926);
-
-/* 8081599C-808159A4 000008 0004+04 3/29 0/0 0/0 .rodata          @3927 */
-SECTION_RODATA static f32 const lit_3927[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x8081599C, &lit_3927);
-
-/* 808159A4-808159AC 000010 0008+00 0/25 0/0 0/0 .rodata          @3928 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3928[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x808159A4, &lit_3928);
-#pragma pop
-
-/* 808159AC-808159B4 000018 0008+00 0/25 0/0 0/0 .rodata          @3929 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3929[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x808159AC, &lit_3929);
-#pragma pop
-
-/* 808159B4-808159BC 000020 0008+00 0/25 0/0 0/0 .rodata          @3930 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3930[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x808159B4, &lit_3930);
-#pragma pop
-
-/* 808159BC-808159C0 000028 0004+00 0/1 0/0 0/0 .rodata          @3931 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3931 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x808159BC, &lit_3931);
-#pragma pop
-
-/* 808159C0-808159C4 00002C 0004+00 0/7 0/0 0/0 .rodata          @3946 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3946 = 20.0f;
-COMPILER_STRIP_GATE(0x808159C0, &lit_3946);
-#pragma pop
-
-/* 808159C4-808159C8 000030 0004+00 1/15 0/0 0/0 .rodata          @3947 */
-SECTION_RODATA static f32 const lit_3947 = 30.0f;
-COMPILER_STRIP_GATE(0x808159C4, &lit_3947);
-
-/* 808159C8-808159CC 000034 0004+00 0/2 0/0 0/0 .rodata          @3948 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3948 = 3.0f / 5.0f;
-COMPILER_STRIP_GATE(0x808159C8, &lit_3948);
-#pragma pop
-
-/* 808159CC-808159D0 000038 0004+00 1/11 0/0 0/0 .rodata          @3949 */
-SECTION_RODATA static f32 const lit_3949 = 3.0f;
-COMPILER_STRIP_GATE(0x808159CC, &lit_3949);
-
-/* 808159D0-808159D4 00003C 0004+00 0/1 0/0 0/0 .rodata          @3950 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3950 = 13.0f;
-COMPILER_STRIP_GATE(0x808159D0, &lit_3950);
-#pragma pop
-
-/* 808159D4-808159D8 000040 0004+00 0/5 0/0 0/0 .rodata          @3951 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3951 = 400.0f;
-COMPILER_STRIP_GATE(0x808159D4, &lit_3951);
-#pragma pop
-
-/* 808159D8-808159DC 000044 0004+00 0/3 0/0 0/0 .rodata          @3952 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3952 = 300.0f;
-COMPILER_STRIP_GATE(0x808159D8, &lit_3952);
-#pragma pop
-
-/* 80815B04-80815B10 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80815B10-80815B24 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80815B24-80815B2C 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3804 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80815B2C-80815B34 000028 0008+00 0/1 0/0 0/0 .data            e_env$3805 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80815B34-80815B3C 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3813 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
-
 /* 80815B3C-80815B7C 000038 0040+00 1/1 0/0 0/0 .data            cc_sph_src__6E_YM_n */
 dCcD_SrcSph E_YM_n::cc_sph_src = {
     {
@@ -604,18 +456,6 @@ BOOL daE_YM_c::checkBck(char const* i_arcName, int i_resNo) {
     return field_0x5b4->getAnm() == (J3DAnmTransform*)dComIfG_getObjectRes(i_arcName, i_resNo);
 }
 
-/* ############################################################################################## */
-/* 808159DC-808159E0 000048 0004+00 0/4 0/0 0/0 .rodata          @3987 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3987 = 2.0f;
-COMPILER_STRIP_GATE(0x808159DC, &lit_3987);
-#pragma pop
-
-/* 808159E0-808159E4 00004C 0004+00 1/2 0/0 0/0 .rodata          @3988 */
-SECTION_RODATA static f32 const lit_3988 = -1.0f;
-COMPILER_STRIP_GATE(0x808159E0, &lit_3988);
-
 /* 808081E0-80808328 0001A0 0148+00 18/18 0/0 0/0 .text            bckSet__8daE_YM_cFiUcff */
 void daE_YM_c::bckSet(int i_resID, u8 i_attribute, f32 i_morf, f32 i_speed) {
     int tm_res_id;
@@ -629,7 +469,7 @@ void daE_YM_c::bckSet(int i_resID, u8 i_attribute, f32 i_morf, f32 i_speed) {
             tm_res_id = 9;
             break;
         case 16:
-            i_speed = FLOAT_LABEL(lit_3987);
+            i_speed = 2.0f;
             tm_res_id = 10;
             break;
         case 14:
@@ -640,36 +480,20 @@ void daE_YM_c::bckSet(int i_resID, u8 i_attribute, f32 i_morf, f32 i_speed) {
         }
 
         field_0x5b4->setAnm((J3DAnmTransform*)dComIfG_getObjectRes("E_TM", tm_res_id), i_attribute,
-                            i_morf, i_speed, FLOAT_LABEL(lit_3926), FLOAT_LABEL(lit_3988));
+                            i_morf, i_speed, 0.0f, -1.0f);
     } else {
         field_0x5b4->setAnm((J3DAnmTransform*)dComIfG_getObjectRes("E_YM", i_resID), i_attribute,
-                            i_morf, i_speed, FLOAT_LABEL(lit_3926), FLOAT_LABEL(lit_3988));
+                            i_morf, i_speed, 0.0f, -1.0f);
     }
 }
 
 /* 80808328-808083CC 0002E8 00A4+00 4/4 0/0 0/0 .text            bckSetFly__8daE_YM_cFiUcff */
 void daE_YM_c::bckSetFly(int i_resID, u8 i_attribute, f32 i_morf, f32 i_speed) {
     field_0x5b4->setAnm((J3DAnmTransform*)dComIfG_getObjectRes("E_TM", i_resID), i_attribute,
-                        i_morf, i_speed, FLOAT_LABEL(lit_3926), FLOAT_LABEL(lit_3988));
+                        i_morf, i_speed, 0.0f, -1.0f);
 }
 
-/* ############################################################################################## */
-/* 808159E4-808159E8 000050 0004+00 0/1 0/0 0/0 .rodata          @4101 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4101 = 255.0f;
-COMPILER_STRIP_GATE(0x808159E4, &lit_4101);
-#pragma pop
-
-/* 808159E8-808159EC 000054 0004+00 0/6 0/0 0/0 .rodata          @4102 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4102 = -70.0f;
-COMPILER_STRIP_GATE(0x808159E8, &lit_4102);
-#pragma pop
-
 /* 808083CC-80808678 00038C 02AC+00 1/1 0/0 0/0 .text            draw__8daE_YM_cFv */
-// NONMATCHING - one instruction order mismatch (probably causes regalloc issue)
 int daE_YM_c::draw() {
     if (field_0x71d) {
         return 1;
@@ -686,7 +510,7 @@ int daE_YM_c::draw() {
     bool bvar = true;
 
     if (field_0x710 != 0) {
-        if (field_0x6d4 == 0.0f) {
+        if (!field_0x6d4) {
             return 1;
         }
 
@@ -768,8 +592,8 @@ static void* s_obj_sub(void* param_0, void* param_1) {
         if (!fpcM_IsCreating(fopAcM_GetID(near_obj))) {
             f32 obj_dist = fopAcM_searchActorDistanceXZ(near_obj, e_ym);
 
-            if (obj_dist < FLOAT_LABEL(lit_3925) && obj_dist < m_obj_dist &&
-                fabsf(fopAcM_searchActorDistanceY(near_obj, e_ym)) < FLOAT_LABEL(lit_3947))
+            if (obj_dist < 100.0f && obj_dist < m_obj_dist &&
+                fabsf(fopAcM_searchActorDistanceY(near_obj, e_ym)) < 30.0f)
             {
                 m_near_obj = near_obj;
                 m_obj_dist = obj_dist;
@@ -790,22 +614,6 @@ void daE_YM_c::setDigEffect() {
     field_0xadc = dComIfGp_particle_set(field_0xadc, 0x83A9, &sp28, &shape_angle, &sp1C);
 }
 
-
-/* ############################################################################################## */
-/* 808159EC-808159F0 000058 0004+00 0/16 0/0 0/0 .rodata          @4214 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4214 = 10.0f;
-COMPILER_STRIP_GATE(0x808159EC, &lit_4214);
-#pragma pop
-
-/* 808159F0-808159F4 00005C 0004+00 0/4 0/0 0/0 .rodata          @4215 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4215 = 6.0f;
-COMPILER_STRIP_GATE(0x808159F0, &lit_4215);
-#pragma pop
-
 /* 80808884-808089DC 000844 0158+00 8/8 0/0 0/0 .text            setElecEffect1__8daE_YM_cFv */
 void daE_YM_c::setElecEffect1() {
     f32 fVar3 = (field_0x68c * 10.0f) / 6.0f;
@@ -819,9 +627,9 @@ void daE_YM_c::setElecEffect1() {
 
     cXyz cStack_38(iVar5[0][3], iVar5[1][3], iVar5[2][3]);
     field_0xad8 = dComIfGp_particle_set(field_0xad8, 0x8393, &cStack_38, &tevStr, &shape_angle, &cStack_2c,
-                                        0xff, 0, 0xffffffff, 0, 0, 0);
+                                        0xff, 0, -1, 0, 0, 0);
     field_0xadc = dComIfGp_particle_set(field_0xadc, 0x8394, &cStack_38, &tevStr, &shape_angle, &cStack_2c,
-                                        0xff, 0, 0xffffffff, 0, 0, 0);
+                                        0xff, 0, -1, 0, 0, 0);
 }
 
 
@@ -838,9 +646,9 @@ void daE_YM_c::setElecEffect2() {
     cXyz cStack_38(iVar5[0][3], iVar5[1][3], iVar5[2][3]);
     setElecEffect1();
     field_0xae0 = dComIfGp_particle_set(field_0xae0, 0x8395, &cStack_38, &tevStr, &shape_angle, &cStack_2c,
-                                        0xff, 0, 0xffffffff, 0, 0, 0);
+                                        0xff, 0, -1, 0, 0, 0);
     field_0xae4 = dComIfGp_particle_set(field_0xae4, 0x8396, &cStack_38, &tevStr, &shape_angle, &cStack_2c,
-                                        0xff, 0, 0xffffffff, 0, 0, 0);
+                                        0xff, 0, -1, 0, 0, 0);
 }
 
 
@@ -848,14 +656,6 @@ void daE_YM_c::setElecEffect2() {
 void daE_YM_c::setFireEffect() {
     // NONMATCHING
 }
-
-/* ############################################################################################## */
-/* 808159F4-808159F8 000060 0004+00 0/1 0/0 0/0 .rodata          @4416 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4416 = 600.0f;
-COMPILER_STRIP_GATE(0x808159F4, &lit_4416);
-#pragma pop
 
 /* 80808E34-80809000 000DF4 01CC+00 3/3 0/0 0/0 .text            checkWallCrash__8daE_YM_cFv */
 bool daE_YM_c::checkWallCrash() {
@@ -1357,7 +1157,7 @@ void daE_YM_c::checkFlyTerritory() {
 /* 8080E630-8080E6A0 0065F0 0070+00 1/1 0/0 0/0 .text            initFly__8daE_YM_cFv */
 void daE_YM_c::initFly() {
     attention_info.distances[fopAc_attn_BATTLE_e] = 46;
-    gravity = FLOAT_LABEL(lit_3926);
+    gravity = 0.0f;
     field_0x6e4 = 0;
 
     if (mTagPosP != NULL) {
@@ -1809,7 +1609,7 @@ void daE_YM_c::setHideType() {
     mSphCc.SetTgType(0x10000);
 
     m_near_obj = NULL;
-    m_obj_dist = FLOAT_LABEL(lit_3925);
+    m_obj_dist = 100.0f;
 
     fpcM_Search(s_obj_sub, this);
 

--- a/src/d/actor/d_a_e_yr.cpp
+++ b/src/d/actor/d_a_e_yr.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_yr.h"
 #include "d/d_cc_d.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -53,7 +54,6 @@ extern "C" void __dt__18fOpAcm_HIO_entry_cFv();
 extern "C" void __dt__14mDoHIO_entry_cFv();
 extern "C" static void func_808283DC();
 extern "C" static void func_808283E4();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_yr__stringBase0;
 
@@ -168,11 +168,9 @@ extern "C" extern void* __vt__12cCcD_SphAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
@@ -187,61 +185,6 @@ static void nodeCallBack(J3DJoint* param_0, int param_1) {
 }
 
 /* ############################################################################################## */
-/* 80828850-80828854 000000 0004+00 20/20 0/0 0/0 .rodata          @3902 */
-SECTION_RODATA static f32 const lit_3902 = 100.0f;
-COMPILER_STRIP_GATE(0x80828850, &lit_3902);
-
-/* 80828854-80828858 000004 0004+00 1/16 0/0 0/0 .rodata          @3903 */
-SECTION_RODATA static u8 const lit_3903[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80828854, &lit_3903);
-
-/* 80828858-80828860 000008 0004+04 1/16 0/0 0/0 .rodata          @3904 */
-SECTION_RODATA static f32 const lit_3904[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80828858, &lit_3904);
-
-/* 80828860-80828868 000010 0008+00 0/3 0/0 0/0 .rodata          @3905 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3905[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80828860, &lit_3905);
-#pragma pop
-
-/* 80828868-80828870 000018 0008+00 0/3 0/0 0/0 .rodata          @3906 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3906[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80828868, &lit_3906);
-#pragma pop
-
-/* 80828870-80828878 000020 0008+00 0/3 0/0 0/0 .rodata          @3907 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3907[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80828870, &lit_3907);
-#pragma pop
-
-/* 80828878-8082887C 000028 0004+00 0/2 0/0 0/0 .rodata          @3908 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3908 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80828878, &lit_3908);
-#pragma pop
-
 /* 8082887C-80828880 00002C 0004+00 0/1 0/0 0/0 .rodata          @4099 */
 #pragma push
 #pragma force_active on
@@ -456,56 +399,6 @@ COMPILER_STRIP_GATE(0x808288CC, &lit_4544);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_4545 = 30.0f;
 COMPILER_STRIP_GATE(0x808288D0, &lit_4545);
-#pragma pop
-
-/* 808289B4-808289C0 000000 000C+00 3/3 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 808289C0-808289D4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 808289D4-808289DC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3781 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 808289DC-808289E4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3782 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 808289E4-808289EC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3790 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 808289EC-80828A58 -00001 006C+00 1/1 0/0 0/0 .data            @4552 */
@@ -1378,13 +1271,6 @@ static void func_808283DC() {
 
 /* 808283E4-808283EC 0062C4 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_808283E4() {
-    // NONMATCHING
-}
-
-/* 808283EC-80828800 0062CC 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_zm.cpp
+++ b/src/d/actor/d_a_e_zm.cpp
@@ -5,7 +5,8 @@
 
 #include "d/actor/d_a_e_zm.h"
 #include "dol2asm.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -51,7 +52,6 @@ extern "C" void __dt__12daE_ZM_HIO_cFv();
 extern "C" void __sinit_d_a_e_zm_cpp();
 extern "C" static void func_80832884();
 extern "C" static void func_8083288C();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void __dt__4cXyzFv();
 extern "C" extern char const* const d_a_e_zm__stringBase0;
 
@@ -165,10 +165,8 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 sincosTable___5JMath[65536];
-extern "C" extern void* calc_mtx[1 + 1 /* padding */];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
@@ -178,61 +176,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 80832CF8-80832CFC 000000 0004+00 12/12 0/0 0/0 .rodata          @3789 */
-SECTION_RODATA static f32 const lit_3789 = 100.0f;
-COMPILER_STRIP_GATE(0x80832CF8, &lit_3789);
-
-/* 80832CFC-80832D00 000004 0004+00 3/12 0/0 0/0 .rodata          @3790 */
-SECTION_RODATA static u8 const lit_3790[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80832CFC, &lit_3790);
-
-/* 80832D00-80832D08 000008 0004+04 1/8 0/0 0/0 .rodata          @3791 */
-SECTION_RODATA static f32 const lit_3791[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x80832D00, &lit_3791);
-
-/* 80832D08-80832D10 000010 0008+00 0/3 0/0 0/0 .rodata          @3792 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3792[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80832D08, &lit_3792);
-#pragma pop
-
-/* 80832D10-80832D18 000018 0008+00 0/3 0/0 0/0 .rodata          @3793 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3793[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80832D10, &lit_3793);
-#pragma pop
-
-/* 80832D18-80832D20 000020 0008+00 0/3 0/0 0/0 .rodata          @3794 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3794[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80832D18, &lit_3794);
-#pragma pop
-
-/* 80832D20-80832D24 000028 0004+00 0/1 0/0 0/0 .rodata          @3795 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3795 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80832D20, &lit_3795);
-#pragma pop
-
 /* 80832D24-80832D28 00002C 0004+00 0/4 0/0 0/0 .rodata          @3810 */
 #pragma push
 #pragma force_active on
@@ -252,56 +195,6 @@ COMPILER_STRIP_GATE(0x80832D28, &lit_3811);
 #pragma force_active on
 SECTION_RODATA static f32 const lit_3812 = 300.0f;
 COMPILER_STRIP_GATE(0x80832D2C, &lit_3812);
-#pragma pop
-
-/* 80832DC4-80832DD0 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80832DD0-80832DE4 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 80832DE4-80832DEC 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3668 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80832DEC-80832DF4 000028 0008+00 0/1 0/0 0/0 .data            e_env$3669 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 80832DF4-80832DFC 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3677 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
 #pragma pop
 
 /* 80832DFC-80832E40 000038 0044+00 1/1 0/0 0/0 .data            cc_zm_src__22@unnamed@d_a_e_zm_cpp@
@@ -900,13 +793,6 @@ static void func_80832884() {
 
 /* 8083288C-80832894 00302C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_8083288C() {
-    // NONMATCHING
-}
-
-/* 80832894-80832CA8 003034 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 

--- a/src/d/actor/d_a_e_zs.cpp
+++ b/src/d/actor/d_a_e_zs.cpp
@@ -6,7 +6,8 @@
 #include "d/actor/d_a_e_zs.h"
 #include "dol2asm.h"
 #include "d/actor/d_a_b_ds.h"
-
+UNK_REL_DATA;
+#include "f_op/f_op_actor_enemy.h"
 
 
 //
@@ -47,7 +48,6 @@ extern "C" void __dt__12daE_ZS_HIO_cFv();
 extern "C" void __sinit_d_a_e_zs_cpp();
 extern "C" static void func_80834E60();
 extern "C" static void func_80834E68();
-extern "C" static void setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz();
 extern "C" void getHandPosR__8daB_DS_cFv();
 extern "C" void getHandPosL__8daB_DS_cFv();
 extern "C" extern char const* const d_a_e_zs__stringBase0;
@@ -133,10 +133,8 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mSimpleTexObj__21dDlst_shadowControl_c[32];
 extern "C" u8 m_midnaActor__9daPy_py_c[4];
-extern "C" extern u8 pauseTimer__9dScnPly_c[4];
 extern "C" void __register_global_object();
 
 //
@@ -144,61 +142,6 @@ extern "C" void __register_global_object();
 //
 
 /* ############################################################################################## */
-/* 808352D0-808352D4 000000 0004+00 9/9 0/0 0/0 .rodata          @3909 */
-SECTION_RODATA static f32 const lit_3909 = 100.0f;
-COMPILER_STRIP_GATE(0x808352D0, &lit_3909);
-
-/* 808352D4-808352D8 000004 0004+00 2/10 0/0 0/0 .rodata          @3910 */
-SECTION_RODATA static u8 const lit_3910[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x808352D4, &lit_3910);
-
-/* 808352D8-808352E0 000008 0004+04 2/7 0/0 0/0 .rodata          @3911 */
-SECTION_RODATA static f32 const lit_3911[1 + 1 /* padding */] = {
-    1.0f,
-    /* padding */
-    0.0f,
-};
-COMPILER_STRIP_GATE(0x808352D8, &lit_3911);
-
-/* 808352E0-808352E8 000010 0008+00 0/2 0/0 0/0 .rodata          @3912 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3912[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x808352E0, &lit_3912);
-#pragma pop
-
-/* 808352E8-808352F0 000018 0008+00 0/2 0/0 0/0 .rodata          @3913 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3913[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x808352E8, &lit_3913);
-#pragma pop
-
-/* 808352F0-808352F8 000020 0008+00 0/2 0/0 0/0 .rodata          @3914 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3914[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x808352F0, &lit_3914);
-#pragma pop
-
-/* 808352F8-808352FC 000028 0004+00 0/1 0/0 0/0 .rodata          @3915 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3915 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x808352F8, &lit_3915);
-#pragma pop
-
 /* 808352FC-80835300 00002C 0004+00 1/1 0/0 0/0 .rodata          @3930 */
 SECTION_RODATA static f32 const lit_3930 = 7.0f / 5.0f;
 COMPILER_STRIP_GATE(0x808352FC, &lit_3930);
@@ -206,56 +149,6 @@ COMPILER_STRIP_GATE(0x808352FC, &lit_3930);
 /* 80835300-80835304 000030 0004+00 1/1 0/0 0/0 .rodata          @3931 */
 SECTION_RODATA static f32 const lit_3931 = 1200.0f;
 COMPILER_STRIP_GATE(0x80835300, &lit_3931);
-
-/* 8083534C-80835358 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80835358-8083536C 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
-};
-#pragma pop
-
-/* 8083536C-80835374 000020 0008+00 0/1 0/0 0/0 .data            e_prim$3788 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_prim[8] = {
-    0xFF, 0x78, 0x00, 0x00, 0xFF, 0x64, 0x78, 0x00,
-};
-#pragma pop
-
-/* 80835374-8083537C 000028 0008+00 0/1 0/0 0/0 .data            e_env$3789 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 e_env[8] = {
-    0x5A, 0x2D, 0x2D, 0x00, 0x3C, 0x1E, 0x1E, 0x00,
-};
-#pragma pop
-
-/* 8083537C-80835384 000030 0006+02 0/1 0/0 0/0 .data            eff_id$3797 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 eff_id[6 + 2 /* padding */] = {
-    0x02,
-    0x9D,
-    0x02,
-    0x9E,
-    0x02,
-    0x9F,
-    /* padding */
-    0x00,
-    0x00,
-};
-#pragma pop
 
 /* 80835384-808353C8 000038 0044+00 1/1 0/0 0/0 .data            cc_zs_src__22@unnamed@d_a_e_zs_cpp@
  */
@@ -690,13 +583,6 @@ static void func_80834E60() {
 
 /* 80834E68-80834E70 001EA8 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
 static void func_80834E68() {
-    // NONMATCHING
-}
-
-/* 80834E70-80835284 001EB0 0414+00 1/1 0/0 0/0 .text
- * setMidnaBindEffect__FP13fopEn_enemy_cP15Z2CreatureEnemyP4cXyzP4cXyz */
-static void setMidnaBindEffect(fopEn_enemy_c* param_0, Z2CreatureEnemy* param_1, cXyz* param_2,
-                                   cXyz* param_3) {
     // NONMATCHING
 }
 


### PR DESCRIPTION
IDEA: All TUs that use the aforementioned function must include f_op_actor_enemy.h. By doing so, .data and .rodata receive a slight boost in matching that'll reduce frustration when, in the future, we attempt to decompile these TUs.

We'll also get a slight bump in matching percentage after this small change.