### PR TITLE
d_a_obj_dust work, 90% matching

### DIFF
--- a/include/d/actor/d_a_obj_dust.h
+++ b/include/d/actor/d_a_obj_dust.h
@@ -2,6 +2,16 @@
 #define D_A_OBJ_DUST_H
 
 #include "f_op/f_op_actor_mng.h"
+#include "d/d_event_lib.h"
+#include "d/d_bg_s_movebg_actor.h"
+#include "d/d_bg_s_acch.h"
+#include "d/d_cc_d.h"
+#include "d/actor/d_a_player.h"
+#include "d/d_bg_w.h"
+#include "d/d_resorce.h"
+#include "d/d_s_play.h"
+
+#include <cmath.h>
 
 /**
  * @ingroup actors-objects
@@ -11,21 +21,42 @@
  * @details
  *
  */
-class daObjDust_c : public fopAc_ac_c {
+class daObjDust_c : public dBgS_MoveBgActor {
 public:
     /* 80BE22B8 */ void Search_Ymb();
     /* 80BE2490 */ void RideOn_Angle(s16&, f32, s16, f32);
-    /* 80BE24F8 */ void Check_RideOn();
+    /* 80BE24F8 */ int Check_RideOn();
     /* 80BE2708 */ void initBaseMtx();
     /* 80BE2734 */ void setBaseMtx();
-    /* 80BE2A70 */ void CreateHeap();
-    /* 80BE2AE8 */ void Create();
-    /* 80BE2B30 */ void Execute(f32 (**)[3][4]);
-    /* 80BE2E9C */ void Draw();
-    /* 80BE2F40 */ void Delete();
+    /* 80BE2A70 */ int CreateHeap();
+    /* 80BE2AE8 */ int Create();
+    /* 80BE2B30 */ int Execute(Mtx**);
+    /* 80BE2E9C */ int Draw();
+    /* 80BE2F40 */ int Delete();
 
-private:
-    /* 0x568 */ u8 field_0x568[0x84c - 0x568];
+    inline int create();
+
+    /* 0x5a0 */ f32 field_0x5a0;
+    /* 0x5a4 */ f32 field_0x5a4; 
+    /* 0x5a8 */ f32 field_0x5a8; 
+    /* 0x5ac */ s16 field_0x5ac;
+    /* 0x5ae */ u8 field_0x5ae[0x5c4 - 0x5ae];
+    /* 0x5c4 */ s16 field_0x5c4;
+    /* 0x5c6 */ s16 field_0x5c6;
+    /* 0x5c8 */ s16 field_0x5c8;
+    /* 0x5ca */ u8 field_0x5ca[0x5cc - 0x5ca];
+    /* 0x5cc */ s16 field_0x5cc;
+    /* 0x5ce */ u8 field_0x5ce[0x5d0 - 0x5ce];
+    /* 0x5d0 */ f32 field_0x5d0;
+    /* 0x5d4 */ u8 field_0x5d4[0x5e1 - 0x5d4];
+    /* 0x5e1 */ bool mYmbFlag;
+    /* 0x5e4 */ dCcD_Stts mStts;
+    /* 0x620 */ J3DModel* mpModel;
+    /* 0x624 */ u8 field_0x624[4];
+    /* 0x628 */ request_of_phase_process_class mPhaseReq;
+    /* 0x630 */ bool mRideOnFlag;
+    /* 0x634 */ dBgS_AcchCir mAcchCir;
+    /* 0x674 */ dBgS_ObjAcch mAcch;
 };
 
 STATIC_ASSERT(sizeof(daObjDust_c) == 0x84c);

--- a/src/d/actor/d_a_obj_dust.cpp
+++ b/src/d/actor/d_a_obj_dust.cpp
@@ -4,97 +4,9 @@
 */
 
 #include "d/actor/d_a_obj_dust.h"
-#include "dol2asm.h"
 
-
-//
-// Forward References:
-//
-
-extern "C" void Search_Ymb__11daObjDust_cFv();
-extern "C" void RideOn_Angle__11daObjDust_cFRsfsf();
-extern "C" void Check_RideOn__11daObjDust_cFv();
-extern "C" void initBaseMtx__11daObjDust_cFv();
-extern "C" void setBaseMtx__11daObjDust_cFv();
-extern "C" static void rideCallBack__FP4dBgWP10fopAc_ac_cP10fopAc_ac_c();
-extern "C" static void daObjDust_Draw__FP11daObjDust_c();
-extern "C" static void daObjDust_Execute__FP11daObjDust_c();
-extern "C" static bool daObjDust_IsDelete__FP11daObjDust_c();
-extern "C" static void daObjDust_Delete__FP11daObjDust_c();
-extern "C" static void daObjDust_Create__FP10fopAc_ac_c();
-extern "C" void __dt__12dBgS_ObjAcchFv();
-extern "C" void CreateHeap__11daObjDust_cFv();
-extern "C" void Create__11daObjDust_cFv();
-extern "C" void Execute__11daObjDust_cFPPA3_A4_f();
-extern "C" void Draw__11daObjDust_cFv();
-extern "C" void Delete__11daObjDust_cFv();
-extern "C" void func_80BE2F74(void* _this, s16);
-extern "C" static void func_80BE2F80();
-extern "C" static void func_80BE2F88();
-extern "C" extern char const* const d_a_obj_dust__stringBase0;
-
-//
-// External References:
-//
-
-extern "C" void mDoMtx_YrotS__FPA4_fs();
-extern "C" void transS__14mDoMtx_stack_cFRC4cXyz();
-extern "C" void ZXYrotM__14mDoMtx_stack_cFRC5csXyz();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void fopAcM_SearchByName__FsPP10fopAc_ac_c();
-extern "C" void fopAcM_setCullSizeBox__FP10fopAc_ac_cffffff();
-extern "C" void fopAcM_posMoveF__FP10fopAc_ac_cPC4cXyz();
-extern "C" void waterCheck__11fopAcM_wt_cFPC4cXyz();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfGp_getReverb__Fi();
-extern "C" void getRes__14dRes_control_cFPCcPCcP11dRes_info_ci();
-extern "C" void getObjectResName2Index__14dRes_control_cFPCcPCc();
-extern "C" void dBgS_MoveBGProc_TypicalRotY__FP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz();
-extern "C" void __ct__12dBgS_AcchCirFv();
-extern "C" void SetWall__12dBgS_AcchCirFff();
-extern "C" void __dt__9dBgS_AcchFv();
-extern "C" void __ct__9dBgS_AcchFv();
-extern "C" void Set__9dBgS_AcchFP4cXyzP4cXyzP10fopAc_ac_ciP12dBgS_AcchCirP4cXyzP5csXyzP5csXyz();
-extern "C" void CrrPos__9dBgS_AcchFR4dBgS();
-extern "C" void __ct__16dBgS_MoveBgActorFv();
-extern "C" bool IsDelete__16dBgS_MoveBgActorFv();
-extern "C" bool ToFore__16dBgS_MoveBgActorFv();
-extern "C" bool ToBack__16dBgS_MoveBgActorFv();
-extern "C" void
-MoveBGCreate__16dBgS_MoveBgActorFPCciPFP4dBgWPvRC13cBgS_PolyInfobP4cXyzP5csXyzP5csXyz_vUlPA3_A4_f();
-extern "C" void MoveBGDelete__16dBgS_MoveBgActorFv();
-extern "C" void MoveBGExecute__16dBgS_MoveBgActorFv();
-extern "C" void SetObj__16dBgS_PolyPassChkFv();
-extern "C" void __ct__10dCcD_GSttsFv();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void cLib_addCalc__FPfffff();
-extern "C" void cLib_addCalcAngleS__FPsssss();
-extern "C" void cLib_chaseF__FPfff();
-extern "C" void seStart__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void seStartLevel__7Z2SeMgrF10JAISoundIDPC3VecUlScffffUc();
-extern "C" void __dl__FPv();
-extern "C" void _savegpr_28();
-extern "C" void _savegpr_29();
-extern "C" void _restgpr_28();
-extern "C" void _restgpr_29();
-extern "C" extern void* __vt__9dCcD_Stts[11];
-extern "C" extern void* __vt__9cCcD_Stts[8];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
-extern "C" u8 sincosTable___5JMath[65536];
-extern "C" f32 mWaterY__11fopAcM_wt_c[1 + 1 /* padding */];
-extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
-
-//
-// Declarations:
-//
-
-/* ############################################################################################## */
 /* 80BE2F98-80BE2FA0 000000 0004+04 4/4 0/0 0/0 .rodata          @3673 */
-SECTION_RODATA static u8 const lit_3673[4 + 4 /* padding */] = {
+static u8 const lit_3673[4+ 4 /* padding */] = {
     0x00,
     0x00,
     0x00,
@@ -105,407 +17,269 @@ SECTION_RODATA static u8 const lit_3673[4 + 4 /* padding */] = {
     0x00,
     0x00,
 };
-COMPILER_STRIP_GATE(0x80BE2F98, &lit_3673);
 
-/* 80BE2FA0-80BE2FA8 000008 0008+00 1/3 0/0 0/0 .rodata          @3675 */
-SECTION_RODATA static u8 const lit_3675[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80BE2FA0, &lit_3675);
+/* 80BE3054-80BE3058 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
+static const char* l_arcName = "M_Dust";
 
-/* 80BE2FA8-80BE2FAC 000010 0004+00 0/2 0/0 0/0 .rodata          @3723 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3723 = 750.0f;
-COMPILER_STRIP_GATE(0x80BE2FA8, &lit_3723);
-#pragma pop
-
-/* 80BE2FAC-80BE2FB0 000014 0004+00 0/2 0/0 0/0 .rodata          @3724 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3724 = -750.0f;
-COMPILER_STRIP_GATE(0x80BE2FAC, &lit_3724);
-#pragma pop
-
-/* 80BE2FB0-80BE2FB4 000018 0004+00 0/2 0/0 0/0 .rodata          @3725 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3725 = 450.0f;
-COMPILER_STRIP_GATE(0x80BE2FB0, &lit_3725);
-#pragma pop
-
-/* 80BE2FB4-80BE2FB8 00001C 0004+00 0/2 0/0 0/0 .rodata          @3726 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3726 = -450.0f;
-COMPILER_STRIP_GATE(0x80BE2FB4, &lit_3726);
-#pragma pop
-
-/* 80BE2FB8-80BE2FBC 000020 0004+00 0/1 0/0 0/0 .rodata          @3727 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3727 = 600.0f;
-COMPILER_STRIP_GATE(0x80BE2FB8, &lit_3727);
-#pragma pop
-
-/* 80BE2FBC-80BE2FC0 000024 0004+00 0/1 0/0 0/0 .rodata          @3728 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3728 = 256.0f;
-COMPILER_STRIP_GATE(0x80BE2FBC, &lit_3728);
-#pragma pop
-
-/* 80BE2FC0-80BE2FC4 000028 0004+00 0/1 0/0 0/0 .rodata          @3729 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3729 = 16.0f;
-COMPILER_STRIP_GATE(0x80BE2FC0, &lit_3729);
-#pragma pop
-
-/* 80BE2FC4-80BE2FC8 00002C 0004+00 0/1 0/0 0/0 .rodata          @3730 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3730 = 31.0f;
-COMPILER_STRIP_GATE(0x80BE2FC4, &lit_3730);
-#pragma pop
-
-/* 80BE2FC8-80BE2FCC 000030 0004+00 0/1 0/0 0/0 .rodata          @3731 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3731 = -100.0f;
-COMPILER_STRIP_GATE(0x80BE2FC8, &lit_3731);
-#pragma pop
-
-/* 80BE2FCC-80BE2FD0 000034 0004+00 0/1 0/0 0/0 .rodata          @3732 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3732 = 0.5f;
-COMPILER_STRIP_GATE(0x80BE2FCC, &lit_3732);
-#pragma pop
-
-/* 80BE2FD0-80BE2FD4 000038 0004+00 0/4 0/0 0/0 .rodata          @3733 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3733 = 100.0f;
-COMPILER_STRIP_GATE(0x80BE2FD0, &lit_3733);
-#pragma pop
-
-/* 80BE2FD4-80BE2FD8 00003C 0004+00 0/2 0/0 0/0 .rodata          @3734 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3734 = 300.0f;
-COMPILER_STRIP_GATE(0x80BE2FD4, &lit_3734);
-#pragma pop
-
-/* 80BE2FD8-80BE2FDC 000040 0004+00 0/1 0/0 0/0 .rodata          @3735 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3735 = 1900.0f;
-COMPILER_STRIP_GATE(0x80BE2FD8, &lit_3735);
-#pragma pop
-
-/* 80BE2FDC-80BE2FE0 000044 0004+00 0/2 0/0 0/0 .rodata          @3736 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3736 = 1.0f;
-COMPILER_STRIP_GATE(0x80BE2FDC, &lit_3736);
-#pragma pop
-
-/* 80BE2FE0-80BE2FE4 000048 0004+00 0/2 0/0 0/0 .rodata          @3737 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3737 = -1.0f;
-COMPILER_STRIP_GATE(0x80BE2FE0, &lit_3737);
-#pragma pop
-
-/* 80BE30F8-80BE30FC 000000 0004+00 2/2 0/0 0/0 .bss             e_ymb__26@unnamed@d_a_obj_dust_cpp@
- */
-static u8 data_80BE30F8[4];
+/* 80BE30F8-80BE30FC 000000 0004+00 2/2 0/0 0/0 .bss             e_ymb__26@unnamed@d_a_obj_dust_cpp@ */
+static fopAc_ac_c* s_ymb;
 
 /* 80BE30FC-80BE3100 000004 0004+00 2/2 0/0 0/0 .bss e_ymb_Pos__26@unnamed@d_a_obj_dust_cpp@ */
-static u8 data_80BE30FC[4];
+static cXyz* s_ymb_Pos;
+
+/* 80BE2490-80BE24F8 000250 0068+00 1/1 0/0 0/0 .text            RideOn_Angle__11daObjDust_cFRsfsf */
+void daObjDust_c::RideOn_Angle(s16& i_angle, f32 i_param1, s16 i_param2, f32 i_param3) {
+    cLib_addCalcAngleS(&i_angle, i_param2 * (i_param1 / i_param3), 1, 0x100, 1);
+}
 
 /* 80BE22B8-80BE2490 000078 01D8+00 1/1 0/0 0/0 .text            Search_Ymb__11daObjDust_cFv */
 void daObjDust_c::Search_Ymb() {
-    // NONMATCHING
-}
+    cXyz ymb_delta(s_ymb_Pos->x - current.pos.x, s_ymb_Pos->y - current.pos.y, s_ymb_Pos->z - current.pos.z);
 
-/* 80BE2490-80BE24F8 000250 0068+00 1/1 0/0 0/0 .text            RideOn_Angle__11daObjDust_cFRsfsf
- */
-void daObjDust_c::RideOn_Angle(s16& param_0, f32 param_1, s16 param_2, f32 param_3) {
-    // NONMATCHING
-}
+    mDoMtx_stack_c::YrotS(-shape_angle.y);
+    mDoMtx_stack_c::multVec(&ymb_delta, &ymb_delta);
 
-/* ############################################################################################## */
-/* 80BE2FE4-80BE2FE8 00004C 0004+00 0/1 0/0 0/0 .rodata          @3775 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3775 = 1.0f / 20.0f;
-COMPILER_STRIP_GATE(0x80BE2FE4, &lit_3775);
-#pragma pop
+    if (ymb_delta.x < 750.0f && ymb_delta.x > -750.0f && ymb_delta.z < 450.0f && ymb_delta.z > -450.0f && ymb_delta.y < 600.0f) {
+        f32 speed = fopAcM_GetSpeedF(s_ymb);
+        if (speed > 0) {
+            field_0x5ac = 256.0f + speed * 16.0f;
+            field_0x5a0 = speed * 31.0f;
+
+            cLib_addCalc(&field_0x5d0, -100.0f, 0.5f, 100.0f, 0);
+            if (mYmbFlag == NULL && mRideOnFlag == NULL && field_0x5a0 > 300.0f && field_0x5a0 < 1900.0f) {
+                fopAcM_seStart(this, Z2SE_OBJ_FLOATBOARD_SWING, 0);
+                mYmbFlag = true; 
+            }
+        }
+    } else {
+        mYmbFlag = false;        
+    }
+}
 
 /* 80BE24F8-80BE2708 0002B8 0210+00 1/1 0/0 0/0 .text            Check_RideOn__11daObjDust_cFv */
-void daObjDust_c::Check_RideOn() {
-    // NONMATCHING
+int daObjDust_c::Check_RideOn() {
+    daPy_py_c* player = daPy_getPlayerActorClass();
+    cXyz* player_pos = fopAcM_GetPosition_p(player);
+    s16 target = 0;
+    mRideOnFlag = false;
+
+    cXyz delta_vec(player_pos->x -current.pos.x, player_pos->y - current.pos.y, player_pos->z - current.pos.z);   
+    mDoMtx_stack_c::YrotS(-shape_angle.y);
+    mDoMtx_stack_c::multVec(&delta_vec, &delta_vec);
+
+    if (delta_vec.x < 750.0f && delta_vec.x > -750.0f && delta_vec.z < 450.0f && delta_vec.z > -450.0f) {
+        RideOn_Angle(field_0x5c8, (s16)-delta_vec.x, 0x200, 750.0);
+        RideOn_Angle(field_0x5cc, delta_vec.z, 0x200, 450.0);
+        mRideOnFlag = true;
+        
+        if (fopAcM_GetSpeedF(player) > 0.0f) {
+            cLib_addCalcAngleS(&field_0x5ac, 0x150, 0xb, 0x100, 0);
+            target = 0x400;            
+        } else {
+            cLib_addCalcAngleS(&field_0x5ac, 0x100, 0xb, 0x100, 0);            
+        }
+    } else {
+        cLib_addCalcAngleS(&field_0x5ac, 0x100, 0xb, 0x100, 0);
+        cLib_addCalcAngleS(&field_0x5c8, 0, 2, 0x100, 1);
+        cLib_addCalcAngleS(&field_0x5cc, 0, 2, 0x100, 1);
+    }
+    cLib_addCalc(&field_0x5a4, target, 0.05, 100.0f, 0.0f);
+    return 0;
 }
 
 /* 80BE2708-80BE2734 0004C8 002C+00 1/1 0/0 0/0 .text            initBaseMtx__11daObjDust_cFv */
 void daObjDust_c::initBaseMtx() {
-    // NONMATCHING
+    fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
+    setBaseMtx();
 }
 
 /* 80BE2734-80BE2790 0004F4 005C+00 2/2 0/0 0/0 .text            setBaseMtx__11daObjDust_cFv */
 void daObjDust_c::setBaseMtx() {
-    // NONMATCHING
-}
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::ZXYrotM(shape_angle);
 
-/* ############################################################################################## */
-/* 80BE2FE8-80BE2FEC 000050 0004+00 1/1 0/0 0/0 .rodata          @3817 */
-SECTION_RODATA static f32 const lit_3817 = 30.0f;
-COMPILER_STRIP_GATE(0x80BE2FE8, &lit_3817);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    cMtx_copy(mDoMtx_stack_c::get(), mBgMtx);
+}
 
 /* 80BE2790-80BE27BC 000550 002C+00 1/1 0/0 0/0 .text
  * rideCallBack__FP4dBgWP10fopAc_ac_cP10fopAc_ac_c              */
-static void rideCallBack(dBgW* param_0, fopAc_ac_c* param_1, fopAc_ac_c* param_2) {
-    // NONMATCHING
+static void rideCallBack(dBgW*, fopAc_ac_c* i_bgActor, fopAc_ac_c* i_rideActor) {
+    if (std::abs(i_rideActor->current.pos.y - i_rideActor->old.pos.y) > 30.0f) {
+        static_cast<daObjDust_c*>(i_bgActor)->field_0x5a8 = i_rideActor->current.pos.y - i_rideActor->old.pos.y;
+    }
 }
 
 /* 80BE27BC-80BE27E8 00057C 002C+00 1/0 0/0 0/0 .text            daObjDust_Draw__FP11daObjDust_c */
-static void daObjDust_Draw(daObjDust_c* param_0) {
-    // NONMATCHING
+static void daObjDust_Draw(daObjDust_c* i_this) {
+    i_this->MoveBGDraw();
 }
 
 /* 80BE27E8-80BE2808 0005A8 0020+00 1/0 0/0 0/0 .text            daObjDust_Execute__FP11daObjDust_c
  */
-static void daObjDust_Execute(daObjDust_c* param_0) {
-    // NONMATCHING
+static void daObjDust_Execute(daObjDust_c* i_this) {
+    i_this->MoveBGExecute();
 }
 
 /* 80BE2808-80BE2810 0005C8 0008+00 1/0 0/0 0/0 .text            daObjDust_IsDelete__FP11daObjDust_c
  */
-static bool daObjDust_IsDelete(daObjDust_c* param_0) {
+static bool daObjDust_IsDelete(daObjDust_c* i_this) {
     return true;
 }
 
 /* 80BE2810-80BE2834 0005D0 0024+00 1/0 0/0 0/0 .text            daObjDust_Delete__FP11daObjDust_c
  */
-static void daObjDust_Delete(daObjDust_c* param_0) {
-    // NONMATCHING
+static int daObjDust_Delete(daObjDust_c* i_this) {
+    fopAcM_GetID(i_this);
+    i_this->MoveBGDelete();
+    return 1;
 }
 
-/* ############################################################################################## */
-/* 80BE2FEC-80BE2FF0 000054 0004+00 0/1 0/0 0/0 .rodata          @3885 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3885 = -200.0f;
-COMPILER_STRIP_GATE(0x80BE2FEC, &lit_3885);
-#pragma pop
+int daObjDust_c::create() {
+    fopAcM_SetupActor(this, daObjDust_c);
 
-/* 80BE2FF0-80BE2FF4 000058 0004+00 0/1 0/0 0/0 .rodata          @3886 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3886 = -50.0f;
-COMPILER_STRIP_GATE(0x80BE2FF0, &lit_3886);
-#pragma pop
+    int phaseStep = dComIfG_resLoad(&mPhaseReq, l_arcName);
+    if (phaseStep == cPhs_COMPLEATE_e) {
+        phaseStep = MoveBGCreate(
+            l_arcName,
+            dComIfG_getObjctResName2Index(l_arcName, "M_FloatingDust01.dzb"),
+            dBgS_MoveBGProc_TypicalRotY,
+            0x1060,
+            NULL);
+        if (phaseStep == cPhs_ERROR_e) {
+            return phaseStep;
+        }
+    }
 
-/* 80BE2FF4-80BE2FF8 00005C 0004+00 0/1 0/0 0/0 .rodata          @3887 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3887 = 200.0f;
-COMPILER_STRIP_GATE(0x80BE2FF4, &lit_3887);
-#pragma pop
-
-/* 80BE2FF8-80BE2FFC 000060 0004+00 0/1 0/0 0/0 .rodata          @3888 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3888 = 50.0f;
-COMPILER_STRIP_GATE(0x80BE2FF8, &lit_3888);
-#pragma pop
-
-/* 80BE2FFC-80BE3000 000064 0004+00 0/1 0/0 0/0 .rodata          @3889 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3889 = -18850.0f;
-COMPILER_STRIP_GATE(0x80BE2FFC, &lit_3889);
-#pragma pop
-
-/* 80BE3020-80BE3020 000088 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80BE3020 = "M_Dust";
-SECTION_DEAD static char const* const stringBase_80BE3027 = "M_FloatingDust01.dzb";
-#pragma pop
-
-/* 80BE3054-80BE3058 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
-SECTION_DATA static void* l_arcName = (void*)&d_a_obj_dust__stringBase0;
-
-/* 80BE3058-80BE3078 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjDust_Method */
-static actor_method_class l_daObjDust_Method = {
-    (process_method_func)daObjDust_Create__FP10fopAc_ac_c,
-    (process_method_func)daObjDust_Delete__FP11daObjDust_c,
-    (process_method_func)daObjDust_Execute__FP11daObjDust_c,
-    (process_method_func)daObjDust_IsDelete__FP11daObjDust_c,
-    (process_method_func)daObjDust_Draw__FP11daObjDust_c,
-};
-
-/* 80BE3078-80BE30A8 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_DUST */
-extern actor_process_profile_definition g_profile_Obj_DUST = {
-  fpcLy_CURRENT_e,        // mLayerID
-  3,                      // mListID
-  fpcPi_CURRENT_e,        // mListPrio
-  PROC_Obj_DUST,          // mProcName
-  &g_fpcLf_Method.base,  // sub_method
-  sizeof(daObjDust_c),    // mSize
-  0,                      // mSizeOther
-  0,                      // mParameters
-  &g_fopAc_Method.base,   // sub_method
-  473,                    // mPriority
-  &l_daObjDust_Method,    // sub_method
-  0x00040180,             // mStatus
-  fopAc_ACTOR_e,          // mActorType
-  fopAc_CULLBOX_CUSTOM_e, // cullType
-};
-
-/* 80BE30A8-80BE30CC 000054 0024+00 2/2 0/0 0/0 .data            __vt__12dBgS_ObjAcch */
-SECTION_DATA extern void* __vt__12dBgS_ObjAcch[9] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__12dBgS_ObjAcchFv,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80BE2F88,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80BE2F80,
-};
-
-/* 80BE30CC-80BE30F4 000078 0028+00 1/1 0/0 0/0 .data            __vt__11daObjDust_c */
-SECTION_DATA extern void* __vt__11daObjDust_c[10] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)CreateHeap__11daObjDust_cFv,
-    (void*)Create__11daObjDust_cFv,
-    (void*)Execute__11daObjDust_cFPPA3_A4_f,
-    (void*)Draw__11daObjDust_cFv,
-    (void*)Delete__11daObjDust_cFv,
-    (void*)IsDelete__16dBgS_MoveBgActorFv,
-    (void*)ToFore__16dBgS_MoveBgActorFv,
-    (void*)ToBack__16dBgS_MoveBgActorFv,
-};
+    fopAcM_setCullSizeBox(this, -200.0f, -50.0f, -200.0f, 200.0f, 50.0f, 200.0f);
+    mAcch.Set(
+        fopAcM_GetPosition_p(this),
+        fopAcM_GetOldPosition_p(this),
+        this,
+        1,
+        &mAcchCir, 
+        fopAcM_GetSpeed_p(this),
+        NULL,
+        NULL);
+    mAcchCir.SetWall(100.0f, 200.0f);
+    mAcch.CrrPos(dComIfG_Bgsp());
+    current.pos.y = -18850.0f;
+    return phaseStep;
+}
 
 /* 80BE2834-80BE2A00 0005F4 01CC+00 1/0 0/0 0/0 .text            daObjDust_Create__FP10fopAc_ac_c */
-static void daObjDust_Create(fopAc_ac_c* param_0) {
-    // NONMATCHING
+static int daObjDust_Create(fopAc_ac_c* i_this) {
+    daObjDust_c* a_this = (daObjDust_c*)i_this;
+    return a_this->create();
 }
-
-/* 80BE2A00-80BE2A70 0007C0 0070+00 3/2 0/0 0/0 .text            __dt__12dBgS_ObjAcchFv */
-// dBgS_ObjAcch::~dBgS_ObjAcch() {
-extern "C" void __dt__12dBgS_ObjAcchFv() {
-    // NONMATCHING
-}
-
-/* ############################################################################################## */
-/* 80BE3020-80BE3020 000088 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80BE303C = "M_FloatingDust01.bmd";
-#pragma pop
 
 /* 80BE2A70-80BE2AE8 000830 0078+00 1/0 0/0 0/0 .text            CreateHeap__11daObjDust_cFv */
-void daObjDust_c::CreateHeap() {
-    // NONMATCHING
+int daObjDust_c::CreateHeap() {
+    J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes(l_arcName, "M_FloatingDust01.bmd");
+    JUT_ASSERT(82, modelData != 0);
+
+    mpModel = mDoExt_J3DModel__create(modelData, 0x80000, 0x11000084);
+    if (mpModel == NULL) {
+        return 0;
+    }
+    return 1;
 }
 
 /* 80BE2AE8-80BE2B30 0008A8 0048+00 1/0 0/0 0/0 .text            Create__11daObjDust_cFv */
-void daObjDust_c::Create() {
-    // NONMATCHING
+int daObjDust_c::Create() {
+    initBaseMtx();
+    mpBgW->SetRideCallback(rideCallBack);
+    fopAcM_wt_c::waterCheck(&current.pos);
+    return cPhs_COMPLEATE_e;
 }
 
-/* ############################################################################################## */
-/* 80BE3000-80BE3004 000068 0004+00 0/1 0/0 0/0 .rodata          @3963 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3963 = 768.0f;
-COMPILER_STRIP_GATE(0x80BE3000, &lit_3963);
-#pragma pop
-
-/* 80BE3004-80BE3008 00006C 0004+00 0/1 0/0 0/0 .rodata          @3964 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3964 = 2.0f;
-COMPILER_STRIP_GATE(0x80BE3004, &lit_3964);
-#pragma pop
-
-/* 80BE3008-80BE300C 000070 0004+00 0/1 0/0 0/0 .rodata          @3965 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3965 = 40.0f;
-COMPILER_STRIP_GATE(0x80BE3008, &lit_3965);
-#pragma pop
-
-/* 80BE300C-80BE3010 000074 0004+00 0/1 0/0 0/0 .rodata          @3966 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3966 = 80.0f;
-COMPILER_STRIP_GATE(0x80BE300C, &lit_3966);
-#pragma pop
-
-/* 80BE3010-80BE3014 000078 0004+00 0/1 0/0 0/0 .rodata          @3967 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3967 = 20.0f;
-COMPILER_STRIP_GATE(0x80BE3010, &lit_3967);
-#pragma pop
-
-/* 80BE3014-80BE3018 00007C 0004+00 0/1 0/0 0/0 .rodata          @3968 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3968 = 1.0f / 10.0f;
-COMPILER_STRIP_GATE(0x80BE3014, &lit_3968);
-#pragma pop
-
-/* 80BE3018-80BE301C 000080 0004+00 0/1 0/0 0/0 .rodata          @3969 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3969 = 15.0f;
-COMPILER_STRIP_GATE(0x80BE3018, &lit_3969);
-#pragma pop
-
-/* 80BE301C-80BE3020 000084 0004+00 0/1 0/0 0/0 .rodata          @3970 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3970 = 1.0f / 100.0f;
-COMPILER_STRIP_GATE(0x80BE301C, &lit_3970);
-#pragma pop
-
 /* 80BE2B30-80BE2E9C 0008F0 036C+00 1/0 0/0 0/0 .text            Execute__11daObjDust_cFPPA3_A4_f */
-void daObjDust_c::Execute(f32 (**param_0)[3][4]) {
-    // NONMATCHING
+// NONMATCHING somehow this needs to not inline TSinCosTable<13,f32>::sinShort
+int daObjDust_c::Execute(Mtx** i_mtx) {
+    fopAcM_seStartLevel(this, Z2SE_OBJ_FLOATBOARD, 0);
+    daPy_py_c* pdVar = daPy_getPlayerActorClass();
+    fopAcM_GetPosition(pdVar);
+    fopAcM_GetSpeed(pdVar);
+
+    if (fopAcM_SearchByName(PROC_E_YMB, (fopAc_ac_c**) &s_ymb) != 0 && s_ymb != NULL) {
+        s_ymb_Pos = fopAcM_GetPosition_p(s_ymb);
+    }
+   
+    field_0x5c4 += field_0x5a4 * 2.0f + 768.0f + field_0x5a0 * 2.0f;
+    field_0x5c6 += field_0x5a4 * 2.0f + 768.0f + field_0x5a0 * 2.0f;
+    Check_RideOn();
+
+    if (s_ymb != NULL) {
+        Search_Ymb();
+    }
+
+    cXyz water_pos(current.pos.x, current.pos.y + 300.0f, current.pos.z);
+    f32 water_f32;
+    if(fopAcM_wt_c::waterCheck(&water_pos)) {
+        water_f32 = fopAcM_wt_c::getWaterY() - 40.0f;
+    }
+
+    cLib_addCalc(&current.pos.y, 
+        water_f32 + cM_ssin(field_0x5c6) * 20.0f + ((field_0x5d0 + 80.0f) + field_0x5a8), 
+        0.1f, 15.0f, 0.1f);
+    cLib_addCalcAngleS(&shape_angle.x,
+        field_0x5c8 + field_0x5ac * cM_ssin(field_0x5c4 + 0x2000), 
+        2, 0x1000, 1);
+    cLib_addCalcAngleS(&shape_angle.z,
+        field_0x5cc + field_0x5ac * cM_ssin(field_0x5c6),
+        2, 0x1000, 1);
+    cLib_chaseF(&field_0x5a8, 0.0f, 1.0f);
+    cLib_addCalc(&field_0x5a0, 0.0f, 0.01f, 100.0f, 0.0f);
+    cLib_addCalc(&field_0x5d0, 0.0f, 0.1f, 100.0f, 0.0f);
+
+    fopAcM_posMoveF(this, mStts.GetCCMoveP());
+
+    *i_mtx = &mBgMtx;    
+    setBaseMtx();
+    mAcch.CrrPos(dComIfG_Bgsp());
+    return 1;
 }
 
 /* 80BE2E9C-80BE2F40 000C5C 00A4+00 1/0 0/0 0/0 .text            Draw__11daObjDust_cFv */
-void daObjDust_c::Draw() {
-    // NONMATCHING
+int daObjDust_c::Draw() {
+    g_env_light.settingTevStruct(16, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpModel, &tevStr);
+    dComIfGd_setListBG();
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+    return 1;
 }
 
 /* 80BE2F40-80BE2F74 000D00 0034+00 1/0 0/0 0/0 .text            Delete__11daObjDust_cFv */
-void daObjDust_c::Delete() {
-    // NONMATCHING
+int daObjDust_c::Delete() {
+    dComIfG_resDelete(&mPhaseReq, l_arcName);
+    return 1;
 }
 
-/* 80BE2F74-80BE2F80 000D34 000C+00 1/1 0/0 0/0 .text sinShort__Q25JMath18TSinCosTable<13,f>CFs */
-extern "C" void func_80BE2F74(void* _this, s16 param_0) /* const */ {
-    // NONMATCHING
-}
+/* 80BE3058-80BE3078 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjDust_Method */
+static actor_method_class l_daObjDust_Method = {
+    (process_method_func)daObjDust_Create,
+    (process_method_func)daObjDust_Delete,
+    (process_method_func)daObjDust_Execute,
+    (process_method_func)daObjDust_IsDelete,
+    (process_method_func)daObjDust_Draw,
+};
 
-/* 80BE2F80-80BE2F88 000D40 0008+00 1/0 0/0 0/0 .text            @36@__dt__12dBgS_ObjAcchFv */
-static void func_80BE2F80() {
-    // NONMATCHING
-}
 
-/* 80BE2F88-80BE2F90 000D48 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
-static void func_80BE2F88() {
-    // NONMATCHING
-}
-
-/* 80BE3020-80BE3020 000088 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
+/* 80BE3078-80BE30A8 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_DUST */
+extern actor_process_profile_definition g_profile_Obj_DUST = {
+    fpcLy_CURRENT_e,        // mLayerID
+    3,                      // mListID
+    fpcPi_CURRENT_e,        // mListPrio
+    PROC_Obj_DUST,          // mProcName
+    &g_fpcLf_Method.base,   // sub_method
+    sizeof(daObjDust_c),    // mSize
+    0,                      // mSizeOther
+    0,                      // mParameters
+    &g_fopAc_Method.base,   // sub_method
+    473,                    // mPriority
+    &l_daObjDust_Method,    // sub_method
+    0x00040180,             // mStatus
+    fopAc_ACTOR_e,          // mActorType
+    fopAc_CULLBOX_CUSTOM_e, // cullType
+  };

--- a/src/d/actor/d_a_obj_dust.cpp
+++ b/src/d/actor/d_a_obj_dust.cpp
@@ -21,11 +21,13 @@ static u8 const lit_3673[4+ 4 /* padding */] = {
 /* 80BE3054-80BE3058 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
 static const char* l_arcName = "M_Dust";
 
-/* 80BE30F8-80BE30FC 000000 0004+00 2/2 0/0 0/0 .bss             e_ymb__26@unnamed@d_a_obj_dust_cpp@ */
-static fopAc_ac_c* s_ymb;
+namespace {
+    /* 80BE30F8-80BE30FC 000000 0004+00 2/2 0/0 0/0 .bss             e_ymb__26@unnamed@d_a_obj_dust_cpp@ */
+    static fopAc_ac_c* e_ymb;
 
-/* 80BE30FC-80BE3100 000004 0004+00 2/2 0/0 0/0 .bss e_ymb_Pos__26@unnamed@d_a_obj_dust_cpp@ */
-static cXyz* s_ymb_Pos;
+    /* 80BE30FC-80BE3100 000004 0004+00 2/2 0/0 0/0 .bss e_ymb_Pos__26@unnamed@d_a_obj_dust_cpp@ */
+    static cXyz* e_ymb_Pos;
+};
 
 /* 80BE2490-80BE24F8 000250 0068+00 1/1 0/0 0/0 .text            RideOn_Angle__11daObjDust_cFRsfsf */
 void daObjDust_c::RideOn_Angle(s16& i_angle, f32 i_param1, s16 i_param2, f32 i_param3) {
@@ -34,13 +36,13 @@ void daObjDust_c::RideOn_Angle(s16& i_angle, f32 i_param1, s16 i_param2, f32 i_p
 
 /* 80BE22B8-80BE2490 000078 01D8+00 1/1 0/0 0/0 .text            Search_Ymb__11daObjDust_cFv */
 void daObjDust_c::Search_Ymb() {
-    cXyz ymb_delta(s_ymb_Pos->x - current.pos.x, s_ymb_Pos->y - current.pos.y, s_ymb_Pos->z - current.pos.z);
+    cXyz ymb_delta(e_ymb_Pos->x - current.pos.x, e_ymb_Pos->y - current.pos.y, e_ymb_Pos->z - current.pos.z);
 
     mDoMtx_stack_c::YrotS(-shape_angle.y);
     mDoMtx_stack_c::multVec(&ymb_delta, &ymb_delta);
 
     if (ymb_delta.x < 750.0f && ymb_delta.x > -750.0f && ymb_delta.z < 450.0f && ymb_delta.z > -450.0f && ymb_delta.y < 600.0f) {
-        f32 speed = fopAcM_GetSpeedF(s_ymb);
+        f32 speed = fopAcM_GetSpeedF(e_ymb);
         if (speed > 0) {
             field_0x5ac = 256.0f + speed * 16.0f;
             field_0x5a0 = speed * 31.0f;
@@ -111,19 +113,19 @@ static void rideCallBack(dBgW*, fopAc_ac_c* i_bgActor, fopAc_ac_c* i_rideActor) 
 }
 
 /* 80BE27BC-80BE27E8 00057C 002C+00 1/0 0/0 0/0 .text            daObjDust_Draw__FP11daObjDust_c */
-static void daObjDust_Draw(daObjDust_c* i_this) {
-    i_this->MoveBGDraw();
+static int daObjDust_Draw(daObjDust_c* i_this) {
+    return i_this->MoveBGDraw();
 }
 
 /* 80BE27E8-80BE2808 0005A8 0020+00 1/0 0/0 0/0 .text            daObjDust_Execute__FP11daObjDust_c
  */
-static void daObjDust_Execute(daObjDust_c* i_this) {
-    i_this->MoveBGExecute();
+static int daObjDust_Execute(daObjDust_c* i_this) {
+    return i_this->MoveBGExecute();
 }
 
 /* 80BE2808-80BE2810 0005C8 0008+00 1/0 0/0 0/0 .text            daObjDust_IsDelete__FP11daObjDust_c
  */
-static bool daObjDust_IsDelete(daObjDust_c* i_this) {
+static int daObjDust_IsDelete(daObjDust_c* i_this) {
     return true;
 }
 
@@ -201,15 +203,15 @@ int daObjDust_c::Execute(Mtx** i_mtx) {
     fopAcM_GetPosition(pdVar);
     fopAcM_GetSpeed(pdVar);
 
-    if (fopAcM_SearchByName(PROC_E_YMB, (fopAc_ac_c**) &s_ymb) != 0 && s_ymb != NULL) {
-        s_ymb_Pos = fopAcM_GetPosition_p(s_ymb);
+    if (fopAcM_SearchByName(PROC_E_YMB, &e_ymb) != 0 && e_ymb != NULL) {
+        e_ymb_Pos = fopAcM_GetPosition_p(e_ymb);
     }
    
     field_0x5c4 += field_0x5a4 * 2.0f + 768.0f + field_0x5a0 * 2.0f;
     field_0x5c6 += field_0x5a4 * 2.0f + 768.0f + field_0x5a0 * 2.0f;
     Check_RideOn();
 
-    if (s_ymb != NULL) {
+    if (e_ymb != NULL) {
         Search_Ymb();
     }
 


### PR DESCRIPTION
Pushing my work on `d_a_obj_dust `. Its currently 90% matching, with the only differences from equivalence being with the `sinShort` inlining in ` daObjDust_c::Execute` and some [extra 0 padding](https://i.imgur.com/v5ftUpK.png) in `.rodata` which I haven't been able to figure out.