### PR TITLE
d_a_bg_obj almost matching

### DIFF
--- a/include/d/actor/d_a_bg_obj.h
+++ b/include/d/actor/d_a_bg_obj.h
@@ -110,7 +110,7 @@ public:
     /* 0xCCA */ u16 field_0xcca;
     /* 0xCCC */ u16 field_0xccc;
     /* 0xCD0 */ spec_data_c mSpecData;
-    /* 0xCF4 */ csXyz field_0xcf4;
+    /* 0xCF4 */ csXyz mRotation;
     /* 0xCFC */ u32 mAttnActorID;
     /* 0xD00 */ u8 field_0xd00;
     /* 0xD01 */ u8 field_0xd01;

--- a/include/m_Do/m_Do_mtx.h
+++ b/include/m_Do/m_Do_mtx.h
@@ -345,6 +345,10 @@ public:
         MTXRotAxisRad(now, axis, rad);
     }
 
+    static void identity() {
+        MTXIdentity(now);
+    }
+
     static Mtx now;
     static Mtx buffer[16];
     static Mtx* next;


### PR DESCRIPTION
There are still a few remaining mismatches which I'm not quite sure how to deal with:

- Last `.bss` element is mismatched
- `"spec.dat"` string still has entry in `.dead` section (removing it messes up its placement in `.data`
- `.rodata` is missing 2 bytes of end padding(?)
- `daBgObj_c::spec_data_c::Set` has several instruction mismatches but I believe it is equivalent
- `daBgObj_c::initAtt` is missing a `nop`
- `daBgObj_c::setParticle` has an `addi` placed too early (but is equivalent)
- `daBgObj_c::orderWait_cyl` has `r30` and `r31` swapped