### PR TITLE
Debug JStudio fix + match one retail func

### DIFF
--- a/config/ShieldD/splits.txt
+++ b/config/ShieldD/splits.txt
@@ -1996,57 +1996,57 @@ JSystem/JStage/JSGObject.cpp:
 	.data       start:0x806F13B8 end:0x806F13F8
 	.sdata2     start:0x80751868 end:0x80751870
 
-JSystem/JStudio/ctb-data.cpp:
+JSystem/JStudio/JStudio/ctb-data.cpp:
 	.sdata2     start:0x80751870 end:0x80751878
 
 JSystem/JStage/JSGSystem.cpp:
 	.text       start:0x80429570 end:0x80429630
 	.data       start:0x806F13F8 end:0x806F1448
 
-JSystem/JStudio/ctb.cpp:
+JSystem/JStudio/JStudio/ctb.cpp:
 	.text       start:0x80429630 end:0x8042B670
 	.data       start:0x806F1448 end:0x806F1818
 	.sdata      start:0x80747780 end:0x80747820
 
-JSystem/JStudio/functionvalue.cpp:
+JSystem/JStudio/JStudio/functionvalue.cpp:
 	.text       start:0x8042B670 end:0x80431130
 	.rodata     start:0x80654288 end:0x806542A8
 	.data       start:0x806F1818 end:0x806F1F18
 	.sdata      start:0x80747820 end:0x80747900
 	.sdata2     start:0x80751878 end:0x807518C8
 
-JSystem/JStudio/fvb.cpp:
+JSystem/JStudio/JStudio/fvb.cpp:
 	.text       start:0x80431130 end:0x80435140
 	.rodata     start:0x806542A8 end:0x806542E8
 	.data       start:0x806F1F18 end:0x806F2618
 	.sdata      start:0x80747900 end:0x80747A00
 	.sdata2     start:0x807518C8 end:0x807518D0
 
-JSystem/JStudio/fvb-data.cpp:
+JSystem/JStudio/JStudio/fvb-data.cpp:
 	.sdata2     start:0x807518D0 end:0x807518D8
 
-JSystem/JStudio/fvb-data-parse.cpp:
+JSystem/JStudio/JStudio/fvb-data-parse.cpp:
 	.text       start:0x80435140 end:0x80435220
 	.data       start:0x806F2618 end:0x806F2638
 	.sdata      start:0x80747A00 end:0x80747A08
 
-JSystem/JStudio/jstudio-control.cpp:
+JSystem/JStudio/JStudio/jstudio-control.cpp:
 	.text       start:0x80435220 end:0x80436FD0
 	.data       start:0x806F2638 end:0x806F28D0
 	.sdata      start:0x80747A08 end:0x80747A78
 	.sdata2     start:0x807518D8 end:0x807518E0
 
-JSystem/JStudio/jstudio-data.cpp:
+JSystem/JStudio/JStudio/jstudio-data.cpp:
 	.text       start:0x80436FD0 end:0x80437070
 	.sdata2     start:0x807518E0 end:0x807518E8
 
-JSystem/JStudio/jstudio-math.cpp:
+JSystem/JStudio/JStudio/jstudio-math.cpp:
 	.text       start:0x80437070 end:0x80437C70
 	.data       start:0x806F28D0 end:0x806F2948
 	.sdata      start:0x80747A78 end:0x80747AC0
 	.sdata2     start:0x807518E8 end:0x80751918
 
-JSystem/JStudio/jstudio-object.cpp:
+JSystem/JStudio/JStudio/jstudio-object.cpp:
 	.text       start:0x80437C70 end:0x8043DF80
 	.ctors      start:0x8062F8E8 end:0x8062F8EC
 	.rodata     start:0x806542E8 end:0x80654408
@@ -2056,36 +2056,36 @@ JSystem/JStudio/jstudio-object.cpp:
 	.sdata2     start:0x80751918 end:0x80751940
 	.bss        start:0x807C7DD8 end:0x807C7F78
 
-JSystem/JStudio/stb-data.cpp:
+JSystem/JStudio/JStudio/stb-data.cpp:
 	.rodata     start:0x80654408 end:0x80654428
 	.sdata2     start:0x80751940 end:0x80751948
 
-JSystem/JStudio/object-id.cpp:
+JSystem/JStudio/JStudio/object-id.cpp:
 	.text       start:0x8043DF80 end:0x8043E130
 	.data       start:0x806F3BA8 end:0x806F3BB8
 	.sdata      start:0x80747BA0 end:0x80747BB0
 
-JSystem/JStudio/stb.cpp:
+JSystem/JStudio/JStudio/stb.cpp:
 	.text       start:0x8043E130 end:0x80441570
 	.data       start:0x806F3BB8 end:0x806F41A0
 	.sdata      start:0x80747BB0 end:0x80747C58
 
-JSystem/JStudio/stb-data-parse.cpp:
+JSystem/JStudio/JStudio/stb-data-parse.cpp:
 	.text       start:0x80441570 end:0x80441980
 	.data       start:0x806F41A0 end:0x806F41C0
 	.sdata      start:0x80747C58 end:0x80747C68
 
