### PR TITLE
d_a_obj_laundry Equivalent

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1949,7 +1949,7 @@ config.libs = [
     ActorRel(Equivalent, "d_a_obj_kwheel00"), # weak func order
     ActorRel(Equivalent, "d_a_obj_kwheel01"), # weak func order
     ActorRel(NonMatching, "d_a_obj_kznkarm"),
-    ActorRel(NonMatching, "d_a_obj_laundry"),
+    ActorRel(Equivalent, "d_a_obj_laundry"), # weak func order
     ActorRel(NonMatching, "d_a_obj_laundry_rope"),
     ActorRel(MatchingFor("GZ2E01"), "d_a_obj_lbox"),
     ActorRel(NonMatching, "d_a_obj_lp"),

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -1,6 +1,7 @@
 #ifndef D_A_OBJ_LAUNDRY_H
 #define D_A_OBJ_LAUNDRY_H
 
+#include "d/d_cc_d.h"
 #include "f_op/f_op_actor_mng.h"
 
 /**
@@ -11,6 +12,18 @@
  * @details
  *
  */
+ class LaundJoint_c {
+    public:
+        /* 80C51D2C */ ~LaundJoint_c();
+        /* 80C51EC0 */ LaundJoint_c();
+    
+        cXyz pos1;
+        cXyz pos2;
+        cXyz pos3;
+        cXyz pos4;
+        csXyz angle;
+    };
+
 class daObjLdy_c : public fopAc_ac_c {
 public:
     /* 80C50F98 */ void create_init();
@@ -21,18 +34,18 @@ public:
     /* 80C51644 */ void calcJointAngle();
     /* 80C5183C */ bool divorceParent();
 
-    static u8 const M_attr[52];
-private:
-    /* 0x568 */ u8 field_0x568[0x7c8 - 0x568];
+    static f32 const M_attr[12];
+    static u8 const M_attr_u8[4];
+
+    /* 0x568 */ J3DModel* mpModel;
+    /* 0x56C */ u8 field_0x56C[0x570 - 0x56C];
+    /* 0x570 */ request_of_phase_process_class mPhase;
+    /* 0x578 */ Mtx mMtx;
+    /* 0x5A8 */ dCcD_Stts mStts;
+    /* 0x5E4 */ dCcD_Cyl mCyl;
+    /* 0x720 */ LaundJoint_c mJoints[3];
 };
 
 STATIC_ASSERT(sizeof(daObjLdy_c) == 0x7c8);
-
-class LaundJoint_c {
-public:
-    /* 80C51D2C */ ~LaundJoint_c();
-    /* 80C51EC0 */ LaundJoint_c();
-};
-
 
 #endif /* D_A_OBJ_LAUNDRY_H */

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -2,7 +2,7 @@
 #define D_A_OBJ_LAUNDRY_H
 
 #include "d/d_cc_d.h"
-#include "f_op/f_op_actor_mng.h"
+#include "f_op/f_op_actor.h"
 
 /**
  * @ingroup actors-objects

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -24,6 +24,24 @@ public:
     csXyz mAngle;
 };
 
+struct daObjLdy_Attr_c {
+    f32 field_0x0;
+    f32 field_0x4;
+    f32 field_0x8;
+    f32 field_0xc;
+    f32 field_0x10;
+    f32 field_0x14;
+    f32 field_0x18;
+    f32 field_0x1c;
+    f32 field_0x20;
+    f32 field_0x24;
+    f32 field_0x28;
+    f32 field_0x2c;
+    u16 field_0x30;
+    u8 field_0x32;
+    u8 field_0x33;
+};
+
 class daObjLdy_c : public fopAc_ac_c {
 public:
     /* 80C50F98 */ void create_init();
@@ -40,6 +58,8 @@ public:
     inline int getObjType();
     inline int daObjLdy_Draw();
     inline int daObjLdy_Execute();
+
+    static const daObjLdy_Attr_c mAttr;
 
 private:
     static f32 const M_attr[12];

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -59,11 +59,8 @@ public:
     inline int daObjLdy_Draw();
     inline int daObjLdy_Execute();
 
-    static const daObjLdy_Attr_c mAttr;
-
 private:
-    static f32 const M_attr[12];
-    static u8 const M_attr_u8[4];
+    static const daObjLdy_Attr_c mAttr;
 
     /* 0x568 */ J3DModel* mpModel;
     /* 0x56C */ mDoExt_btkAnm* mpBtkAnm;

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -12,17 +12,17 @@
  * @details
  *
  */
- class LaundJoint_c {
-    public:
-        /* 80C51D2C */ ~LaundJoint_c();
-        /* 80C51EC0 */ LaundJoint_c();
-    
-        cXyz pos1;
-        cXyz pos2;
-        cXyz pos3;
-        cXyz pos4;
-        csXyz angle;
-    };
+class LaundJoint_c {
+public:
+    /* 80C51D2C */ ~LaundJoint_c();
+    /* 80C51EC0 */ LaundJoint_c();
+
+    cXyz pos1;
+    cXyz pos2;
+    cXyz pos3;
+    cXyz pos4;
+    csXyz angle;
+};
 
 class daObjLdy_c : public fopAc_ac_c {
 public:
@@ -41,6 +41,7 @@ public:
     inline int daObjLdy_Draw();
     inline int daObjLdy_Execute();
 
+private:
     static f32 const M_attr[12];
     static u8 const M_attr_u8[4];
 

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -17,11 +17,11 @@ public:
     /* 80C51D2C */ ~LaundJoint_c();
     /* 80C51EC0 */ LaundJoint_c();
 
-    cXyz pos1;
-    cXyz pos2;
-    cXyz pos3;
-    cXyz pos4;
-    csXyz angle;
+    cXyz mPos1;
+    cXyz mPos2;
+    cXyz mPos3;
+    cXyz mPos4;
+    csXyz mAngle;
 };
 
 class daObjLdy_c : public fopAc_ac_c {

--- a/include/d/actor/d_a_obj_laundry.h
+++ b/include/d/actor/d_a_obj_laundry.h
@@ -34,11 +34,18 @@ public:
     /* 80C51644 */ void calcJointAngle();
     /* 80C5183C */ bool divorceParent();
 
+    inline ~daObjLdy_c();
+    inline int create();
+    inline int createHeap();
+    inline int getObjType();
+    inline int daObjLdy_Draw();
+    inline int daObjLdy_Execute();
+
     static f32 const M_attr[12];
     static u8 const M_attr_u8[4];
 
     /* 0x568 */ J3DModel* mpModel;
-    /* 0x56C */ u8 field_0x56C[0x570 - 0x56C];
+    /* 0x56C */ mDoExt_btkAnm* mpBtkAnm;
     /* 0x570 */ request_of_phase_process_class mPhase;
     /* 0x578 */ Mtx mMtx;
     /* 0x5A8 */ dCcD_Stts mStts;

--- a/include/d/d_kankyo_wether.h
+++ b/include/d/d_kankyo_wether.h
@@ -24,6 +24,7 @@ void dKyw_rain_set(int count);
 void dKyw_wind_set();
 cXyz* dKyw_get_wind_vec();
 cXyz dKyw_get_wind_vecpow();
+cXyz dKyw_get_AllWind_vecpow(cXyz* param_0);
 void dKyw_evt_wind_set(s16 angleX, s16 angleY);
 void dKyw_custom_windpower(f32 pow);
 void dKyw_evt_wind_set_go();

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -16,7 +16,8 @@
 
 /* ############################################################################################## */
 /* 80C52000-80C52034 000000 0034+00 3/3 0/0 0/0 .rodata          M_attr__10daObjLdy_c */
-daObjLdy_Attr_c const daObjLdy_c::mAttr = {5.0f, 30.0f, 130.0f, -50.0f, 0.15f, 0.45f, 0.3f, 1000.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0, 10, 0};
+daObjLdy_Attr_c const daObjLdy_c::mAttr = {5.0f, 30.0f, 130.0f, -50.0f, 0.15f, 0.45f, 0.3f, 1000.0f,
+                                           0.0f, 0.0f,  0.0f,   0.0f,   0,     10,    0};
 
 /* 80C50F98-80C51088 000078 00F0+00 1/1 0/0 0/0 .text            create_init__10daObjLdy_cFv */
 void daObjLdy_c::create_init() {

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -16,12 +16,7 @@
 
 /* ############################################################################################## */
 /* 80C52000-80C52034 000000 0034+00 3/3 0/0 0/0 .rodata          M_attr__10daObjLdy_c */
-SECTION_RODATA f32 const daObjLdy_c::M_attr[12] = {5.0, 30.0,   130.0, -50.0, 0.15, 0.45,
-                                                   0.3, 1000.0, 0.0,   0.0,   0.0,  0.0};
-COMPILER_STRIP_GATE(0x80C52000, &daObjLdy_c::M_attr);
-
-SECTION_RODATA u8 const daObjLdy_c::M_attr_u8[4] = {0x00, 0x00, 0x0A, 0x00};
-COMPILER_STRIP_GATE(0x80C52030, &daObjLdy_c::M_attr_u8);
+daObjLdy_Attr_c const daObjLdy_c::mAttr = {5.0f, 30.0f, 130.0f, -50.0f, 0.15f, 0.45f, 0.3f, 1000.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0, 10, 0};
 
 /* 80C50F98-80C51088 000078 00F0+00 1/1 0/0 0/0 .text            create_init__10daObjLdy_cFv */
 void daObjLdy_c::create_init() {
@@ -32,13 +27,13 @@ void daObjLdy_c::create_init() {
     int index = 0;
     for (int i = 0; i < 3; i++) {
         joint->mPos1 = current.pos;
-        joint->mPos1.y += (index + 1) * M_attr[3];
+        joint->mPos1.y += (index + 1) * mAttr.field_0xc;
         joint->mPos2 = joint->mPos1;
         index++;
         joint++;
     }
 
-    gravity = M_attr[0];
+    gravity = mAttr.field_0x0;
     initBaseMtx();
 }
 
@@ -95,7 +90,7 @@ static f32 dummy(cXyz v) {
 void daObjLdy_c::setNormalClothPos() {
     cXyz adjustedPosition;
     cXyz windVector = dKyw_get_AllWind_vecpow(&current.pos);
-    windVector *= M_attr[3] * M_attr[4];
+    windVector *= mAttr.field_0xc * mAttr.field_0x10;
     f32 windPower = windVector.abs();
     LaundJoint_c* joint = &mJoints[0];
 
@@ -107,7 +102,7 @@ void daObjLdy_c::setNormalClothPos() {
             position *= 100.0f;
             for (int i = 2; i >= 0; i--) {
                 mJoints[i].mPos3 = position;
-                position *= M_attr[6];
+                position *= mAttr.field_0x18;
             }
             divorceParent();
         } else {
@@ -123,7 +118,7 @@ void daObjLdy_c::setNormalClothPos() {
                 position *= 100.0f;
                 for (int i = 2; i >= 0; i--) {
                     mJoints[i].mPos3 = position;
-                    position *= M_attr[6];
+                    position *= mAttr.field_0x18;
                 }
                 divorceParent();
             }
@@ -147,8 +142,8 @@ void daObjLdy_c::setNormalClothPos() {
         adjustedPosition.y += gravity;
         adjustedPosition += mJoint->mPos3;
         adjustedPosition.normalizeZP();
-        mJoint->mPos1 = *currentPosition + (adjustedPosition * M_attr[3]);
-        mJoint->mPos3 = (mJoint->mPos3 + (mJoint->mPos2 - mJoint->mPos1)) * M_attr[5];
+        mJoint->mPos1 = *currentPosition + (adjustedPosition * mAttr.field_0xc);
+        mJoint->mPos3 = (mJoint->mPos3 + (mJoint->mPos2 - mJoint->mPos1)) * mAttr.field_0x14;
         mJoint->mPos2 = mJoint->mPos1;
         currentPosition = &mJoint->mPos1;
         mJoint++;
@@ -169,7 +164,7 @@ void daObjLdy_c::calcJointAngle() {
         joint->mAngle.x = cM_atan2s(position.z, position.y);
         joint->mAngle.z = cM_atan2s(-position.y, position.absXZ());
         mDoMtx_stack_c::XrotM(joint->mAngle.x);
-        mDoMtx_stack_c::transM(0.0f, M_attr[3], 0.0f);
+        mDoMtx_stack_c::transM(0.0f, mAttr.field_0xc, 0.0f);
         joint++;
     }
 }

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -178,64 +178,13 @@ const static dCcD_SrcCyl ccCylSrc = {
 };
 #pragma pop
 
-/* 80C52098-80C520A0 000098 0008+00 0/2 0/0 0/0 .rodata          @3855 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3855[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C52098, &lit_3855);
-#pragma pop
-
-/* 80C520A0-80C520A8 0000A0 0008+00 0/2 0/0 0/0 .rodata          @3856 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3856[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C520A0, &lit_3856);
-#pragma pop
-
-/* 80C520A8-80C520B0 0000A8 0008+00 0/2 0/0 0/0 .rodata          @3857 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_3857[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C520A8, &lit_3857);
-#pragma pop
-
-/* 80C520B0-80C520B4 0000B0 0004+00 0/0 0/0 0/0 .rodata          @3858 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3858 = 40.0f;
-COMPILER_STRIP_GATE(0x80C520B0, &lit_3858);
-#pragma pop
-
-/* 80C520B4-80C520B8 0000B4 0004+00 0/1 0/0 0/0 .rodata          @4041 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4041 = 100.0f;
-COMPILER_STRIP_GATE(0x80C520B4, &lit_4041);
-#pragma pop
-
-/* 80C520B8-80C520BC 0000B8 0004+00 0/1 0/0 0/0 .rodata          @4042 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4042 = 3.0f / 5.0f;
-COMPILER_STRIP_GATE(0x80C520B8, &lit_4042);
-#pragma pop
-
-/* 80C520BC-80C520C0 0000BC 0004+00 0/1 0/0 0/0 .rodata          @4043 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4043 = 1.0f / 10.0f;
-COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
-#pragma pop
+static f32 dummy(cXyz v) {
+    return 40.0f + v.abs();
+}
 
 /* 80C51194-80C51644 000274 04B0+00 1/1 0/0 0/0 .text            setNormalClothPos__10daObjLdy_cFv
  */
- void daObjLdy_c::setNormalClothPos() {
+void daObjLdy_c::setNormalClothPos() {
     cXyz adjustedPosition;
     cXyz windVector = dKyw_get_AllWind_vecpow(&current.pos);
     windVector *= M_attr[3] * M_attr[4];
@@ -253,7 +202,7 @@ COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
                 position *= M_attr[6];
             }
             divorceParent();            
-        }
+            }
         else{
             if (tgHitObj->ChkAtType(AT_TYPE_BOOMERANG) != 0){
                 divorceParent();
@@ -262,7 +211,7 @@ COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
     }
     else{        
         if (mCyl.ChkCoHit() != 0){
-            if (fopAcM_GetName(mCyl.GetCoHitAc()) == 256) {
+            if (fopAcM_GetName(mCyl.GetCoHitAc()) == AT_TYPE_100) {
                 cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
                 position.normalizeZP();
                 position *= 100.0f;
@@ -278,11 +227,11 @@ COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
                 for (int i = 0; i < 3; i++){
                     if (cM_rnd() < 0.6f && cM_rnd() < 0.1f){
                         joint->pos3 += joint->pos4 * windPower;
-                    }                    
+                    }                 
                     joint++;
                 }
             }
-        } 
+        }
     }
 
     int i;
@@ -301,17 +250,23 @@ COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
     }
 }
 
-/* ############################################################################################## */
-/* 80C520C0-80C520C4 0000C0 0004+00 0/1 0/0 0/0 .rodata          @4097 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4097 = -1.0f;
-COMPILER_STRIP_GATE(0x80C520C0, &lit_4097);
-#pragma pop
-
 /* 80C51644-80C5183C 000724 01F8+00 1/1 0/0 0/0 .text            calcJointAngle__10daObjLdy_cFv */
 void daObjLdy_c::calcJointAngle() {
-    // NONMATCHING
+    cXyz position;
+    LaundJoint_c* joint = &mJoints[0];
+    mDoMtx_stack_c::copy(mMtx);
+    for(int i = 0; i < 3; i++){
+        mDoMtx_stack_c::push();
+        mDoMtx_stack_c::inverse();
+        mDoMtx_stack_c::multVec(&joint->pos1, &position);
+        mDoMtx_stack_c::pop();
+        position *= -1.0f;
+        joint->angle.x = cM_atan2s(position.z, position.y);
+        joint->angle.z = cM_atan2s(-position.y, position.absXZ());
+        mDoMtx_stack_c::XrotM(joint->angle.x);
+        mDoMtx_stack_c::transM(0.0f, M_attr[3], 0.0f);
+        joint++;
+    }
 }
 
 /* 80C5183C-80C51844 00091C 0008+00 1/1 0/0 0/0 .text            divorceParent__10daObjLdy_cFv */
@@ -320,8 +275,24 @@ bool daObjLdy_c::divorceParent() {
 }
 
 /* 80C51844-80C518FC 000924 00B8+00 1/1 0/0 0/0 .text            nodeCallBack__FP8J3DJointi */
-static void nodeCallBack(J3DJoint* param_0, int param_1) {
-    // NONMATCHING
+static int nodeCallBack(J3DJoint* joint, int callbackCondition) {
+    J3DModel* jointModel;
+    u16 jointNo;
+    csXyz jointAngle[2];
+
+    if (callbackCondition != 0){
+        return 1;
+    }
+    
+    jointNo = joint->getJntNo();
+    jointModel = j3dSys.getModel();
+    ((daObjLdy_c*)jointModel->getUserArea())->getJointAngle(jointAngle, jointNo);
+    cMtx_copy(jointModel->getAnmMtx(jointNo), mDoMtx_stack_c::get());
+    mDoMtx_stack_c::XrotM(jointAngle->x);
+    jointModel->setAnmMtx(jointNo, mDoMtx_stack_c::get());
+    mDoMtx_copy(mDoMtx_stack_c::get(), J3DSys::mCurrentMtx);
+
+    return 1;
 }
 
 /* ############################################################################################## */
@@ -335,6 +306,7 @@ COMPILER_STRIP_GATE(0x80C520C4, &lit_4203);
 SECTION_DEAD static char const* const stringBase_80C520C8 = "J_Sentaku";
 SECTION_DEAD static char const* const stringBase_80C520D2 = "J_Sentaku.bmd";
 SECTION_DEAD static char const* const stringBase_80C520E0 = "J_Sentaku.btk";
+SECTION_DEAD static char const* const rodataPadding = "\0";
 #pragma pop
 
 /* 80C520F0-80C520F4 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
@@ -419,20 +391,20 @@ static void daObjLdy_Draw(daObjLdy_c* param_0) {
 }
 
 /* 80C51B9C-80C51BDC 000C7C 0040+00 1/0 0/0 0/0 .text            daObjLdy_Execute__FP10daObjLdy_c */
-static int daObjLdy_Execute(daObjLdy_c* param_0) {
-    param_0->setNormalClothPos();
-    param_0->setBaseMtx();
-    param_0->calcJointAngle();
+static int daObjLdy_Execute(daObjLdy_c* i_this) {
+    i_this->setNormalClothPos();
+    i_this->setBaseMtx();
+    i_this->calcJointAngle();
     return 1;
 }
 
 /* 80C51BDC-80C51BE4 000CBC 0008+00 1/0 0/0 0/0 .text            daObjLdy_IsDelete__FP10daObjLdy_c
  */
-static bool daObjLdy_IsDelete(daObjLdy_c* param_0) {
+static bool daObjLdy_IsDelete(daObjLdy_c* i_this) {
     return true;
 }
 
-/* 8045D11C-8045D144 0002BC 0028+00 1/0 0/0 0/0 .text            daDmidna_Delete__FP10daDmidna_c */
+/* 80C51BE4-80C51D2C 000CC4 0148+00 1/0 0/0 0/0 .text            daObjLdy_Delete__FP10daObjLdy_c */
 static int daObjLdy_Delete(daObjLdy_c* i_this) {
     if (i_this){
         dComIfG_resDelete(&i_this->mPhase, l_arcName);
@@ -442,14 +414,8 @@ static int daObjLdy_Delete(daObjLdy_c* i_this) {
     return 1;
 }
 
-/* 80C51BE4-80C51D2C 000CC4 0148+00 1/0 0/0 0/0 .text            daObjLdy_Delete__FP10daObjLdy_c */
-/*static void daObjLdy_Delete(daObjLdy_c* param_0) {
-    // NONMATCHING
-}*/
-
 /* 80C51D2C-80C51D68 000E0C 003C+00 2/2 0/0 0/0 .text            __dt__12LaundJoint_cFv */
 LaundJoint_c::~LaundJoint_c() {
-    // NONMATCHING
 }
 
 /* 80C51D68-80C51EC0 000E48 0158+00 1/0 0/0 0/0 .text            daObjLdy_Create__FP10fopAc_ac_c */
@@ -475,30 +441,6 @@ static int daObjLdy_Create(fopAc_ac_c* i_this) {
 /* 80C51EC0-80C51EC4 000FA0 0004+00 1/1 0/0 0/0 .text            __ct__12LaundJoint_cFv */
 LaundJoint_c::LaundJoint_c() {
     /* empty function */
-}
-
-/* 80C51EC4-80C51F0C 000FA4 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGCylFv */
-// cM3dGCyl::~cM3dGCyl() {
-extern "C" void __dt__8cM3dGCylFv() {
-    // NONMATCHING
-}
-
-/* 80C51F0C-80C51F54 000FEC 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGAabFv */
-// cM3dGAab::~cM3dGAab() {
-extern "C" void __dt__8cM3dGAabFv() {
-    // NONMATCHING
-}
-
-/* 80C51F54-80C51FB0 001034 005C+00 1/0 0/0 0/0 .text            __dt__10dCcD_GSttsFv */
-// dCcD_GStts::~dCcD_GStts() {
-extern "C" void __dt__10dCcD_GSttsFv() {
-    // NONMATCHING
-}
-
-/* 80C51FB0-80C51FF8 001090 0048+00 1/0 0/0 0/0 .text            __dt__10cCcD_GSttsFv */
-// cCcD_GStts::~cCcD_GStts() {
-extern "C" void __dt__10cCcD_GSttsFv() {
-    // NONMATCHING
 }
 
 /* 80C520C8-80C520C8 0000C8 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -72,8 +72,6 @@ void daObjLdy_c::getJointAngle(csXyz* jointAngle, int index) {
 
 /* ############################################################################################## */
 /* 80C52054-80C52098 000054 0044+00 0/0 0/0 0/0 .rodata          ccCylSrc$3800 */
-#pragma push
-#pragma force_active on
 const static dCcD_SrcCyl ccCylSrc = {
     {
         {0x0, {{0x0, 0x0, 0x0}, {0x16048, 0x11}, 0x149}},  // mObj
@@ -87,7 +85,6 @@ const static dCcD_SrcCyl ccCylSrc = {
         25.0f                  // mHeight
     }  // mCyl
 };
-#pragma pop
 
 static f32 dummy(cXyz v) {
     return 40.0f + v.abs();
@@ -313,6 +310,7 @@ static int daObjLdy_Create(fopAc_ac_c* i_this) {
 LaundJoint_c::LaundJoint_c() {
     /* empty function */
 }
+
 /* 80C520F4-80C52114 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjLdy_Method */
 static actor_method_class l_daObjLdy_Method = {
     (process_method_func)daObjLdy_Create,  (process_method_func)daObjLdy_Delete,

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -336,5 +336,6 @@ extern actor_process_profile_definition g_profile_Obj_Laundry = {
     fopAc_CULLBOX_CUSTOM_e,  // cullType
 };
 
-/* 80C520C8-80C520C8 0000C8 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-SECTION_DEAD static char const* const rodataPadding = "\0";
+static char* rodataPadding() {
+    return "\0";
+}

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -235,27 +235,27 @@ COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
 
 /* 80C51194-80C51644 000274 04B0+00 1/1 0/0 0/0 .text            setNormalClothPos__10daObjLdy_cFv
  */
-void daObjLdy_c::setNormalClothPos() {
+ void daObjLdy_c::setNormalClothPos() {
+    cXyz adjustedPosition;
     cXyz windVector = dKyw_get_AllWind_vecpow(&current.pos);
     windVector *= M_attr[3] * M_attr[4];
     float windPower = windVector.abs();
-    LaundJoint_c* joint2 = &mJoints[0];
+    LaundJoint_c* joint = &mJoints[0];
     
     if (mCyl.ChkTgHit() != 0){
         cCcD_Obj* tgHitObj = mCyl.GetTgHitObj();
-        if (tgHitObj->ChkAtType(64) != 0 || tgHitObj->ChkAtType(8192) != 0){
+        if (tgHitObj->ChkAtType(AT_TYPE_40) != 0 || tgHitObj->ChkAtType(AT_TYPE_ARROW) != 0){
             cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
             position.normalizeZP();
-            PSVECScale(&position, &position, 100.0f);
+            position *= 100.0f;
             for (int i = 2; i >= 0; i--){
                 mJoints[i].pos3 = position;
                 position *= M_attr[6];
             }
-            divorceParent();
-            
+            divorceParent();            
         }
         else{
-            if (tgHitObj->ChkAtType(65536) != 0){
+            if (tgHitObj->ChkAtType(AT_TYPE_BOOMERANG) != 0){
                 divorceParent();
             }
         }
@@ -265,7 +265,7 @@ void daObjLdy_c::setNormalClothPos() {
             if (fopAcM_GetName(mCyl.GetCoHitAc()) == 256) {
                 cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
                 position.normalizeZP();
-                PSVECScale(&position, &position, 100.0f);
+                position *= 100.0f;
                 for (int i = 2; i >= 0; i--){
                     mJoints[i].pos3 = position;
                     position *= M_attr[6];
@@ -277,27 +277,27 @@ void daObjLdy_c::setNormalClothPos() {
             if (!windVector.isZero()){
                 for (int i = 0; i < 3; i++){
                     if (cM_rnd() < 0.6f && cM_rnd() < 0.1f){
-                        joint2->pos3 += joint2->pos4 * windPower;
+                        joint->pos3 += joint->pos4 * windPower;
                     }                    
-                    joint2++;
+                    joint++;
                 }
             }
         } 
     }
 
     int i;
-    LaundJoint_c* joint = &mJoints[0];
+    LaundJoint_c* mJoint = &mJoints[0];
     cXyz* currentPosition = &fopAcM_GetPosition(this);
     for (i = 0; i < 3; i++){
-        cXyz temp = *currentPosition - joint->pos1;
-        temp.y += gravity;
-        joint->pos3 += temp;
-        temp.normalizeZP();
-        joint->pos1 = *currentPosition + (temp * M_attr[3]);
-        joint->pos3 = (joint->pos3 + (joint->pos2 - joint->pos1)) * M_attr[5];
-        joint->pos2 = joint->pos1;
-        currentPosition = &joint->pos1;
-        joint++;
+        adjustedPosition = *currentPosition - mJoint->pos1;
+        adjustedPosition.y += gravity;
+        adjustedPosition += mJoint->pos3;
+        adjustedPosition.normalizeZP();
+        mJoint->pos1 = *currentPosition + (adjustedPosition * M_attr[3]);
+        mJoint->pos3 = (mJoint->pos3 + (mJoint->pos2 - mJoint->pos1)) * M_attr[5];
+        mJoint->pos2 = mJoint->pos1;
+        currentPosition = &mJoint->pos1;
+        mJoint++;
     }
 }
 

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -5,9 +5,10 @@
 
 #include "d/actor/d_a_obj_laundry.h"
 #include "d/d_cc_d.h"
+#include "d/d_com_inf_game.h"
+#include "d/d_kankyo_wether.h"
 #include "dol2asm.h"
-
-
+#include "SSystem/SComponent/c_math.h"
 
 //
 // Forward References:
@@ -93,7 +94,6 @@ extern "C" extern void* __vt__12cCcD_CylAttr[25];
 extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_dComIfG_gameInfo[122384];
 extern "C" u8 mCurrentMtx__6J3DSys[48];
 extern "C" u8 sincosTable___5JMath[65536];
 
@@ -103,83 +103,60 @@ extern "C" u8 sincosTable___5JMath[65536];
 
 /* ############################################################################################## */
 /* 80C52000-80C52034 000000 0034+00 3/3 0/0 0/0 .rodata          M_attr__10daObjLdy_c */
-SECTION_RODATA u8 const daObjLdy_c::M_attr[52] = {
-    0x40, 0xA0, 0x00, 0x00, 0x41, 0xF0, 0x00, 0x00, 0x43, 0x02, 0x00, 0x00, 0xC2,
-    0x48, 0x00, 0x00, 0x3E, 0x19, 0x99, 0x9A, 0x3E, 0xE6, 0x66, 0x66, 0x3E, 0x99,
-    0x99, 0x9A, 0x44, 0x7A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0x00,
+SECTION_RODATA f32 const daObjLdy_c::M_attr[12] = {
+     5.0, 30.0, 130.0, -50.0, 0.15, 0.45, 0.3, 1000.0, 0.0, 0.0, 0.0, 0.0
 };
 COMPILER_STRIP_GATE(0x80C52000, &daObjLdy_c::M_attr);
 
-/* 80C52034-80C52038 000034 0004+00 0/1 0/0 0/0 .rodata          @3751 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3751 = -60.0f;
-COMPILER_STRIP_GATE(0x80C52034, &lit_3751);
-#pragma pop
+SECTION_RODATA u8 const daObjLdy_c::M_attr_u8[4] = {0x00, 0x00, 0x0A, 0x00};
+COMPILER_STRIP_GATE(0x80C52030, &daObjLdy_c::M_attr_u8);
 
-/* 80C52038-80C5203C 000038 0004+00 0/1 0/0 0/0 .rodata          @3752 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3752 = -200.0f;
-COMPILER_STRIP_GATE(0x80C52038, &lit_3752);
-#pragma pop
-
-/* 80C5203C-80C52040 00003C 0004+00 0/1 0/0 0/0 .rodata          @3753 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3753 = 60.0f;
-COMPILER_STRIP_GATE(0x80C5203C, &lit_3753);
-#pragma pop
-
-/* 80C52040-80C52044 000040 0004+00 0/1 0/0 0/0 .rodata          @3754 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3754 = 50.0f;
-COMPILER_STRIP_GATE(0x80C52040, &lit_3754);
-#pragma pop
-
-/* 80C52044-80C52048 000044 0004+00 0/1 0/0 0/0 .rodata          @3755 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_3755 = 1.5f;
-COMPILER_STRIP_GATE(0x80C52044, &lit_3755);
-#pragma pop
-
-/* 80C52048-80C52050 000048 0008+00 1/2 0/0 0/0 .rodata          @3757 */
-SECTION_RODATA static u8 const lit_3757[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80C52048, &lit_3757);
 
 /* 80C50F98-80C51088 000078 00F0+00 1/1 0/0 0/0 .text            create_init__10daObjLdy_cFv */
 void daObjLdy_c::create_init() {
-    // NONMATCHING
-}
+    fopAcM_setCullSizeBox(this, -60.0f, -200.0f, -60.0f, 60.0f, 50.0f, 60.0f);
+    fopAcM_setCullSizeFar(this, 1.5f);
+    
+    LaundJoint_c* joint = &mJoints[0];
+    int index = 0;
+    for (int i = 0; i < 3; i++) {
+        joint->pos1 = current.pos;
+        joint->pos1.y += (index + 1) * M_attr[3];
+        joint->pos2 = joint->pos1;
+        index++;
+        joint++;
+    }
 
-/* ############################################################################################## */
-/* 80C52050-80C52054 000050 0004+00 1/3 0/0 0/0 .rodata          @3782 */
-SECTION_RODATA static u8 const lit_3782[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80C52050, &lit_3782);
+    gravity = M_attr[0];
+    initBaseMtx();
+}
 
 /* 80C51088-80C510F8 000168 0070+00 1/1 0/0 0/0 .text            initBaseMtx__10daObjLdy_cFv */
 void daObjLdy_c::initBaseMtx() {
-    // NONMATCHING
+    setBaseMtx();
+
+    LaundJoint_c* joint = &mJoints[0];
+    for (int i = 0; i < 3; i++){
+        float cosAngleY = cM_scos(shape_angle.y);
+        float sinAngleY = cM_ssin(shape_angle.y);
+        joint->pos4.set(sinAngleY, 0.0f, cosAngleY);
+        joint++;
+    }
 }
 
 /* 80C510F8-80C5116C 0001D8 0074+00 2/2 0/0 0/0 .text            setBaseMtx__10daObjLdy_cFv */
 void daObjLdy_c::setBaseMtx() {
-    // NONMATCHING
+    mDoMtx_stack_c::transS(current.pos);
+    mDoMtx_stack_c::YrotM(shape_angle.y);
+    mDoMtx_stack_c::ZrotM(shape_angle.z);
+    mpModel->setBaseTRMtx(mDoMtx_stack_c::get());
+    PSMTXCopy(mDoMtx_stack_c::get(), mMtx);
 }
 
 /* 80C5116C-80C51194 00024C 0028+00 1/1 0/0 0/0 .text getJointAngle__10daObjLdy_cFP5csXyzi */
-void daObjLdy_c::getJointAngle(csXyz* param_0, int param_1) {
-    // NONMATCHING
+void daObjLdy_c::getJointAngle(csXyz* jointAngle, int index) {
+    LaundJoint_c* joint = &mJoints[index];
+    *jointAngle = joint->angle;
 }
 
 /* ############################################################################################## */
@@ -259,7 +236,69 @@ COMPILER_STRIP_GATE(0x80C520BC, &lit_4043);
 /* 80C51194-80C51644 000274 04B0+00 1/1 0/0 0/0 .text            setNormalClothPos__10daObjLdy_cFv
  */
 void daObjLdy_c::setNormalClothPos() {
-    // NONMATCHING
+    cXyz windVector = dKyw_get_AllWind_vecpow(&current.pos);
+    windVector *= M_attr[3] * M_attr[4];
+    float windPower = windVector.abs();
+    LaundJoint_c* joint2 = &mJoints[0];
+    
+    if (mCyl.ChkTgHit() != 0){
+        cCcD_Obj* tgHitObj = mCyl.GetTgHitObj();
+        if (tgHitObj->ChkAtType(64) != 0 || tgHitObj->ChkAtType(8192) != 0){
+            cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
+            position.normalizeZP();
+            PSVECScale(&position, &position, 100.0f);
+            for (int i = 2; i >= 0; i--){
+                mJoints[i].pos3 = position;
+                position *= M_attr[6];
+            }
+            divorceParent();
+            
+        }
+        else{
+            if (tgHitObj->ChkAtType(65536) != 0){
+                divorceParent();
+            }
+        }
+    }
+    else{        
+        if (mCyl.ChkCoHit() != 0){
+            if (fopAcM_GetName(mCyl.GetCoHitAc()) == 256) {
+                cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
+                position.normalizeZP();
+                PSVECScale(&position, &position, 100.0f);
+                for (int i = 2; i >= 0; i--){
+                    mJoints[i].pos3 = position;
+                    position *= M_attr[6];
+                }
+                divorceParent();
+            }
+        }
+        else{
+            if (!windVector.isZero()){
+                for (int i = 0; i < 3; i++){
+                    if (cM_rnd() < 0.6f && cM_rnd() < 0.1f){
+                        joint2->pos3 += joint2->pos4 * windPower;
+                    }                    
+                    joint2++;
+                }
+            }
+        } 
+    }
+
+    int i;
+    LaundJoint_c* joint = &mJoints[0];
+    cXyz* currentPosition = &fopAcM_GetPosition(this);
+    for (i = 0; i < 3; i++){
+        cXyz temp = *currentPosition - joint->pos1;
+        temp.y += gravity;
+        joint->pos3 += temp;
+        temp.normalizeZP();
+        joint->pos1 = *currentPosition + (temp * M_attr[3]);
+        joint->pos3 = (joint->pos3 + (joint->pos2 - joint->pos1)) * M_attr[5];
+        joint->pos2 = joint->pos1;
+        currentPosition = &joint->pos1;
+        joint++;
+    }
 }
 
 /* ############################################################################################## */
@@ -299,7 +338,7 @@ SECTION_DEAD static char const* const stringBase_80C520E0 = "J_Sentaku.btk";
 #pragma pop
 
 /* 80C520F0-80C520F4 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
-SECTION_DATA static void* l_arcName = (void*)&d_a_obj_laundry__stringBase0;
+static char* l_arcName = "J_Sentaku";
 
 /* 80C520F4-80C52114 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjLdy_Method */
 static actor_method_class l_daObjLdy_Method = {
@@ -364,7 +403,7 @@ SECTION_DATA extern void* __vt__12J3DFrameCtrl[3] = {
 };
 
 /* 80C518FC-80C51A98 0009DC 019C+00 1/1 0/0 0/0 .text            createSolidHeap__FP10fopAc_ac_c */
-static void createSolidHeap(fopAc_ac_c* param_0) {
+static int createSolidHeap(fopAc_ac_c* param_0) {
     // NONMATCHING
 }
 
@@ -380,8 +419,11 @@ static void daObjLdy_Draw(daObjLdy_c* param_0) {
 }
 
 /* 80C51B9C-80C51BDC 000C7C 0040+00 1/0 0/0 0/0 .text            daObjLdy_Execute__FP10daObjLdy_c */
-static void daObjLdy_Execute(daObjLdy_c* param_0) {
-    // NONMATCHING
+static int daObjLdy_Execute(daObjLdy_c* param_0) {
+    param_0->setNormalClothPos();
+    param_0->setBaseMtx();
+    param_0->calcJointAngle();
+    return 1;
 }
 
 /* 80C51BDC-80C51BE4 000CBC 0008+00 1/0 0/0 0/0 .text            daObjLdy_IsDelete__FP10daObjLdy_c
@@ -390,10 +432,20 @@ static bool daObjLdy_IsDelete(daObjLdy_c* param_0) {
     return true;
 }
 
-/* 80C51BE4-80C51D2C 000CC4 0148+00 1/0 0/0 0/0 .text            daObjLdy_Delete__FP10daObjLdy_c */
-static void daObjLdy_Delete(daObjLdy_c* param_0) {
-    // NONMATCHING
+/* 8045D11C-8045D144 0002BC 0028+00 1/0 0/0 0/0 .text            daDmidna_Delete__FP10daDmidna_c */
+static int daObjLdy_Delete(daObjLdy_c* i_this) {
+    if (i_this){
+        dComIfG_resDelete(&i_this->mPhase, l_arcName);
+        i_this->~daObjLdy_c();
+    }
+    
+    return 1;
 }
+
+/* 80C51BE4-80C51D2C 000CC4 0148+00 1/0 0/0 0/0 .text            daObjLdy_Delete__FP10daObjLdy_c */
+/*static void daObjLdy_Delete(daObjLdy_c* param_0) {
+    // NONMATCHING
+}*/
 
 /* 80C51D2C-80C51D68 000E0C 003C+00 2/2 0/0 0/0 .text            __dt__12LaundJoint_cFv */
 LaundJoint_c::~LaundJoint_c() {
@@ -401,8 +453,23 @@ LaundJoint_c::~LaundJoint_c() {
 }
 
 /* 80C51D68-80C51EC0 000E48 0158+00 1/0 0/0 0/0 .text            daObjLdy_Create__FP10fopAc_ac_c */
-static void daObjLdy_Create(fopAc_ac_c* param_0) {
-    // NONMATCHING
+
+static int daObjLdy_Create(fopAc_ac_c* i_this) {
+    daObjLdy_c* a_this = static_cast<daObjLdy_c*>(i_this);
+    fopAcM_SetupActor(a_this, daObjLdy_c);
+
+    int phase = dComIfG_resLoad(&a_this->mPhase, l_arcName);
+    if (phase == cPhs_COMPLEATE_e) {
+        if (!fopAcM_entrySolidHeap(a_this, createSolidHeap, 0x9a0)) {
+            phase = cPhs_ERROR_e;
+        }
+        else{
+            a_this->create_init();
+            i_this->cullMtx = a_this->mMtx;
+        }
+    }
+
+    return phase;
 }
 
 /* 80C51EC0-80C51EC4 000FA0 0004+00 1/1 0/0 0/0 .text            __ct__12LaundJoint_cFv */

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -1,101 +1,14 @@
 /**
  * @file d_a_obj_laundry.cpp
- * 
-*/
+ *
+ */
 
 #include "d/actor/d_a_obj_laundry.h"
+#include "SSystem/SComponent/c_math.h"
 #include "d/d_cc_d.h"
 #include "d/d_com_inf_game.h"
 #include "d/d_kankyo_wether.h"
 #include "dol2asm.h"
-#include "SSystem/SComponent/c_math.h"
-
-//
-// Forward References:
-//
-
-extern "C" void create_init__10daObjLdy_cFv();
-extern "C" void initBaseMtx__10daObjLdy_cFv();
-extern "C" void setBaseMtx__10daObjLdy_cFv();
-extern "C" void getJointAngle__10daObjLdy_cFP5csXyzi();
-extern "C" void setNormalClothPos__10daObjLdy_cFv();
-extern "C" void calcJointAngle__10daObjLdy_cFv();
-extern "C" bool divorceParent__10daObjLdy_cFv();
-extern "C" static void nodeCallBack__FP8J3DJointi();
-extern "C" static void createSolidHeap__FP10fopAc_ac_c();
-extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" static void daObjLdy_Draw__FP10daObjLdy_c();
-extern "C" static void daObjLdy_Execute__FP10daObjLdy_c();
-extern "C" static bool daObjLdy_IsDelete__FP10daObjLdy_c();
-extern "C" static void daObjLdy_Delete__FP10daObjLdy_c();
-extern "C" void __dt__12LaundJoint_cFv();
-extern "C" static void daObjLdy_Create__FP10fopAc_ac_c();
-extern "C" void __ct__12LaundJoint_cFv();
-extern "C" void __dt__8cM3dGCylFv();
-extern "C" void __dt__8cM3dGAabFv();
-extern "C" void __dt__10dCcD_GSttsFv();
-extern "C" void __dt__10cCcD_GSttsFv();
-extern "C" u8 const M_attr__10daObjLdy_c[52];
-extern "C" extern char const* const d_a_obj_laundry__stringBase0;
-
-//
-// External References:
-//
-
-extern "C" void mDoMtx_XrotM__FPA4_fs();
-extern "C" void mDoMtx_YrotM__FPA4_fs();
-extern "C" void mDoMtx_ZrotM__FPA4_fs();
-extern "C" void push__14mDoMtx_stack_cFv();
-extern "C" void pop__14mDoMtx_stack_cFv();
-extern "C" void transS__14mDoMtx_stack_cFRC4cXyz();
-extern "C" void transM__14mDoMtx_stack_cFfff();
-extern "C" void init__13mDoExt_btkAnmFP16J3DMaterialTableP19J3DAnmTextureSRTKeyiifss();
-extern "C" void entry__13mDoExt_btkAnmFP16J3DMaterialTablef();
-extern "C" void mDoExt_modelUpdateDL__FP8J3DModel();
-extern "C" void mDoExt_J3DModel__create__FP12J3DModelDataUlUl();
-extern "C" void __ct__10fopAc_ac_cFv();
-extern "C" void __dt__10fopAc_ac_cFv();
-extern "C" void fopAcM_entrySolidHeap__FP10fopAc_ac_cPFP10fopAc_ac_c_iUl();
-extern "C" void fopAcM_setCullSizeBox__FP10fopAc_ac_cffffff();
-extern "C" void dComIfG_resLoad__FP30request_of_phase_process_classPCc();
-extern "C" void dComIfG_resDelete__FP30request_of_phase_process_classPCc();
-extern "C" void getRes__14dRes_control_cFPCcPCcP11dRes_info_ci();
-extern "C" void dKyw_get_AllWind_vecpow__FP4cXyz();
-extern "C" void GetAc__22dCcD_GAtTgCoCommonBaseFv();
-extern "C" void __ct__10dCcD_GSttsFv();
-extern "C" void __ct__12dCcD_GObjInfFv();
-extern "C" void __dt__12dCcD_GObjInfFv();
-extern "C" void ChkTgHit__12dCcD_GObjInfFv();
-extern "C" void GetTgHitObj__12dCcD_GObjInfFv();
-extern "C" void ChkCoHit__12dCcD_GObjInfFv();
-extern "C" void settingTevStruct__18dScnKy_env_light_cFiP4cXyzP12dKy_tevstr_c();
-extern "C" void setLightTevColorType_MAJI__18dScnKy_env_light_cFP12J3DModelDataP12dKy_tevstr_c();
-extern "C" void __pl__4cXyzCFRC3Vec();
-extern "C" void __mi__4cXyzCFRC3Vec();
-extern "C" void __ml__4cXyzCFf();
-extern "C" void normalizeZP__4cXyzFv();
-extern "C" void isZero__4cXyzCFv();
-extern "C" void cM_atan2s__Fff();
-extern "C" void cM_rnd__Fv();
-extern "C" void* __nw__FUl();
-extern "C" void __dl__FPv();
-extern "C" void init__12J3DFrameCtrlFs();
-extern "C" void __destroy_arr();
-extern "C" void __construct_array();
-extern "C" void _savegpr_25();
-extern "C" void _savegpr_28();
-extern "C" void _savegpr_29();
-extern "C" void _restgpr_25();
-extern "C" void _restgpr_28();
-extern "C" void _restgpr_29();
-extern "C" extern void* __vt__8dCcD_Cyl[36];
-extern "C" extern void* __vt__9dCcD_Stts[11];
-extern "C" extern void* __vt__12cCcD_CylAttr[25];
-extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
-extern "C" extern void* __vt__9cCcD_Stts[8];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" u8 mCurrentMtx__6J3DSys[48];
-extern "C" u8 sincosTable___5JMath[65536];
 
 //
 // Declarations:
@@ -103,20 +16,18 @@ extern "C" u8 sincosTable___5JMath[65536];
 
 /* ############################################################################################## */
 /* 80C52000-80C52034 000000 0034+00 3/3 0/0 0/0 .rodata          M_attr__10daObjLdy_c */
-SECTION_RODATA f32 const daObjLdy_c::M_attr[12] = {
-     5.0, 30.0, 130.0, -50.0, 0.15, 0.45, 0.3, 1000.0, 0.0, 0.0, 0.0, 0.0
-};
+SECTION_RODATA f32 const daObjLdy_c::M_attr[12] = {5.0, 30.0,   130.0, -50.0, 0.15, 0.45,
+                                                   0.3, 1000.0, 0.0,   0.0,   0.0,  0.0};
 COMPILER_STRIP_GATE(0x80C52000, &daObjLdy_c::M_attr);
 
 SECTION_RODATA u8 const daObjLdy_c::M_attr_u8[4] = {0x00, 0x00, 0x0A, 0x00};
 COMPILER_STRIP_GATE(0x80C52030, &daObjLdy_c::M_attr_u8);
 
-
 /* 80C50F98-80C51088 000078 00F0+00 1/1 0/0 0/0 .text            create_init__10daObjLdy_cFv */
 void daObjLdy_c::create_init() {
     fopAcM_setCullSizeBox(this, -60.0f, -200.0f, -60.0f, 60.0f, 50.0f, 60.0f);
     fopAcM_setCullSizeFar(this, 1.5f);
-    
+
     LaundJoint_c* joint = &mJoints[0];
     int index = 0;
     for (int i = 0; i < 3; i++) {
@@ -136,7 +47,7 @@ void daObjLdy_c::initBaseMtx() {
     setBaseMtx();
 
     LaundJoint_c* joint = &mJoints[0];
-    for (int i = 0; i < 3; i++){
+    for (int i = 0; i < 3; i++) {
         float cosAngleY = cM_scos(shape_angle.y);
         float sinAngleY = cM_ssin(shape_angle.y);
         joint->pos4.set(sinAngleY, 0.0f, cosAngleY);
@@ -165,16 +76,16 @@ void daObjLdy_c::getJointAngle(csXyz* jointAngle, int index) {
 #pragma force_active on
 const static dCcD_SrcCyl ccCylSrc = {
     {
-        {0x0, {{0x0, 0x0, 0x0}, {0x16048, 0x11}, 0x149}}, // mObj
-        {dCcD_SE_NONE, 0x0, 0x0, 0x0, 0x0}, // mGObjAt
-        {dCcD_SE_NONE, 0x0, 0x0, 0x0, 0x4}, // mGObjTg
-        {0x0}, // mGObjCo
-    }, // mObjInf
+        {0x0, {{0x0, 0x0, 0x0}, {0x16048, 0x11}, 0x149}},  // mObj
+        {dCcD_SE_NONE, 0x0, 0x0, 0x0, 0x0},                // mGObjAt
+        {dCcD_SE_NONE, 0x0, 0x0, 0x0, 0x4},                // mGObjTg
+        {0x0},                                             // mGObjCo
+    },                                                     // mObjInf
     {
-        {0.0f, -80.0f, 0.0f}, // mCenter
-        25.0f, // mRadius
-        25.0f // mHeight
-    } // mCyl
+        {0.0f, -80.0f, 0.0f},  // mCenter
+        25.0f,                 // mRadius
+        25.0f                  // mHeight
+    }  // mCyl
 };
 #pragma pop
 
@@ -190,44 +101,41 @@ void daObjLdy_c::setNormalClothPos() {
     windVector *= M_attr[3] * M_attr[4];
     float windPower = windVector.abs();
     LaundJoint_c* joint = &mJoints[0];
-    
-    if (mCyl.ChkTgHit() != 0){
+
+    if (mCyl.ChkTgHit() != 0) {
         cCcD_Obj* tgHitObj = mCyl.GetTgHitObj();
-        if (tgHitObj->ChkAtType(AT_TYPE_40) != 0 || tgHitObj->ChkAtType(AT_TYPE_ARROW) != 0){
+        if (tgHitObj->ChkAtType(AT_TYPE_40) != 0 || tgHitObj->ChkAtType(AT_TYPE_ARROW) != 0) {
             cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
             position.normalizeZP();
             position *= 100.0f;
-            for (int i = 2; i >= 0; i--){
+            for (int i = 2; i >= 0; i--) {
                 mJoints[i].pos3 = position;
                 position *= M_attr[6];
             }
-            divorceParent();            
-            }
-        else{
-            if (tgHitObj->ChkAtType(AT_TYPE_BOOMERANG) != 0){
+            divorceParent();
+        } else {
+            if (tgHitObj->ChkAtType(AT_TYPE_BOOMERANG) != 0) {
                 divorceParent();
             }
         }
-    }
-    else{        
-        if (mCyl.ChkCoHit() != 0){
+    } else {
+        if (mCyl.ChkCoHit() != 0) {
             if (fopAcM_GetName(mCyl.GetCoHitAc()) == AT_TYPE_100) {
                 cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
                 position.normalizeZP();
                 position *= 100.0f;
-                for (int i = 2; i >= 0; i--){
+                for (int i = 2; i >= 0; i--) {
                     mJoints[i].pos3 = position;
                     position *= M_attr[6];
                 }
                 divorceParent();
             }
-        }
-        else{
-            if (!windVector.isZero()){
-                for (int i = 0; i < 3; i++){
-                    if (cM_rnd() < 0.6f && cM_rnd() < 0.1f){
+        } else {
+            if (!windVector.isZero()) {
+                for (int i = 0; i < 3; i++) {
+                    if (cM_rnd() < 0.6f && cM_rnd() < 0.1f) {
                         joint->pos3 += joint->pos4 * windPower;
-                    }                 
+                    }
                     joint++;
                 }
             }
@@ -237,7 +145,7 @@ void daObjLdy_c::setNormalClothPos() {
     int i;
     LaundJoint_c* mJoint = &mJoints[0];
     cXyz* currentPosition = &fopAcM_GetPosition(this);
-    for (i = 0; i < 3; i++){
+    for (i = 0; i < 3; i++) {
         adjustedPosition = *currentPosition - mJoint->pos1;
         adjustedPosition.y += gravity;
         adjustedPosition += mJoint->pos3;
@@ -255,7 +163,7 @@ void daObjLdy_c::calcJointAngle() {
     cXyz position;
     LaundJoint_c* joint = &mJoints[0];
     mDoMtx_stack_c::copy(mMtx);
-    for(int i = 0; i < 3; i++){
+    for (int i = 0; i < 3; i++) {
         mDoMtx_stack_c::push();
         mDoMtx_stack_c::inverse();
         mDoMtx_stack_c::multVec(&joint->pos1, &position);
@@ -280,10 +188,10 @@ static int nodeCallBack(J3DJoint* joint, int callbackCondition) {
     u16 jointNo;
     csXyz jointAngle[2];
 
-    if (callbackCondition != 0){
+    if (callbackCondition != 0) {
         return 1;
     }
-    
+
     jointNo = joint->getJntNo();
     jointModel = j3dSys.getModel();
     ((daObjLdy_c*)jointModel->getUserArea())->getJointAngle(jointAngle, jointNo);
@@ -295,107 +203,73 @@ static int nodeCallBack(J3DJoint* joint, int callbackCondition) {
     return 1;
 }
 
-/* ############################################################################################## */
-/* 80C520C4-80C520C8 0000C4 0004+00 1/1 0/0 0/0 .rodata          @4203 */
-SECTION_RODATA static f32 const lit_4203 = 1.0f;
-COMPILER_STRIP_GATE(0x80C520C4, &lit_4203);
-
-/* 80C520C8-80C520C8 0000C8 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
-#pragma push
-#pragma force_active on
-SECTION_DEAD static char const* const stringBase_80C520C8 = "J_Sentaku";
-SECTION_DEAD static char const* const stringBase_80C520D2 = "J_Sentaku.bmd";
-SECTION_DEAD static char const* const stringBase_80C520E0 = "J_Sentaku.btk";
-SECTION_DEAD static char const* const rodataPadding = "\0";
-#pragma pop
-
 /* 80C520F0-80C520F4 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
 static char* l_arcName = "J_Sentaku";
 
-/* 80C520F4-80C52114 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjLdy_Method */
-static actor_method_class l_daObjLdy_Method = {
-    (process_method_func)daObjLdy_Create__FP10fopAc_ac_c,
-    (process_method_func)daObjLdy_Delete__FP10daObjLdy_c,
-    (process_method_func)daObjLdy_Execute__FP10daObjLdy_c,
-    (process_method_func)daObjLdy_IsDelete__FP10daObjLdy_c,
-    (process_method_func)daObjLdy_Draw__FP10daObjLdy_c,
-};
 
-/* 80C52114-80C52144 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_Laundry */
-extern actor_process_profile_definition g_profile_Obj_Laundry = {
-  fpcLy_CURRENT_e,        // mLayerID
-  7,                      // mListID
-  fpcPi_CURRENT_e,        // mListPrio
-  PROC_Obj_Laundry,       // mProcName
-  &g_fpcLf_Method.base,  // sub_method
-  sizeof(daObjLdy_c),     // mSize
-  0,                      // mSizeOther
-  0,                      // mParameters
-  &g_fopAc_Method.base,   // sub_method
-  37,                     // mPriority
-  &l_daObjLdy_Method,     // sub_method
-  0x00040180,             // mStatus
-  fopAc_ACTOR_e,          // mActorType
-  fopAc_CULLBOX_CUSTOM_e, // cullType
-};
 
-/* 80C52144-80C52150 000054 000C+00 3/3 0/0 0/0 .data            __vt__10cCcD_GStts */
-SECTION_DATA extern void* __vt__10cCcD_GStts[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__10cCcD_GSttsFv,
-};
-
-/* 80C52150-80C5215C 000060 000C+00 2/2 0/0 0/0 .data            __vt__10dCcD_GStts */
-SECTION_DATA extern void* __vt__10dCcD_GStts[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__10dCcD_GSttsFv,
-};
-
-/* 80C5215C-80C52168 00006C 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGAab */
-SECTION_DATA extern void* __vt__8cM3dGAab[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGAabFv,
-};
-
-/* 80C52168-80C52174 000078 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGCyl */
-SECTION_DATA extern void* __vt__8cM3dGCyl[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGCylFv,
-};
-
-/* 80C52174-80C52180 000084 000C+00 2/2 0/0 0/0 .data            __vt__12J3DFrameCtrl */
-SECTION_DATA extern void* __vt__12J3DFrameCtrl[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__12J3DFrameCtrlFv,
-};
-
-/* 80C518FC-80C51A98 0009DC 019C+00 1/1 0/0 0/0 .text            createSolidHeap__FP10fopAc_ac_c */
-static int createSolidHeap(fopAc_ac_c* param_0) {
-    // NONMATCHING
+int daObjLdy_c::getObjType() {
+    return fopAcM_GetParam(this) & 0xff;
 }
 
-/* 80C51A98-80C51AE0 000B78 0048+00 1/0 0/0 0/0 .text            __dt__12J3DFrameCtrlFv */
-// J3DFrameCtrl::~J3DFrameCtrl() {
-extern "C" void __dt__12J3DFrameCtrlFv() {
-    // NONMATCHING
+int daObjLdy_c::createHeap() {
+    J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes(l_arcName, "J_Sentaku.bmd");
+    mpModel = mDoExt_J3DModel__create(modelData, 0x80000, 0x11000284);
+    J3DAnmTextureSRTKey* key =
+        (J3DAnmTextureSRTKey*)dComIfG_getObjectRes(l_arcName, "J_Sentaku.btk");
+
+    mpBtkAnm = new mDoExt_btkAnm();
+    int initResult = mpBtkAnm->init(modelData, key, 1, 2, 1.0f, 0, -1);
+    if (initResult == 0) {
+        return 0;
+    }
+
+    mpBtkAnm->setFrame(getObjType());
+    for (u16 i = 0; i < 3; i++) {
+        J3DJoint* joint = mpModel->getModelData()->getJointNodePointer(i);
+        if (joint != NULL) {
+            joint->setCallBack(nodeCallBack);
+            mpModel->setUserArea((u32)this);
+        }
+    }
+
+    if (mpModel == NULL) {
+        return 0;
+    }
+
+    return 1;
+}
+
+/* 80C518FC-80C51A98 0009DC 019C+00 1/1 0/0 0/0 .text            createSolidHeap__FP10fopAc_ac_c */
+static int createSolidHeap(fopAc_ac_c* i_this) {
+    return static_cast<daObjLdy_c*>(i_this)->createHeap();
+}
+
+int daObjLdy_c::daObjLdy_Draw() {
+    g_env_light.settingTevStruct(0x10, &current.pos, &tevStr);
+    g_env_light.setLightTevColorType_MAJI(mpModel, &tevStr);
+    dComIfGd_setListBG();
+    mpBtkAnm->entry(mpModel->getModelData());
+    mDoExt_modelUpdateDL(mpModel);
+    dComIfGd_setList();
+    return 1;
 }
 
 /* 80C51AE0-80C51B9C 000BC0 00BC+00 1/0 0/0 0/0 .text            daObjLdy_Draw__FP10daObjLdy_c */
-static void daObjLdy_Draw(daObjLdy_c* param_0) {
-    // NONMATCHING
+static int daObjLdy_Draw(daObjLdy_c* i_this) {
+    return i_this->daObjLdy_Draw();
+}
+
+int daObjLdy_c::daObjLdy_Execute() {
+    setNormalClothPos();
+    setBaseMtx();
+    calcJointAngle();
+    return 1;
 }
 
 /* 80C51B9C-80C51BDC 000C7C 0040+00 1/0 0/0 0/0 .text            daObjLdy_Execute__FP10daObjLdy_c */
 static int daObjLdy_Execute(daObjLdy_c* i_this) {
-    i_this->setNormalClothPos();
-    i_this->setBaseMtx();
-    i_this->calcJointAngle();
-    return 1;
+    return i_this->daObjLdy_Execute();
 }
 
 /* 80C51BDC-80C51BE4 000CBC 0008+00 1/0 0/0 0/0 .text            daObjLdy_IsDelete__FP10daObjLdy_c
@@ -404,22 +278,26 @@ static bool daObjLdy_IsDelete(daObjLdy_c* i_this) {
     return true;
 }
 
+daObjLdy_c::~daObjLdy_c() {
+    dComIfG_resDelete(&mPhase, l_arcName);
+}
+
 /* 80C51BE4-80C51D2C 000CC4 0148+00 1/0 0/0 0/0 .text            daObjLdy_Delete__FP10daObjLdy_c */
 static int daObjLdy_Delete(daObjLdy_c* i_this) {
-    if (i_this){
-        dComIfG_resDelete(&i_this->mPhase, l_arcName);
-        i_this->~daObjLdy_c();
-    }
-    
+    fopAcM_GetID(i_this);
+    i_this->~daObjLdy_c();
+
     return 1;
 }
 
 /* 80C51D2C-80C51D68 000E0C 003C+00 2/2 0/0 0/0 .text            __dt__12LaundJoint_cFv */
-LaundJoint_c::~LaundJoint_c() {
+LaundJoint_c::~LaundJoint_c() {}
+
+int daObjLdy_c::create(){
+    
 }
 
 /* 80C51D68-80C51EC0 000E48 0158+00 1/0 0/0 0/0 .text            daObjLdy_Create__FP10fopAc_ac_c */
-
 static int daObjLdy_Create(fopAc_ac_c* i_this) {
     daObjLdy_c* a_this = static_cast<daObjLdy_c*>(i_this);
     fopAcM_SetupActor(a_this, daObjLdy_c);
@@ -428,8 +306,7 @@ static int daObjLdy_Create(fopAc_ac_c* i_this) {
     if (phase == cPhs_COMPLEATE_e) {
         if (!fopAcM_entrySolidHeap(a_this, createSolidHeap, 0x9a0)) {
             phase = cPhs_ERROR_e;
-        }
-        else{
+        } else {
             a_this->create_init();
             i_this->cullMtx = a_this->mMtx;
         }
@@ -442,5 +319,32 @@ static int daObjLdy_Create(fopAc_ac_c* i_this) {
 LaundJoint_c::LaundJoint_c() {
     /* empty function */
 }
+/* 80C520F4-80C52114 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjLdy_Method */
+static actor_method_class l_daObjLdy_Method = {
+    (process_method_func)daObjLdy_Create,
+    (process_method_func)daObjLdy_Delete,
+    (process_method_func)daObjLdy_Execute,
+    (process_method_func)daObjLdy_IsDelete,
+    (process_method_func)daObjLdy_Draw,
+};
+
+/* 80C52114-80C52144 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_Obj_Laundry */
+extern actor_process_profile_definition g_profile_Obj_Laundry = {
+    fpcLy_CURRENT_e,         // mLayerID
+    7,                       // mListID
+    fpcPi_CURRENT_e,         // mListPrio
+    PROC_Obj_Laundry,        // mProcName
+    &g_fpcLf_Method.base,    // sub_method
+    sizeof(daObjLdy_c),      // mSize
+    0,                       // mSizeOther
+    0,                       // mParameters
+    &g_fopAc_Method.base,    // sub_method
+    37,                      // mPriority
+    &l_daObjLdy_Method,      // sub_method
+    0x00040180,              // mStatus
+    fopAc_ACTOR_e,           // mActorType
+    fopAc_CULLBOX_CUSTOM_e,  // cullType
+};
 
 /* 80C520C8-80C520C8 0000C8 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
+SECTION_DEAD static char const* const rodataPadding = "\0";

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -31,9 +31,9 @@ void daObjLdy_c::create_init() {
     LaundJoint_c* joint = &mJoints[0];
     int index = 0;
     for (int i = 0; i < 3; i++) {
-        joint->pos1 = current.pos;
-        joint->pos1.y += (index + 1) * M_attr[3];
-        joint->pos2 = joint->pos1;
+        joint->mPos1 = current.pos;
+        joint->mPos1.y += (index + 1) * M_attr[3];
+        joint->mPos2 = joint->mPos1;
         index++;
         joint++;
     }
@@ -50,7 +50,7 @@ void daObjLdy_c::initBaseMtx() {
     for (int i = 0; i < 3; i++) {
         float cosAngleY = cM_scos(shape_angle.y);
         float sinAngleY = cM_ssin(shape_angle.y);
-        joint->pos4.set(sinAngleY, 0.0f, cosAngleY);
+        joint->mPos4.set(sinAngleY, 0.0f, cosAngleY);
         joint++;
     }
 }
@@ -67,7 +67,7 @@ void daObjLdy_c::setBaseMtx() {
 /* 80C5116C-80C51194 00024C 0028+00 1/1 0/0 0/0 .text getJointAngle__10daObjLdy_cFP5csXyzi */
 void daObjLdy_c::getJointAngle(csXyz* jointAngle, int index) {
     LaundJoint_c* joint = &mJoints[index];
-    *jointAngle = joint->angle;
+    *jointAngle = joint->mAngle;
 }
 
 /* ############################################################################################## */
@@ -102,11 +102,11 @@ void daObjLdy_c::setNormalClothPos() {
     if (mCyl.ChkTgHit() != 0) {
         cCcD_Obj* tgHitObj = mCyl.GetTgHitObj();
         if (tgHitObj->ChkAtType(AT_TYPE_40) != 0 || tgHitObj->ChkAtType(AT_TYPE_ARROW) != 0) {
-            cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
+            cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].mPos1;
             position.normalizeZP();
             position *= 100.0f;
             for (int i = 2; i >= 0; i--) {
-                mJoints[i].pos3 = position;
+                mJoints[i].mPos3 = position;
                 position *= M_attr[6];
             }
             divorceParent();
@@ -118,11 +118,11 @@ void daObjLdy_c::setNormalClothPos() {
     } else {
         if (mCyl.ChkCoHit() != 0) {
             if (fopAcM_GetName(mCyl.GetCoHitAc()) == AT_TYPE_100) {
-                cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].pos1;
+                cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].mPos1;
                 position.normalizeZP();
                 position *= 100.0f;
                 for (int i = 2; i >= 0; i--) {
-                    mJoints[i].pos3 = position;
+                    mJoints[i].mPos3 = position;
                     position *= M_attr[6];
                 }
                 divorceParent();
@@ -131,7 +131,7 @@ void daObjLdy_c::setNormalClothPos() {
             if (!windVector.isZero()) {
                 for (int i = 0; i < 3; i++) {
                     if (cM_rnd() < 0.6f && cM_rnd() < 0.1f) {
-                        joint->pos3 += joint->pos4 * windPower;
+                        joint->mPos3 += joint->mPos4 * windPower;
                     }
                     joint++;
                 }
@@ -143,14 +143,14 @@ void daObjLdy_c::setNormalClothPos() {
     LaundJoint_c* mJoint = &mJoints[0];
     cXyz* currentPosition = &fopAcM_GetPosition(this);
     for (i = 0; i < 3; i++) {
-        adjustedPosition = *currentPosition - mJoint->pos1;
+        adjustedPosition = *currentPosition - mJoint->mPos1;
         adjustedPosition.y += gravity;
-        adjustedPosition += mJoint->pos3;
+        adjustedPosition += mJoint->mPos3;
         adjustedPosition.normalizeZP();
-        mJoint->pos1 = *currentPosition + (adjustedPosition * M_attr[3]);
-        mJoint->pos3 = (mJoint->pos3 + (mJoint->pos2 - mJoint->pos1)) * M_attr[5];
-        mJoint->pos2 = mJoint->pos1;
-        currentPosition = &mJoint->pos1;
+        mJoint->mPos1 = *currentPosition + (adjustedPosition * M_attr[3]);
+        mJoint->mPos3 = (mJoint->mPos3 + (mJoint->mPos2 - mJoint->mPos1)) * M_attr[5];
+        mJoint->mPos2 = mJoint->mPos1;
+        currentPosition = &mJoint->mPos1;
         mJoint++;
     }
 }
@@ -163,12 +163,12 @@ void daObjLdy_c::calcJointAngle() {
     for (int i = 0; i < 3; i++) {
         mDoMtx_stack_c::push();
         mDoMtx_stack_c::inverse();
-        mDoMtx_stack_c::multVec(&joint->pos1, &position);
+        mDoMtx_stack_c::multVec(&joint->mPos1, &position);
         mDoMtx_stack_c::pop();
         position *= -1.0f;
-        joint->angle.x = cM_atan2s(position.z, position.y);
-        joint->angle.z = cM_atan2s(-position.y, position.absXZ());
-        mDoMtx_stack_c::XrotM(joint->angle.x);
+        joint->mAngle.x = cM_atan2s(position.z, position.y);
+        joint->mAngle.z = cM_atan2s(-position.y, position.absXZ());
+        mDoMtx_stack_c::XrotM(joint->mAngle.x);
         mDoMtx_stack_c::transM(0.0f, M_attr[3], 0.0f);
         joint++;
     }

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -8,7 +8,6 @@
 #include "d/d_cc_d.h"
 #include "d/d_com_inf_game.h"
 #include "d/d_kankyo_wether.h"
-#include "dol2asm.h"
 
 //
 // Declarations:

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -206,8 +206,6 @@ static int nodeCallBack(J3DJoint* joint, int callbackCondition) {
 /* 80C520F0-80C520F4 -00001 0004+00 3/3 0/0 0/0 .data            l_arcName */
 static char* l_arcName = "J_Sentaku";
 
-
-
 int daObjLdy_c::getObjType() {
     return fopAcM_GetParam(this) & 0xff;
 }
@@ -284,35 +282,31 @@ daObjLdy_c::~daObjLdy_c() {
 
 /* 80C51BE4-80C51D2C 000CC4 0148+00 1/0 0/0 0/0 .text            daObjLdy_Delete__FP10daObjLdy_c */
 static int daObjLdy_Delete(daObjLdy_c* i_this) {
-    fopAcM_GetID(i_this);
     i_this->~daObjLdy_c();
-
     return 1;
 }
 
 /* 80C51D2C-80C51D68 000E0C 003C+00 2/2 0/0 0/0 .text            __dt__12LaundJoint_cFv */
 LaundJoint_c::~LaundJoint_c() {}
 
-int daObjLdy_c::create(){
-    
-}
-
-/* 80C51D68-80C51EC0 000E48 0158+00 1/0 0/0 0/0 .text            daObjLdy_Create__FP10fopAc_ac_c */
-static int daObjLdy_Create(fopAc_ac_c* i_this) {
-    daObjLdy_c* a_this = static_cast<daObjLdy_c*>(i_this);
-    fopAcM_SetupActor(a_this, daObjLdy_c);
-
-    int phase = dComIfG_resLoad(&a_this->mPhase, l_arcName);
+int daObjLdy_c::create() {
+    fopAcM_SetupActor(this, daObjLdy_c);
+    int phase = dComIfG_resLoad(&mPhase, l_arcName);
     if (phase == cPhs_COMPLEATE_e) {
-        if (!fopAcM_entrySolidHeap(a_this, createSolidHeap, 0x9a0)) {
+        if (!fopAcM_entrySolidHeap(this, createSolidHeap, 0x9a0)) {
             phase = cPhs_ERROR_e;
         } else {
-            a_this->create_init();
-            i_this->cullMtx = a_this->mMtx;
+            create_init();
+            fopAcM_SetMtx(this, mMtx);
         }
     }
 
     return phase;
+}
+
+/* 80C51D68-80C51EC0 000E48 0158+00 1/0 0/0 0/0 .text            daObjLdy_Create__FP10fopAc_ac_c */
+static int daObjLdy_Create(fopAc_ac_c* i_this) {
+    return ((daObjLdy_c*)i_this)->create();
 }
 
 /* 80C51EC0-80C51EC4 000FA0 0004+00 1/1 0/0 0/0 .text            __ct__12LaundJoint_cFv */
@@ -321,10 +315,8 @@ LaundJoint_c::LaundJoint_c() {
 }
 /* 80C520F4-80C52114 -00001 0020+00 1/0 0/0 0/0 .data            l_daObjLdy_Method */
 static actor_method_class l_daObjLdy_Method = {
-    (process_method_func)daObjLdy_Create,
-    (process_method_func)daObjLdy_Delete,
-    (process_method_func)daObjLdy_Execute,
-    (process_method_func)daObjLdy_IsDelete,
+    (process_method_func)daObjLdy_Create,  (process_method_func)daObjLdy_Delete,
+    (process_method_func)daObjLdy_Execute, (process_method_func)daObjLdy_IsDelete,
     (process_method_func)daObjLdy_Draw,
 };
 

--- a/src/d/actor/d_a_obj_laundry.cpp
+++ b/src/d/actor/d_a_obj_laundry.cpp
@@ -48,8 +48,8 @@ void daObjLdy_c::initBaseMtx() {
 
     LaundJoint_c* joint = &mJoints[0];
     for (int i = 0; i < 3; i++) {
-        float cosAngleY = cM_scos(shape_angle.y);
-        float sinAngleY = cM_ssin(shape_angle.y);
+        f32 cosAngleY = cM_scos(shape_angle.y);
+        f32 sinAngleY = cM_ssin(shape_angle.y);
         joint->mPos4.set(sinAngleY, 0.0f, cosAngleY);
         joint++;
     }
@@ -65,9 +65,9 @@ void daObjLdy_c::setBaseMtx() {
 }
 
 /* 80C5116C-80C51194 00024C 0028+00 1/1 0/0 0/0 .text getJointAngle__10daObjLdy_cFP5csXyzi */
-void daObjLdy_c::getJointAngle(csXyz* jointAngle, int index) {
-    LaundJoint_c* joint = &mJoints[index];
-    *jointAngle = joint->mAngle;
+void daObjLdy_c::getJointAngle(csXyz* i_jointAngle, int i_index) {
+    LaundJoint_c* joint = &mJoints[i_index];
+    *i_jointAngle = joint->mAngle;
 }
 
 /* ############################################################################################## */
@@ -96,7 +96,7 @@ void daObjLdy_c::setNormalClothPos() {
     cXyz adjustedPosition;
     cXyz windVector = dKyw_get_AllWind_vecpow(&current.pos);
     windVector *= M_attr[3] * M_attr[4];
-    float windPower = windVector.abs();
+    f32 windPower = windVector.abs();
     LaundJoint_c* joint = &mJoints[0];
 
     if (mCyl.ChkTgHit() != 0) {
@@ -117,7 +117,7 @@ void daObjLdy_c::setNormalClothPos() {
         }
     } else {
         if (mCyl.ChkCoHit() != 0) {
-            if (fopAcM_GetName(mCyl.GetCoHitAc()) == AT_TYPE_100) {
+            if (fopAcM_GetName(mCyl.GetCoHitAc()) == PROC_NPC_TK) {
                 cXyz position = fopAcM_GetPosition(dComIfGp_getPlayer(0)) - mJoints[1].mPos1;
                 position.normalizeZP();
                 position *= 100.0f;
@@ -180,16 +180,16 @@ bool daObjLdy_c::divorceParent() {
 }
 
 /* 80C51844-80C518FC 000924 00B8+00 1/1 0/0 0/0 .text            nodeCallBack__FP8J3DJointi */
-static int nodeCallBack(J3DJoint* joint, int callbackCondition) {
+static int nodeCallBack(J3DJoint* i_joint, int i_callbackCondition) {
     J3DModel* jointModel;
     u16 jointNo;
     csXyz jointAngle[2];
 
-    if (callbackCondition != 0) {
+    if (i_callbackCondition != 0) {
         return 1;
     }
 
-    jointNo = joint->getJntNo();
+    jointNo = i_joint->getJntNo();
     jointModel = j3dSys.getModel();
     ((daObjLdy_c*)jointModel->getUserArea())->getJointAngle(jointAngle, jointNo);
     cMtx_copy(jointModel->getAnmMtx(jointNo), mDoMtx_stack_c::get());
@@ -269,8 +269,8 @@ static int daObjLdy_Execute(daObjLdy_c* i_this) {
 
 /* 80C51BDC-80C51BE4 000CBC 0008+00 1/0 0/0 0/0 .text            daObjLdy_IsDelete__FP10daObjLdy_c
  */
-static bool daObjLdy_IsDelete(daObjLdy_c* i_this) {
-    return true;
+static int daObjLdy_IsDelete(daObjLdy_c* i_this) {
+    return 1;
 }
 
 daObjLdy_c::~daObjLdy_c() {
@@ -335,7 +335,3 @@ extern actor_process_profile_definition g_profile_Obj_Laundry = {
     fopAc_ACTOR_e,           // mActorType
     fopAc_CULLBOX_CUSTOM_e,  // cullType
 };
-
-static char* rodataPadding() {
-    return "\0";
-}


### PR DESCRIPTION
First decompilation for me, if anything seems off let me know.
Also I don't know if the reason for not matching is actually weak func order, this is the build output with MatchingFor in configuration.py, not sure how to fix it:

```
[1/9] LINK build\GZ2E01\d_a_obj_laundry\d_a_obj_laundry.preplf
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   No linker command file input for section '.dead' of type 'CONST' in file
#   'd_a_obj_laundry.o'.
#   '.dead' will be input for output section '.rodata'.
[3/9] LINK build\GZ2E01\d_a_obj_laundry\d_a_obj_laundry.plf
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   No linker command file input for section '.dead' of type 'CONST' in file
#   'd_a_obj_laundry.o'.
#   '.dead' will be input for output section '.ctors'.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'nodeCallBack(J3DJoint*,int)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'createSolidHeap(fopAc_ac_c*)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'daObjLdy_Draw(daObjLdy_c*)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'daObjLdy_Execute(daObjLdy_c*)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'daObjLdy_IsDelete(daObjLdy_c*)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'daObjLdy_Delete(daObjLdy_c*)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'daObjLdy_Create(fopAc_ac_c*)' is either not a global
#   symbol or doesn't exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'l_arcName' is either not a global symbol or doesn't 
#   exist.  Ignored.
### build\compilers\GC\2.7\mwldeppc.exe Linker Warning:
#   FORCEACTIVE symbol 'l_daObjLdy_Method' is either not a global symbol or
#   doesn't exist.  Ignored.
[6/9] REPORT
 INFO Loading project .
 INFO Generating report for 2995 units (using 12 threads)
 INFO Report generated in 5.334s
 INFO Writing to build\GZ2E01\report.json
[7/9] REL
 INFO Loading 758 modules
 INFO Symbol resolution completed in 0.082s (resolved 209064 symbols)
 INFO RELs written in 0.587s
 INFO Total time: 3.749s
[8/9] CHECK config\GZ2E01\build.sha1
FAILED: build/GZ2E01/ok
build\tools\dtk.exe shasum -q  -c config\GZ2E01\build.sha1 -o build\GZ2E01\ok
build/GZ2E01/d_a_obj_laundry/d_a_obj_laundry.rel: FAILED
757 files OK
WARNING: 1 computed checksum(s) did NOT match
ninja: build stopped: subcommand failed.
```