### PR TITLE
Debug build now takes .alf as input instead of .dol

### DIFF
--- a/config/ShieldD/config.yml
+++ b/config/ShieldD/config.yml
@@ -1,7 +1,7 @@
 name: framework
 object_base: orig/ShieldD
-object: sys/main.dol
-hash: 16415549d9adce985b8cf736f1a5d7afb570b48e
+object: RframeworkD.alf
+hash: 14b910141cc0c0a4b24e62c3d3fd9cd14338f725
 symbols: config/ShieldD/symbols.txt
 splits: config/ShieldD/splits.txt
 # map: orig/ShieldD/fixed_maps/RframeworkD.map

--- a/include/JSystem/JGadget/binary.h
+++ b/include/JSystem/JGadget/binary.h
@@ -92,7 +92,7 @@ struct TValueIterator {
 
     const void* get() const { return mBegin; }
 
-    typename Parser::ParseType operator*() {
+    typename Parser::ParseType operator*() const {
         return *(typename Parser::ParseType*)get();
     }
 

--- a/include/JSystem/JStudio/JStudio/stb.h
+++ b/include/JSystem/JStudio/JStudio/stb.h
@@ -201,11 +201,11 @@ struct TParseData_fixed : public TParseData<T> {
         return TParseData::isValid() && getNext() != NULL;
     }
 
-    Iterator begin() {
+    Iterator begin() const {
         return Iterator(fileCount);
     }
 
-    Iterator end() {
+    Iterator end() const {
         Iterator i(fileCount);
         i += size();
         return i;

--- a/include/JSystem/JStudio/JStudio_JAudio2/control.h
+++ b/include/JSystem/JStudio/JStudio_JAudio2/control.h
@@ -15,6 +15,7 @@ struct TCreateObject : public JStudio::TCreateObject {
         pJAISoundStarter_ = p_soundStarter;
         pJSGSystem_ = p_system;
         mPermit_onExit_notEnd = false;
+        JUT_ASSERT(45, pJAISoundStarter_!=0);
     }
 
     /* 8028D550 */ virtual ~TCreateObject();

--- a/include/JSystem/JStudio/JStudio_JParticle/control.h
+++ b/include/JSystem/JStudio/JStudio_JParticle/control.h
@@ -14,6 +14,7 @@ struct TCreateObject : public JStudio::TCreateObject {
         pJPAEmitterManager_ = p_emitMgr;
         pJSGSystem_ = p_system;
         mPermit_onExit_notEnd = false;
+        JUT_ASSERT(48, pJPAEmitterManager_!=0);
     }
 
     /* 8028E3A0 */ virtual ~TCreateObject();

--- a/include/JSystem/JStudio/JStudio_JStage/control.h
+++ b/include/JSystem/JStudio/JStudio_JStage/control.h
@@ -16,6 +16,7 @@ typedef JStudio::TObject* (*ObjCreateFuncT)(const JStudio::stb::data::TParse_TBl
 struct TCreateObject : public JStudio::TCreateObject {
     TCreateObject(const JStage::TSystem* pSystem) {
         pJSGSystem_ = pSystem;
+        JUT_ASSERT(42, pJSGSystem_!=0);
     }
 
     /* 80289B00 */ virtual ~TCreateObject();

--- a/include/d/actor/d_a_alink.h
+++ b/include/d/actor/d_a_alink.h
@@ -3195,9 +3195,10 @@ public:
     
 
     // this might be a fake match, but helps fix usage in many functions
+#pragma push
 #pragma optimization_level 2
     BOOL checkAttentionLock() { return mAttention->Lockon(); }
-#pragma optimization_level 3
+#pragma pop
 
     bool checkUpperAnime(u16 i_idx) const { return mUpperAnmHeap[UPPER_2].getIdx() == i_idx; }
     bool checkUnderAnime(u16 i_idx) const { return mUnderAnmHeap[UNDER_2].getIdx() == i_idx; }

--- a/include/d/actor/d_a_b_bh.h
+++ b/include/d/actor/d_a_b_bh.h
@@ -89,18 +89,12 @@ public:
 
 STATIC_ASSERT(sizeof(b_bh_class) == 0xf4c);
 
-class daB_BH_HIO_c
-#ifdef DEBUG
-: public JORReflexible
-#endif
-{
+class daB_BH_HIO_c : public JORReflexible {
 public:
     /* 805AE26C */ daB_BH_HIO_c();
     /* 805B3098 */ virtual ~daB_BH_HIO_c() {}
 
-#ifdef DEBUG
-    virtual void genMessage(JORMContext*);
-#endif
+    void genMessage(JORMContext*);
 
     /* 0x04 */ s8 no;
     /* 0x08 */ f32 model_size;

--- a/include/d/actor/d_a_b_gnd.h
+++ b/include/d/actor/d_a_b_gnd.h
@@ -189,17 +189,12 @@ public:
 
 STATIC_ASSERT(sizeof(b_gnd_class) == 0x2790);
 
-class daB_GND_HIO_c
-#ifdef DEBUG
-: public JORReflexible
-#endif
-{
+class daB_GND_HIO_c : public JORReflexible {
 public:
     /* 805F4A4C */ daB_GND_HIO_c();
-#if DEBUG
-    virtual void genMessage(JORMContext*);
-#endif
     /* 80602230 */ virtual ~daB_GND_HIO_c() {}
+
+    void genMessage(JORMContext*);
 
     /* 0x04 */ s8 no;
     /* 0x08 */ f32 model_size;

--- a/include/d/actor/d_a_b_mgn.h
+++ b/include/d/actor/d_a_b_mgn.h
@@ -5,6 +5,7 @@
 #include "d/d_cc_d.h"
 #include "dolphin/types.h"
 #include "f_op/f_op_actor.h"
+#include "JSystem/JHostIO/JORReflexible.h"
 
 /**
  * @ingroup actors-enemies
@@ -15,31 +16,24 @@
  *
  */
 
- class daB_MGN_HIO_c 
- #ifdef DEBUG
- : public JORReflexible
- #endif
- {
-     
- public:
-     /* 8060572C */ daB_MGN_HIO_c();
-     /* 8060F8D0 */ ~daB_MGN_HIO_c();
- 
- #ifdef DEBUG
- virtual void genMessage(JORMContext*);
- #endif
- 
-     /* 0x08 */ f32 field_0x08; // 1.2f
-     /* 0x0C */ f32 field_0x0c; // 50.0f
-     /* 0x10 */ f32 field_0x10; // 70.0f
-     /* 0x14 */ f32 field_0x14; // 1.0f
-     /* 0x18 */ f32 field_0x18; // 100.0f
-     /* 0x1C */ f32 field_0x1c; // 100.0f
-     /* 0x20 */ f32 field_0x20; // 100.0f
-     /* 0x24 */ f32 field_0x24;
-     /* 0x28 */ f32 field_0x28;
-     /* 0x2C */ f32 field_0x2c;
- };
+class daB_MGN_HIO_c : public JORReflexible {
+public:
+    /* 8060572C */ daB_MGN_HIO_c();
+    /* 8060F8D0 */ ~daB_MGN_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    /* 0x08 */ f32 field_0x08; // 1.2f
+    /* 0x0C */ f32 field_0x0c; // 50.0f
+    /* 0x10 */ f32 field_0x10; // 70.0f
+    /* 0x14 */ f32 field_0x14; // 1.0f
+    /* 0x18 */ f32 field_0x18; // 100.0f
+    /* 0x1C */ f32 field_0x1c; // 100.0f
+    /* 0x20 */ f32 field_0x20; // 100.0f
+    /* 0x24 */ f32 field_0x24;
+    /* 0x28 */ f32 field_0x28;
+    /* 0x2C */ f32 field_0x2c;
+};
 
 class daB_MGN_c : public fopEn_enemy_c {
 public:

--- a/include/d/actor/d_a_e_mb.h
+++ b/include/d/actor/d_a_e_mb.h
@@ -48,18 +48,12 @@ public:
 
 STATIC_ASSERT(sizeof(e_mb_class) == 0x8cc);
 
-class daE_MB_HIO_c
-#ifdef DEBUG
-: public JORReflexible
-#endif
-{
+class daE_MB_HIO_c : public JORReflexible {
 public:
     /* 8070616C */ daE_MB_HIO_c();
     /* 8070882C */ virtual ~daE_MB_HIO_c() {}
 
-#ifdef DEBUG
-    virtual void genMessage(JORMContext*);
-#endif
+    void genMessage(JORMContext*);
 
     /* 0x04 */ s8 no;
     /* 0x08 */ f32 base_size;

--- a/include/d/actor/d_a_e_th.h
+++ b/include/d/actor/d_a_e_th.h
@@ -93,10 +93,12 @@ public:
 
 STATIC_ASSERT(sizeof(e_th_class) == 0x123c);
 
-class daE_TH_HIO_c {
+class daE_TH_HIO_c : public JORReflexible {
 public:
     /* 807B038C */ daE_TH_HIO_c();
     /* 807B3FA4 */ virtual ~daE_TH_HIO_c() {}
+
+    void genMessage(JORMContext*);
 
     /* 0x04 */ s8 no;
     /* 0x08 */ f32 base_size;

--- a/include/d/actor/d_a_npc_cd2.h
+++ b/include/d/actor/d_a_npc_cd2.h
@@ -20,11 +20,7 @@ enum AnmNum {
     CD2_ANM_14 = 14,
 };
 
-struct daNpcCd2_HIO_Jnt_c 
-#ifdef DEBUG
-: public JORReflexible
-#endif
-{
+struct daNpcCd2_HIO_Jnt_c : public JORReflexible {
     /* 8015A6E8 */ virtual ~daNpcCd2_HIO_Jnt_c() {}
     /* 8015A788 */ daNpcCd2_HIO_Jnt_c();
 

--- a/include/d/actor/d_a_peru.h
+++ b/include/d/actor/d_a_peru.h
@@ -66,7 +66,7 @@ public:
                             daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_5, int param_6,
                             daNpcT_evtData_c const* param_7, char** param_8)
         : daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8) {
-            OS_REPORT("|%06d:%x|daPeru_c -> コンストラクト\n", g_counter, this);
+            OS_REPORT("|%06d:%x|daPeru_c -> コンストラクト\n", g_Counter.mCounter0, this);
         }
     /* 80D4BEC4 */ s32 getEyeballMaterialNo() { return 1; }
     /* 80D4BECC */ s32 getHeadJointNo() { return 4; }

--- a/include/m_Do/m_Do_hostIO.h
+++ b/include/m_Do/m_Do_hostIO.h
@@ -24,11 +24,7 @@ public:
     /* 0x1C */ JORReflexible* mPt;
 };
 
-class mDoHIO_entry_c
-#ifdef DEBUG
-: public JORReflexible
-#endif
-{
+class mDoHIO_entry_c : public JORReflexible {
 public:
 #ifdef DEBUG
     mDoHIO_entry_c();

--- a/src/d/actor/d_a_e_th.cpp
+++ b/src/d/actor/d_a_e_th.cpp
@@ -1174,7 +1174,7 @@ static int daE_TH_Delete(e_th_class* i_this) {
 
     if (i_this->mInitHIO) {
         l_initHIO = FALSE;
-        mDoHIO_DELETE_CHILD(&l_HIO);
+        mDoHIO_DELETE_CHILD(l_HIO.no);
     }
 
     if (i_this->heap != NULL) {

--- a/src/d/d_bright_check.cpp
+++ b/src/d/d_bright_check.cpp
@@ -33,13 +33,6 @@ static u8 cNullVec__6Z2Calc[12] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-/* 803BB5D4-803BB5EC 0186F4 0018+00 1/2 0/0 0/0 .data            brightChackProc */
-typedef void (dBrightCheck_c::*procFunc)();
-static procFunc brightChackProc[] = {
-    &dBrightCheck_c::modeWait,
-    &dBrightCheck_c::modeMove,
-};
-
 /* 80192F10-80192F98 18D850 0088+00 0/0 1/1 0/0 .text __ct__14dBrightCheck_cFP10JKRArchive */
 dBrightCheck_c::dBrightCheck_c(JKRArchive* i_archive) {
     mArchive = i_archive;
@@ -125,6 +118,13 @@ void dBrightCheck_c::screenSet() {
         }
     }
 }
+
+/* 803BB5D4-803BB5EC 0186F4 0018+00 1/2 0/0 0/0 .data            brightChackProc */
+typedef void (dBrightCheck_c::*procFunc)();
+static procFunc brightChackProc[] = {
+    &dBrightCheck_c::modeWait,
+    &dBrightCheck_c::modeMove,
+};
 
 /* 801934D0-80193508 18DE10 0038+00 0/0 1/1 0/0 .text            _move__14dBrightCheck_cFv */
 void dBrightCheck_c::_move() {


### PR DESCRIPTION
This allows skipping the step of converting alf -> dol, the .alf can now be placed directly in `orig/ShieldD/RframeworkD.alf`

By the way, it turned out that a header was incorrectly resetting the optimization level, so that's why debug wasn't matching right for any TUs that include that header