-JSystem/JStudio_JStage/control.cpp:
+JSystem/JStudio/JStudio_JStage/control.cpp:
 	.text       start:0x80441980 end:0x80442BB0
 	.data       start:0x806F41C0 end:0x806F42E0
 	.sdata      start:0x80747C68 end:0x80747C80
 
-JSystem/JStudio_JStage/object.cpp:
+JSystem/JStudio/JStudio_JStage/object.cpp:
 	.text       start:0x80442BB0 end:0x804433E0
 	.data       start:0x806F42E0 end:0x806F43C8
 	.sdata      start:0x80747C80 end:0x80747C88
 
-JSystem/JStudio_JStage/object-actor.cpp:
+JSystem/JStudio/JStudio_JStage/object-actor.cpp:
 	.text       start:0x804433E0 end:0x80446130
 	.ctors      start:0x8062F8EC end:0x8062F8F0
 	.data       start:0x806F43C8 end:0x806F4A98
@@ -2093,26 +2093,26 @@ JSystem/JStudio_JStage/object-actor.cpp:
 	.sdata2     start:0x80751948 end:0x80751950
 	.bss        start:0x807C7F78 end:0x807C8088
 
-JSystem/JStudio_JStage/object-ambientlight.cpp:
+JSystem/JStudio/JStudio_JStage/object-ambientlight.cpp:
 	.text       start:0x80446130 end:0x80446460
 	.data       start:0x806F4A98 end:0x806F4B48
 	.sdata      start:0x80747DB8 end:0x80747DC8
 
-JSystem/JStudio_JStage/object-camera.cpp:
+JSystem/JStudio/JStudio_JStage/object-camera.cpp:
 	.text       start:0x80446460 end:0x80448180
 	.ctors      start:0x8062F8F0 end:0x8062F8F4
 	.data       start:0x806F4B48 end:0x806F4FC0
 	.sdata      start:0x80747DC8 end:0x80747E08
 	.bss        start:0x807C8088 end:0x807C8168
 
-JSystem/JStudio_JStage/object-fog.cpp:
+JSystem/JStudio/JStudio_JStage/object-fog.cpp:
 	.text       start:0x80448180 end:0x80448960
 	.ctors      start:0x8062F8F4 end:0x8062F8F8
 	.data       start:0x806F4FC0 end:0x806F51D0
 	.sdata      start:0x80747E08 end:0x80747E30
 	.bss        start:0x807C8168 end:0x807C81F0
 
-JSystem/JStudio_JStage/object-light.cpp:
+JSystem/JStudio/JStudio_JStage/object-light.cpp:
 	.text       start:0x80448960 end:0x804499F0
 	.ctors      start:0x8062F8F8 end:0x8062F8FC
 	.data       start:0x806F51D0 end:0x806F5620
@@ -2120,12 +2120,12 @@ JSystem/JStudio_JStage/object-light.cpp:
 	.sdata2     start:0x80751950 end:0x80751958
 	.bss        start:0x807C81F0 end:0x807C8280
 
-JSystem/JStudio_JAudio2/control.cpp:
+JSystem/JStudio/JStudio_JAudio2/control.cpp:
 	.text       start:0x804499F0 end:0x80449E20
 	.data       start:0x806F5620 end:0x806F56A8
 	.sdata      start:0x80747EA8 end:0x80747EB8
 
-JSystem/JStudio_JAudio2/object-sound.cpp:
+JSystem/JStudio/JStudio_JAudio2/object-sound.cpp:
 	.text       start:0x80449E20 end:0x8044C430
 	.ctors      start:0x8062F8FC end:0x8062F900
 	.data       start:0x806F56A8 end:0x806F5BD8
@@ -2134,12 +2134,12 @@ JSystem/JStudio_JAudio2/object-sound.cpp:
 	.sdata2     start:0x80751958 end:0x80751968
 	.bss        start:0x807C8280 end:0x807C8330
 
-JSystem/JStudio_JParticle/control.cpp:
+JSystem/JStudio/JStudio_JParticle/control.cpp:
 	.text       start:0x8044C430 end:0x8044C940
 	.data       start:0x806F5BD8 end:0x806F5C68
 	.sdata      start:0x80747EF8 end:0x80747F00
 
-JSystem/JStudio_JParticle/object-particle.cpp:
+JSystem/JStudio/JStudio_JParticle/object-particle.cpp:
 	.text       start:0x8044C940 end:0x8044F0B0
 	.rodata     start:0x80654428 end:0x80654438
 	.data       start:0x806F5C68 end:0x806F6298
@@ -2147,7 +2147,7 @@ JSystem/JStudio_JParticle/object-particle.cpp:
 	.sdata2     start:0x80751968 end:0x807519A0
 	.bss        start:0x807C8330 end:0x807C83C0
 
-JSystem/JStudioCameraEditor/control.cpp:
+JSystem/JStudio/JStudioCameraEditor/control.cpp:
 	.text       start:0x8044F0B0 end:0x80463890
 	.ctors      start:0x8062F900 end:0x8062F904
 	.rodata     start:0x80654438 end:0x80654698
@@ -2156,50 +2156,50 @@ JSystem/JStudioCameraEditor/control.cpp:
 	.sdata2     start:0x807519A0 end:0x80751A28
 	.bss        start:0x807C83C0 end:0x807C8520
 
-JSystem/JStudioCameraEditor/controlset-csb-valueset.cpp:
+JSystem/JStudio/JStudioCameraEditor/controlset-csb-valueset.cpp:
 	.text       start:0x80463890 end:0x80464E20
 	.ctors      start:0x8062F904 end:0x8062F908
 	.data       start:0x806F84F0 end:0x806F8678
 	.sdata      start:0x80748328 end:0x80748390
 	.bss        start:0x807C8520 end:0x807C85D0
 
-JSystem/JStudioCameraEditor/csb.cpp:
+JSystem/JStudio/JStudioCameraEditor/csb.cpp:
 	.text       start:0x80464E20 end:0x80467990
 	.data       start:0x806F8678 end:0x806F9110
 	.sdata      start:0x80748390 end:0x80748478
 	.sdata2     start:0x80751A28 end:0x80751A40
 
-JSystem/JStudioCameraEditor/csb-data.cpp:
+JSystem/JStudio/JStudioCameraEditor/csb-data.cpp:
 	.rodata     start:0x80654698 end:0x80654728
 	.data       start:0x806F9110 end:0x806F9170
 	.sdata      start:0x80748478 end:0x80748488
 
-JSystem/JStudioCameraEditor/sequence.cpp:
+JSystem/JStudio/JStudioCameraEditor/sequence.cpp:
 	.text       start:0x80467990 end:0x80468330
 	.data       start:0x806F9170 end:0x806F9348
 	.sdata      start:0x80748488 end:0x807484B0
 
-JSystem/JStudioPreviewer/control.cpp:
+JSystem/JStudio/JStudioPreviewer/control.cpp:
 	.text       start:0x80468330 end:0x8046B0B0
 	.data       start:0x806F9348 end:0x806F9EB0
 	.sdata      start:0x807484B0 end:0x80748500
 	.sdata2     start:0x80751A40 end:0x80751A50
 
-JSystem/JStudioToolLibrary/anchor.cpp:
+JSystem/JStudio/JStudioToolLibrary/anchor.cpp:
 	.text       start:0x8046B0B0 end:0x8046B290
 	.data       start:0x806F9EB0 end:0x806F9EC8
 	.sdata      start:0x80748500 end:0x80748510
 
-JSystem/JStudioToolLibrary/console.cpp:
+JSystem/JStudio/JStudioToolLibrary/console.cpp:
 	.text       start:0x8046B290 end:0x8046EB30
 	.data       start:0x806F9EC8 end:0x806FA718
 	.sdata      start:0x80748510 end:0x80748550
 	.sdata2     start:0x80751A50 end:0x80751A68
 
-JSystem/JStudioToolLibrary/controlset.cpp:
+JSystem/JStudio/JStudioToolLibrary/controlset.cpp:
 	.text       start:0x8046EB30 end:0x8046EEF0
 
-JSystem/JStudioToolLibrary/controlset-anchor.cpp:
+JSystem/JStudio/JStudioToolLibrary/controlset-anchor.cpp:
 	.text       start:0x8046EEF0 end:0x8046F600
 	.ctors      start:0x8062F908 end:0x8062F90C
 	.rodata     start:0x80654728 end:0x80654740
@@ -2207,7 +2207,7 @@ JSystem/JStudioToolLibrary/controlset-anchor.cpp:
 	.sdata      start:0x80748550 end:0x80748590
 	.bss        start:0x807C85D0 end:0x807C8610
 
-JSystem/JStudioToolLibrary/controlset-preview.cpp:
+JSystem/JStudio/JStudioToolLibrary/controlset-preview.cpp:
 	.text       start:0x8046F600 end:0x80470A10
 	.ctors      start:0x8062F90C end:0x8062F910
 	.rodata     start:0x80654740 end:0x80654780
@@ -2215,13 +2215,13 @@ JSystem/JStudioToolLibrary/controlset-preview.cpp:
 	.sdata      start:0x80748590 end:0x807485C8
 	.bss        start:0x807C8610 end:0x807C86A0
 
-JSystem/JStudioToolLibrary/interface.cpp:
+JSystem/JStudio/JStudioToolLibrary/interface.cpp:
 	.text       start:0x80470A10 end:0x804710E0
 	.data       start:0x806FAAC8 end:0x806FAC58
 	.sdata      start:0x807485C8 end:0x80748620
 	.sdata2     start:0x80751A68 end:0x80751A70
 
-JSystem/JStudioToolLibrary/scroll.cpp:
+JSystem/JStudio/JStudioToolLibrary/scroll.cpp:
 	.text       start:0x804710E0 end:0x80471AF0
 	.ctors      start:0x8062F910 end:0x8062F914
 	.data       start:0x806FAC58 end:0x806FADA0
@@ -2229,19 +2229,19 @@ JSystem/JStudioToolLibrary/scroll.cpp:
 	.sbss       start:0x8074CBC8 end:0x8074CBD8
 	.sdata2     start:0x80751A70 end:0x80751A90
 
-JSystem/JStudioToolLibrary/visual.cpp:
+JSystem/JStudio/JStudioToolLibrary/visual.cpp:
 	.text       start:0x80471AF0 end:0x80472F00
 	.rodata     start:0x80654780 end:0x80654868
 	.data       start:0x806FADA0 end:0x806FADB8
 	.sdata      start:0x80748650 end:0x80748660
 	.sdata2     start:0x80751A90 end:0x80751AB0
 
-JSystem/JStudioToolLibrary/xml.cpp:
+JSystem/JStudio/JStudioToolLibrary/xml.cpp:
 	.text       start:0x80472F00 end:0x804731E0
 	.data       start:0x806FADB8 end:0x806FADC8
 	.sdata      start:0x80748660 end:0x807486A0
 
-JSystem/JStudioToolLibrary/jstudio-controlset-transform.cpp:
+JSystem/JStudio/JStudioToolLibrary/jstudio-controlset-transform.cpp:
 	.text       start:0x804731E0 end:0x80473F10
 	.ctors      start:0x8062F914 end:0x8062F918
 	.rodata     start:0x80654868 end:0x80654898

--- a/include/JSystem/JStudio/JStudio/functionvalue.h
+++ b/include/JSystem/JStudio/JStudio/functionvalue.h
@@ -7,6 +7,8 @@
 
 namespace JStudio {
 
+typedef f64 TValue;
+
 typedef f64 (*ExtrapolateParameter)(f64, f64);
 
 class TFunctionValue;

--- a/include/JSystem/JStudio/JStudio_JStage/control.h
+++ b/include/JSystem/JStudio/JStudio_JStage/control.h
@@ -10,6 +10,15 @@
 #include "JSystem/JStudio/JStudio/jstudio-object.h"
 #include "JSystem/JStudio/JStudio/jstudio-math.h"
 
+#ifdef DEBUG
+namespace JStudio_JStage {
+template<class TAdaptor, class TStageObject>
+struct TVariableValueOutput_object_;
+};  // namespace JStudio_JStage
+#else
+#include "JSystem/JStudio/JStudio_JStage/tvariable_value_output_object.h"
+#endif
+
 namespace JStudio_JStage {
 typedef JStudio::TObject* (*ObjCreateFuncT)(const JStudio::stb::data::TParse_TBlock_object&, JStage::TObject*, const JStage::TSystem*);
 
@@ -40,10 +49,6 @@ struct TAdaptor_object_ {
     /* 0x0 */ JStage::TSystem const* pJSGSystem_;
     /* 0x4 */ JStage::TObject* pJSGObject_;
 };
-
-
-template<class TAdaptor, class TStageObject>
-struct TVariableValueOutput_object_;
 
 struct TAdaptor_actor : public JStudio::TAdaptor_actor, public JStudio_JStage::TAdaptor_object_ {
     typedef JStudio::TObject_actor ObjectType;
@@ -282,35 +287,6 @@ struct TAdaptor_light : public JStudio::TAdaptor_light, public TAdaptor_object_ 
     static TVVOutput_direction_ saoVVOutput_direction_[6];
 };
 
-template<class TAdaptor, class TStageObject>
-struct TVariableValueOutput_object_ : public JStudio::TVariableValue::TOutput {
-    typedef f32 (TStageObject::*GetFunc)() const;
-    typedef void (TStageObject::*SetFunc)(f32);
-    TVariableValueOutput_object_() : field_0x4(-1), field_0x8(NULL), field_0x14(NULL) {}
-    TVariableValueOutput_object_(typename TAdaptor::TEVariableValue param_1, 
-    SetFunc param_2, GetFunc param_3) : field_0x4(param_1), field_0x8(param_2), field_0x14(param_3) {
-
-    }
-
-    virtual void operator()(f32 param_1, JStudio::TAdaptor* param_2) const {
-        (((TAdaptor*)param_2)->get_pJSG_()->*field_0x8)(param_1);
-    }
-    virtual ~TVariableValueOutput_object_() {}
-
-    bool isEnd_() const { return field_0x4 == -1; }
-    void adaptor_setOutput_(TAdaptor* adaptor) {
-        adaptor->adaptor_referVariableValue(field_0x4)->setOutput(this);
-    }
-    void setVariableValue_(const TStageObject* pObj, TAdaptor* pAdaptor) const {
-        f32 val = (pObj->*field_0x14)();
-        pAdaptor->adaptor_setVariableValue_immediate(field_0x4, val);
-    }
-
-    int field_0x4;
-    SetFunc field_0x8;
-    GetFunc field_0x14;
-};
-
 /* 8028A1F8 */ bool
     transform_toGlobalFromLocal(f32 (*)[4],
                                 JStudio::TControl::TTransform_translation_rotation_scaling const&,
@@ -338,5 +314,9 @@ inline bool transform_toGlobalFromLocal(JStudio::TControl::TTransform_position* 
                                                 JStudio::TControl::TTransform_position const&,
                                                 JStage::TObject const*, u32);
 };  // namespace JStudio_JStage
+
+#ifdef DEBUG
+#include "JSystem/JStudio/JStudio_JStage/tvariable_value_output_object.h"
+#endif
 
 #endif /* JSTUDIO_JSTAGE_CONTROL_H */

--- a/include/JSystem/JStudio/JStudio_JStage/control.h
+++ b/include/JSystem/JStudio/JStudio_JStage/control.h
@@ -43,33 +43,7 @@ struct TAdaptor_object_ {
 
 
 template<class TAdaptor, class TStageObject>
-struct TVariableValueOutput_object_ : public JStudio::TVariableValue::TOutput {
-    typedef f32 (TStageObject::*GetFunc)() const;
-    typedef void (TStageObject::*SetFunc)(f32);
-    TVariableValueOutput_object_() : field_0x4(-1), field_0x8(NULL), field_0x14(NULL) {}
-    TVariableValueOutput_object_(typename TAdaptor::TEVariableValue param_1, 
-    SetFunc param_2, GetFunc param_3) : field_0x4(param_1), field_0x8(param_2), field_0x14(param_3) {
-
-    }
-
-    virtual void operator()(f32 param_1, JStudio::TAdaptor* param_2) const {
-        (((TAdaptor*)param_2)->get_pJSG_()->*field_0x8)(param_1);
-    }
-    virtual ~TVariableValueOutput_object_() {}
-
-    bool isEnd_() { return field_0x4 == -1; }
-    void adaptor_setOutput_(TAdaptor* adaptor) {
-        adaptor->adaptor_referVariableValue(field_0x4)->setOutput(this);
-    }
-    void setVariableValue_(TStageObject* pObj, TAdaptor* pAdaptor) {
-        f32 val = (pObj->*field_0x14)();
-        pAdaptor->adaptor_setVariableValue_immediate(field_0x4, val);
-    }
-
-    int field_0x4;
-    SetFunc field_0x8;
-    GetFunc field_0x14;
-};
+struct TVariableValueOutput_object_;
 
 struct TAdaptor_actor : public JStudio::TAdaptor_actor, public JStudio_JStage::TAdaptor_object_ {
     typedef JStudio::TObject_actor ObjectType;
@@ -108,12 +82,12 @@ struct TAdaptor_actor : public JStudio::TAdaptor_actor, public JStudio_JStage::T
             adaptor->adaptor_referVariableValue(mValueIndex)->setOutput(this);
         }
 
-        void setVariableValue_(JStage::TActor *param_1, JStudio::TAdaptor *param_2) {
+        void setVariableValue_(const JStage::TActor *param_1, JStudio::TAdaptor *param_2) const {
             f32 val = (param_1->*mGetter)();
             param_2->adaptor_setVariableValue_immediate(mValueIndex, val);
         }
 
-        bool isEnd_() { return mValueIndex == -1; }
+        bool isEnd_() const { return mValueIndex == -1; }
 
         /* 0x04 */ int mValueIndex;
         /* 0x08 */ u32 field_0x8;
@@ -158,10 +132,7 @@ struct TAdaptor_actor : public JStudio::TAdaptor_actor, public JStudio_JStage::T
 
     JStage::TActor* get_pJSG_() { return (JStage::TActor*) pJSGObject_; }
 
-    // TODO: Why doesn't this line compile with MWCC version Wii/1.0?
-#if __MWERKS__ && __MWERKS__ < 0x4200
     static TVVOutputObject saoVVOutput_[2];
-#endif
     static TVVOutput_ANIMATION_FRAME_  saoVVOutput_ANIMATION_FRAME_[3];
 
     /* 0x130 */ u32 field_0x130;
@@ -224,10 +195,7 @@ struct TAdaptor_camera : public JStudio::TAdaptor_camera, public TAdaptor_object
 
     JStage::TCamera* get_pJSG_() { return (JStage::TCamera*)pJSGObject_; }
 
-    // TODO: Why doesn't this line compile with MWCC version Wii/1.0?
-#if __MWERKS__ && __MWERKS__ < 0x4200
     static TVVOutput saoVVOutput_[5];
-#endif
 
     /* 0x108 */ int field_0x108;
     /* 0x10C */ JStage::TObject* field_0x10c;
@@ -255,10 +223,7 @@ struct TAdaptor_fog : public JStudio::TAdaptor_fog, public TAdaptor_object_ {
 
     JStage::TFog* get_pJSG_() { return (JStage::TFog*)pJSGObject_; }
 
-    // TODO: Why doesn't this line compile with MWCC version Wii/1.0?
-#if __MWERKS__ && __MWERKS__ < 0x4200
     static TVariableValueOutput_object_<TAdaptor_fog, JStage::TFog> saoVVOutput_[3];
-#endif
 };
 
 struct TAdaptor_light : public JStudio::TAdaptor_light, public TAdaptor_object_ {
@@ -294,7 +259,7 @@ struct TAdaptor_light : public JStudio::TAdaptor_light, public TAdaptor_object_ 
             adaptor->adaptor_referVariableValue(field_0x4)->setOutput(this);
         }
 
-        bool isEnd_() { return field_0x4 == -1; }
+        bool isEnd_() const { return field_0x4 == -1; }
 
         TEVariableValue field_0x4;
         TEDirection_ field_0x8;
@@ -315,6 +280,35 @@ struct TAdaptor_light : public JStudio::TAdaptor_light, public TAdaptor_object_ 
     int field_0x11c;
 
     static TVVOutput_direction_ saoVVOutput_direction_[6];
+};
+
+template<class TAdaptor, class TStageObject>
+struct TVariableValueOutput_object_ : public JStudio::TVariableValue::TOutput {
+    typedef f32 (TStageObject::*GetFunc)() const;
+    typedef void (TStageObject::*SetFunc)(f32);
+    TVariableValueOutput_object_() : field_0x4(-1), field_0x8(NULL), field_0x14(NULL) {}
+    TVariableValueOutput_object_(typename TAdaptor::TEVariableValue param_1, 
+    SetFunc param_2, GetFunc param_3) : field_0x4(param_1), field_0x8(param_2), field_0x14(param_3) {
+
+    }
+
+    virtual void operator()(f32 param_1, JStudio::TAdaptor* param_2) const {
+        (((TAdaptor*)param_2)->get_pJSG_()->*field_0x8)(param_1);
+    }
+    virtual ~TVariableValueOutput_object_() {}
+
+    bool isEnd_() const { return field_0x4 == -1; }
+    void adaptor_setOutput_(TAdaptor* adaptor) {
+        adaptor->adaptor_referVariableValue(field_0x4)->setOutput(this);
+    }
+    void setVariableValue_(const TStageObject* pObj, TAdaptor* pAdaptor) const {
+        f32 val = (pObj->*field_0x14)();
+        pAdaptor->adaptor_setVariableValue_immediate(field_0x4, val);
+    }
+
+    int field_0x4;
+    SetFunc field_0x8;
+    GetFunc field_0x14;
 };
 
 /* 8028A1F8 */ bool

--- a/include/JSystem/JStudio/JStudio_JStage/tvariable_value_output_object.h
+++ b/include/JSystem/JStudio/JStudio_JStage/tvariable_value_output_object.h
@@ -1,0 +1,43 @@
+#ifndef TVARIABLE_VALUE_OUTPUT_OBJECT_H
+#define TVARIABLE_VALUE_OUTPUT_OBJECT_H
+
+#include "JSystem/JStudio/JStudio/jstudio-object.h"
+
+// Fake header for JStudio_JStage/control.h. Due to compiler version differences, retail needs the
+// class definition of TVariableValueOutput_object_ to come before it's used, while debug needs it
+// to come after it's used. The include of this header is ifdefed to support both.
+
+namespace JStudio_JStage {
+
+template<class TAdaptor, class TStageObject>
+struct TVariableValueOutput_object_ : public JStudio::TVariableValue::TOutput {
+    typedef f32 (TStageObject::*GetFunc)() const;
+    typedef void (TStageObject::*SetFunc)(f32);
+    TVariableValueOutput_object_() : field_0x4(-1), field_0x8(NULL), field_0x14(NULL) {}
+    TVariableValueOutput_object_(typename TAdaptor::TEVariableValue param_1, 
+    SetFunc param_2, GetFunc param_3) : field_0x4(param_1), field_0x8(param_2), field_0x14(param_3) {
+
+    }
+
+    virtual void operator()(f32 param_1, JStudio::TAdaptor* param_2) const {
+        (((TAdaptor*)param_2)->get_pJSG_()->*field_0x8)(param_1);
+    }
+    virtual ~TVariableValueOutput_object_() {}
+
+    bool isEnd_() const { return field_0x4 == -1; }
+    void adaptor_setOutput_(TAdaptor* adaptor) {
+        adaptor->adaptor_referVariableValue(field_0x4)->setOutput(this);
+    }
+    void setVariableValue_(const TStageObject* pObj, TAdaptor* pAdaptor) const {
+        f32 val = (pObj->*field_0x14)();
+        pAdaptor->adaptor_setVariableValue_immediate(field_0x4, val);
+    }
+
+    int field_0x4;
+    SetFunc field_0x8;
+    GetFunc field_0x14;
+};
+
+};  // namespace JStudio_JStage
+
+#endif /* TVARIABLE_VALUE_OUTPUT_OBJECT_H */

--- a/include/d/d_com_inf_game.h
+++ b/include/d/d_com_inf_game.h
@@ -3509,19 +3509,19 @@ inline void dComIfGp_event_setTalkPartner(fopAc_ac_c* i_actor) {
 }
 
 inline fopAc_ac_c* dComIfGp_event_getTalkPartner() {
-    return (fopAc_ac_c*)g_dComIfG_gameInfo.play.getEvent().getPtT();
+    return g_dComIfG_gameInfo.play.getEvent().getPtT();
 }
 
 inline fopAc_ac_c* dComIfGp_event_getItemPartner() {
-    return (fopAc_ac_c*)g_dComIfG_gameInfo.play.getEvent().getPtI();
+    return g_dComIfG_gameInfo.play.getEvent().getPtI();
 }
 
 inline fopAc_ac_c* dComIfGp_event_getPt1() {
-    return (fopAc_ac_c*)g_dComIfG_gameInfo.play.getEvent().getPt1();
+    return g_dComIfG_gameInfo.play.getEvent().getPt1();
 }
 
 inline fopAc_ac_c* dComIfGp_event_getPt2() {
-    return (fopAc_ac_c*)g_dComIfG_gameInfo.play.getEvent().getPt2();
+    return g_dComIfG_gameInfo.play.getEvent().getPt2();
 }
 
 inline BOOL dComIfGp_event_runCheck() {

--- a/include/m_Do/m_Do_mtx.h
+++ b/include/m_Do/m_Do_mtx.h
@@ -36,7 +36,7 @@ inline void cMtx_scale(Mtx m, f32 x, f32 y, f32 z) {
     MTXScale(m, x, y, z);
 }
 
-inline void mDoMtx_multVec(Mtx m, const Vec* src, Vec* dst) {
+inline void mDoMtx_multVec(CMtxP m, const Vec* src, Vec* dst) {
     MTXMultVec(m, src, dst);
 }
 

--- a/src/JSystem/JFramework/JFWDisplay.cpp
+++ b/src/JSystem/JFramework/JFWDisplay.cpp
@@ -328,13 +328,6 @@ void JFWDisplay::endRender() {
     calcCombinationRatio();
 }
 
-/* ############################################################################################## */
-/* 804511C4-804511C8 0006C4 0004+00 1/1 0/0 0/0 .sbss            prevFrame$2597 */
-static u32 prevFrame;
-
-/* 804511C8-804511D0 0006C8 0008+00 1/1 0/0 0/0 .sbss            None */
-static s8 data_804511C8;
-
 /* 80272AB0-80272C60 26D3F0 01B0+00 1/0 0/0 0/0 .text            endFrame__10JFWDisplayFv */
 void JFWDisplay::endFrame() {
     JUTProcBar::getManager()->cpuEnd();
@@ -361,10 +354,7 @@ void JFWDisplay::endFrame() {
     }
 
     if (field_0x40) {
-        if (data_804511C8 == 0) {
-            prevFrame = VIGetRetraceCount();
-            data_804511C8 = 1;
-        }
+        static u32 prevFrame = VIGetRetraceCount();;
         u32 retrace_cnt = VIGetRetraceCount();
         JUTProcBar::getManager()->setCostFrame(retrace_cnt - prevFrame);
         prevFrame = retrace_cnt;
@@ -378,24 +368,11 @@ void JFWDisplay::waitBlanking(int param_0) {
     }
 }
 
-/* ############################################################################################## */
-/* 804511D0-804511D4 0006D0 0004+00 1/1 0/0 0/0 .sbss            nextTick$2642 */
-static OSTime nextTick ALIGN_DECL(8);
-
-/* 804511D8-804511DC 0006D8 0004+00 1/1 0/0 0/0 .sbss            None */
-static s8 data_804511D8;
-
-/* 804511DC-804511E0 0006DC 0004+00 1/1 0/0 0/0 .sbss            nextCount$2650 */
-static u32 nextCount;
-
-/* 804511E0-804511E8 0006E0 0008+00 1/1 0/0 0/0 .sbss            None */
-static s8 data_804511E0;
-
 /* 80272CB0-80272DD0 26D5F0 0120+00 2/2 0/0 0/0 .text            waitForTick__FUlUs */
 static void waitForTick(u32 p1, u16 p2) {
     if (p1 != 0) {
-        static s64 nextTick = OSGetTime();
-        s64 time = OSGetTime();
+        static OSTime nextTick = OSGetTime();
+        OSTime time = OSGetTime();
         while (time < nextTick) {
             JFWDisplay::getManager()->threadSleep((nextTick - time));
             time = OSGetTime();

--- a/src/JSystem/JStudio/JStudio/functionvalue.cpp
+++ b/src/JSystem/JStudio/JStudio/functionvalue.cpp
@@ -489,7 +489,7 @@ void TFunctionValueAttribute_range::range_set(f64 begin, f64 end) {
     fEnd_ = end;
     fDifference_ = end - begin;
 
-    ASSERT(fDifference_ >= TValue(0));
+    JUT_ASSERT(458, fDifference_ >= TValue(0));
 }
 
 // /* 80281A08-80281D18 27C348 0310+00 2/2 0/0 0/0 .text
@@ -1033,13 +1033,13 @@ void TFunctionValue_list_parameter::prepare() {
 
 /* 80282F10-80282FE8 27D850 00D8+00 1/0 0/0 0/0 .text
  * getValue__Q27JStudio29TFunctionValue_list_parameterFd        */
-f64 TFunctionValue_list_parameter::getValue(f64 pfData_) {
-    pfData_ = range_getParameter(pfData_, data_getValue_front(), data_getValue_back());
+f64 TFunctionValue_list_parameter::getValue(f64 param_0) {
+    param_0 = range_getParameter(param_0, data_getValue_front(), data_getValue_back());
     JUT_ASSERT(1395, pfData_!=0)
 
     // TODO: change to actual function
     //dat3 = JGadget::findUpperBound_binary_current(dat1, dat2, dat3, &pfData_);
-    dat3 = func_802835DC(dat1, dat2, dat3, pfData_);
+    dat3 = func_802835DC(dat1, dat2, dat3, param_0);
     if (dat3 == dat1) {
         return dat3.get()[1];
     }
@@ -1052,7 +1052,7 @@ f64 TFunctionValue_list_parameter::getValue(f64 pfData_) {
     const int suData_size = 1;
     JUT_ASSERT(1411, (pfData_<=pf-suData_size)&&(pf<pfData_+suData_size*uData_));
     JUT_ASSERT(1412, pfnUpdate_!=0);
-    return pfnUpdate_(*this, pfData_);
+    return pfnUpdate_(*this, param_0);
 }
 
 f64 TFunctionValue_list_parameter::update_INTERPOLATE_NONE_(

--- a/src/d/actor/d_a_alink_demo.inc
+++ b/src/d/actor/d_a_alink_demo.inc
@@ -984,7 +984,6 @@ void daAlink_c::endDemoMode() {
 }
 
 /* 801180EC-80118170 112A2C 0084+00 2/2 0/0 0/0 .text            getDemoLookActor__9daAlink_cFv */
-// NONMATCHING - weird gameinfo load
 fopAc_ac_c* daAlink_c::getDemoLookActor() {
     if (mDemo.getParam0() == 1) {
         return dComIfGp_event_getPt1();

--- a/src/d/actor/d_a_obj_lv8Lift.cpp
+++ b/src/d/actor/d_a_obj_lv8Lift.cpp
@@ -45,14 +45,15 @@ f32 const daL8Lift_c::mSpeed[16] = {
 /* 80C88860-80C88928 000220 00C8+00 1/0 0/0 0/0 .text            CreateHeap__10daL8Lift_cFv */
 int daL8Lift_c::CreateHeap() {
     J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes("L8Lift", 5);
+    JUT_ASSERT(190, modelData != 0);
     mpModel = mDoExt_J3DModel__create(modelData, 0, 0x11000284);
     if (!mpModel) {
         return 0;
     }
 
-    mBtk.init(modelData, (J3DAnmTextureSRTKey*)dComIfG_getObjectRes("L8Lift", 8),
+    int res = mBtk.init(modelData, (J3DAnmTextureSRTKey*)dComIfG_getObjectRes("L8Lift", 8),
         1, 0, 1.0f, 0, -1);
-    JUT_ASSERT("d_a_obj_lv8Lift.cpp", 0xcf, "res == 1");
+    JUT_ASSERT(207, res == 1);
 
     return 1;
 }

--- a/src/d/d_ev_camera.cpp
+++ b/src/d/d_ev_camera.cpp
@@ -991,7 +991,7 @@ bool dCamera_c::restorePosEvCamera() {
 
 /* 80090174-80090230 08AAB4 00BC+00 0/0 1/0 0/0 .text            talktoEvCamera__9dCamera_cFv */
 bool dCamera_c::talktoEvCamera() {
-    dComIfGp_event_getPt1();
+    fopAc_ac_c* r27 = (fopAc_ac_c*)dComIfGp_event_getPt1();
     s32 style = mCamTypeData[mEventData.field_0xc].field_0x18[mIsWolf][3];
 
     if (mCurCamStyleTimer == 0) {
@@ -1005,7 +1005,7 @@ bool dCamera_c::talktoEvCamera() {
 #if DEBUG
     if (mCurCamStyleTimer == 0 && mCamSetup.CheckFlag(0x40)) {
         u32 id = mCamParam.Id(style);
-        OS_REPORT("camera: event: %16s  = %d (%c%c%c%c)\n", "style", style, (u8)(id >> 0x18), (u8)(id >> 0x10), (u8)(id >> 0x8), (u8)(id));
+        OS_REPORT("camera: event: %16s  = %d (%c%c%c%c)\n", "style", style, (id >> 0x18) & 0xFF, (id >> 0x10) & 0xFF, (id >> 0x8) & 0xFF, (id) & 0xFF);
     }
 #endif
 

--- a/src/f_op/f_op_actor_mng.cpp
+++ b/src/f_op/f_op_actor_mng.cpp
@@ -1106,22 +1106,22 @@ s32 fopAcM_orderTreasureEvent(fopAc_ac_c* i_actorA, fopAc_ac_c* i_actorB, u16 i_
 /* 8001BB14-8001BB44 016454 0030+00 0/0 11/11 10/10 .text
  * fopAcM_getTalkEventPartner__FPC10fopAc_ac_c                  */
 fopAc_ac_c* fopAcM_getTalkEventPartner(fopAc_ac_c const*) {
-    return dComIfGp_event_getTalkPartner();
+    return (fopAc_ac_c*)dComIfGp_event_getTalkPartner();
 }
 
 /* 8001BB44-8001BB74 016484 0030+00 0/0 5/5 0/0 .text fopAcM_getItemEventPartner__FPC10fopAc_ac_c
  */
 fopAc_ac_c* fopAcM_getItemEventPartner(fopAc_ac_c const*) {
-    return dComIfGp_event_getItemPartner();
+    return (fopAc_ac_c*)dComIfGp_event_getItemPartner();
 }
 
 /* 8001BB74-8001BBE8 0164B4 0074+00 0/0 1/1 0/0 .text fopAcM_getEventPartner__FPC10fopAc_ac_c */
 fopAc_ac_c* fopAcM_getEventPartner(fopAc_ac_c const* i_actor) {
     if (dComIfGp_event_getPt1() != i_actor) {
-        return dComIfGp_event_getPt1();
+        return (fopAc_ac_c*)dComIfGp_event_getPt1();
     }
 
-    return dComIfGp_event_getPt2();
+    return (fopAc_ac_c*)dComIfGp_event_getPt2();
 }
 
 /* 8001BBE8-8001BC74 016528 008C+00 0/0 5/5 43/43 .text


### PR DESCRIPTION
The weird gameinfo load in daAlink_c::getDemoLookActor was caused by the redundant cast, some callers need the extra cast and some don't