### PR TITLE
Add more J3D_ASSERTs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,5 +32,11 @@
       "command": "${command:python.interpreterPath} configure.py --version ${input:gameVersion}",
       "problemMatcher": [],
     },
+    {
+      "label": "ninja changes_all",
+      "type": "shell",
+      "command": "ninja changes_all",
+      "problemMatcher": [],
+    },
   ]
 }

--- a/configure.py
+++ b/configure.py
@@ -558,6 +558,7 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2J01"), "d/d_vibration.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "d/d_vib_pattern.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "d/d_attention.cpp", extra_cflags=['-pragma "nosyminline on"']),
+            Object(NonMatching, "d/d_bg_parts.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "d/d_bg_pc.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "d/d_att_dist.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "d/d_bg_plc.cpp"),
@@ -1090,7 +1091,7 @@ config.libs = [
             Object(NonMatching, "JSystem/J3DGraphAnimator/J3DSkinDeform.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphAnimator/J3DCluster.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphAnimator/J3DJoint.cpp"),
-            Object(NonMatching, "JSystem/J3DGraphAnimator/J3DMaterialAttach.cpp"),
+            Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphAnimator/J3DMaterialAttach.cpp"),
         ],
     ),
     JSystemLib(

--- a/include/JSystem/J3DGraphAnimator/J3DAnimation.h
+++ b/include/JSystem/J3DGraphAnimator/J3DAnimation.h
@@ -589,14 +589,23 @@ public:
         calcTransform(getFrame(), param_0, pSRTInfo);
     }
 
-    u16 getUpdateMaterialID(u16 idx) const { return mUpdateMaterialID[idx]; }
+    u16 getUpdateMaterialID(u16 idx) const {
+        J3D_ASSERT(1029, idx < mTrackNum / 3, "Error : range over.");
+        return mUpdateMaterialID[idx];
+    }
     u16 getUpdateMaterialNum() const { return mTrackNum / 3; }
     u16 getPostUpdateMaterialNum() const { return field_0x4a / 3; }
 
-    int getUpdateTexMtxID(u16 idx) const { return mUpdateTexMtxID[idx]; }
+    int getUpdateTexMtxID(u16 idx) const {
+        J3D_ASSERT(1017, idx < mTrackNum / 3, "Error : range over.");
+        return mUpdateTexMtxID[idx];
+    }
     bool isValidUpdateMaterialID(u16 idx) const { return mUpdateMaterialID[idx] != 0xffff; }
     u32 getTexMtxCalcType() { return mTexMtxCalcType; }
-    Vec* getSRTCenter(u16 idx) { return &mSRTCenter[idx]; }
+    Vec* getSRTCenter(u16 idx) {
+        J3D_ASSERT(1047, idx < mTrackNum / 3, "Error : range over.");
+        return &mSRTCenter[idx];
+    }
 
     /* 0x0C */ int mDecShift;
     /* 0x10 */ J3DAnmTransformKeyTable* mAnmTable;
@@ -640,7 +649,10 @@ public:
     /* 8032BD20 */ virtual ~J3DAnmTexPattern() {}
     /* 8032BD94 */ virtual s32 getKind() const { return 2; }
 
-    u16 getUpdateMaterialID(u16 idx) const { return mUpdateMaterialID[idx]; }
+    u16 getUpdateMaterialID(u16 idx) const {
+        J3D_ASSERT(2288, idx < mUpdateMaterialNum, "Error : range over.");
+        return mUpdateMaterialID[idx];
+    }
     u16 getUpdateMaterialNum() const { return mUpdateMaterialNum; }
     bool isValidUpdateMaterialID(u16 id) const { return mUpdateMaterialID[id] != 0xFFFF; }
     J3DAnmTexPatternFullTable* getAnmTable() { return mAnmTable; }
@@ -671,8 +683,14 @@ public:
     u16 getCRegUpdateMaterialNum() const { return mCRegUpdateMaterialNum; }
     u16 getKRegUpdateMaterialNum() const { return mKRegUpdateMaterialNum; }
 
-    u16 getCRegUpdateMaterialID(u16 idx) const { return mCRegUpdateMaterialID[idx]; }
-    u16 getKRegUpdateMaterialID(u16 idx) const { return mKRegUpdateMaterialID[idx]; }
+    u16 getCRegUpdateMaterialID(u16 idx) const {
+        J3D_ASSERT(2100, idx < mCRegUpdateMaterialNum, "Error : range over.");
+        return mCRegUpdateMaterialID[idx];
+    }
+    u16 getKRegUpdateMaterialID(u16 idx) const {
+        J3D_ASSERT(2140, idx < mKRegUpdateMaterialNum, "Error : range over.");
+        return mKRegUpdateMaterialID[idx];
+    }
 
     const J3DAnmCRegKeyTable* getAnmCRegKeyTable() const { return mAnmCRegKeyTable; }
     const J3DAnmKRegKeyTable* getAnmKRegKeyTable() const { return mAnmKRegKeyTable; }
@@ -722,7 +740,7 @@ public:
     u16 getUpdateMaterialNum() const { return mUpdateMaterialNum; }
     bool isValidUpdateMaterialID(u16 id) const { return mUpdateMaterialID[id] != 0xFFFF; }
     u16 getUpdateMaterialID(u16 idx) const { 
-        J3D_ASSERT(1578, idx < mUpdateMaterialNum, "Error : range over.")
+        J3D_ASSERT(1578, idx < mUpdateMaterialNum, "Error : range over.");
         return mUpdateMaterialID[idx];
     }
 

--- a/include/JSystem/J3DGraphAnimator/J3DCluster.h
+++ b/include/JSystem/J3DGraphAnimator/J3DCluster.h
@@ -81,12 +81,15 @@ public:
     /* 8032E364 */ void setAnm(J3DAnmCluster*);
 
     J3DCluster* getClusterPointer(u16 index) {
-        J3D_ASSERT(186, (index < mClusterNum),"Error : range over.");
+        J3D_ASSERT(186, (index < mClusterNum), "Error : range over.");
         return &mClusterPointer[index];
     }
     u16 getClusterNum() const { return mClusterNum; }
     u16 getClusterKeyNum() const { return mClusterKeyNum; }
-    J3DClusterKey* getClusterKeyPointer(u16 i) { return &mClusterKeyPointer[i]; }
+    J3DClusterKey* getClusterKeyPointer(u16 i) {
+        J3D_ASSERT(199, (i < mClusterKeyNum), "Error : range over.");
+        return &mClusterKeyPointer[i];
+    }
     f32* getVtxPos() { return mVtxPos; }
     f32* getVtxNrm() { return mVtxNrm; }
 

--- a/include/JSystem/J3DGraphAnimator/J3DJointTree.h
+++ b/include/JSystem/J3DGraphAnimator/J3DJointTree.h
@@ -63,7 +63,10 @@ public:
     J3DDrawMtxData* getDrawMtxData() { return &mDrawMtxData; }
     JUTNameTab* getJointName() const { return mJointName; }
     J3DJoint* getRootNode() { return mRootNode; }
-    J3DJoint* getJointNodePointer(u16 idx) const { return mJointNodePointer[idx]; }
+    J3DJoint* getJointNodePointer(u16 idx) const {
+        J3D_ASSERT(139, idx < mJointNum, "Error : range over.");
+        return mJointNodePointer[idx];
+    }
     J3DMtxCalc* getBasicMtxCalc() const { return mBasicMtxCalc; }
     Mtx& getInvJointMtx(int idx) { return mInvJointMtx[idx]; }
     u32 getModelDataType() const { return mModelDataType; }

--- a/include/JSystem/J3DGraphAnimator/J3DMaterialAttach.h
+++ b/include/JSystem/J3DGraphAnimator/J3DMaterialAttach.h
@@ -1,6 +1,7 @@
 #ifndef J3DMATERIALATTACH_H
 #define J3DMATERIALATTACH_H
 
+#include "JSystem/JUtility/JUTAssert.h"
 #include "dolphin/types.h"
 
 class J3DMaterial;
@@ -31,7 +32,10 @@ public:
 
     /* 8032F604 */ virtual ~J3DMaterialTable();
 
-    J3DMaterial* getMaterialNodePointer(u16 idx) const { return mMaterialNodePointer[idx]; }
+    J3DMaterial* getMaterialNodePointer(u16 idx) const {
+        J3D_ASSERT(92, idx < mMaterialNum, "Error : range over.");
+        return mMaterialNodePointer[idx];
+    }
 
     J3DTexture* getTexture() const { return mTexture; }
     JUTNameTab* getTextureName() const { return mTextureName; }

--- a/include/JSystem/J3DGraphAnimator/J3DShapeTable.h
+++ b/include/JSystem/J3DGraphAnimator/J3DShapeTable.h
@@ -2,6 +2,7 @@
 #define J3DSHAPETABLE_H
 
 #include "JSystem/J3DGraphBase/J3DShape.h"
+#include "JSystem/JUtility/JUTAssert.h"
 
 class JUTNameTab;
 
@@ -25,7 +26,10 @@ public:
     virtual ~J3DShapeTable() {}
 
     u16 getShapeNum() const { return mShapeNum; }
-    J3DShape* getShapeNodePointer(u16 idx) const { return mShapeNodePointer[idx]; }
+    J3DShape* getShapeNodePointer(u16 idx) const {
+        J3D_ASSERT(85, idx < mShapeNum, "Error : range over.");
+        return mShapeNodePointer[idx];
+    }
 
 private:
     friend class J3DModelLoader;

--- a/include/JSystem/J3DGraphBase/J3DMatBlock.h
+++ b/include/JSystem/J3DGraphBase/J3DMatBlock.h
@@ -3,6 +3,7 @@
 
 #include "JSystem/J3DGraphBase/J3DTevs.h"
 #include "JSystem/J3DGraphBase/J3DTexture.h"
+#include "JSystem/JUtility/JUTAssert.h"
 #include "dolphin/types.h"
 
 /**
@@ -304,7 +305,10 @@ public:
     /* 80317BB4 */ virtual s32 countDLSize();
     /* 803229D0 */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
     /* 803229C0 */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 803229E4 */ virtual u16 getTexNo(u32 idx) const { return mTexNo[idx]; }
+    /* 803229E4 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(1353, idx < 8, "Error : range over.");
+        return mTexNo[idx];
+    }
     /* 80322A08 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
     /* 803229F4 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
     /* 80322A1C */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
@@ -370,7 +374,10 @@ public:
     /* 80317BCC */ virtual s32 countDLSize();
     /* 8032202C */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
     /* 8032201C */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 80322040 */ virtual u16 getTexNo(u32 idx) const { return mTexNo[idx]; }
+    /* 80322040 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(2019, idx < 4, "Error : range over.");
+        return mTexNo[idx];
+    }
     /* 80322064 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
     /* 80322050 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
     /* 80322078 */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
@@ -446,7 +453,10 @@ public:
     /* 80317BC4 */ virtual s32 countDLSize();
     /* 803223F0 */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
     /* 803223E0 */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 80322404 */ virtual u16 getTexNo(u32 idx) const { return mTexNo[idx]; }
+    /* 80322404 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(1730, idx < 2, "Error : range over.");
+        return mTexNo[idx];
+    }
     /* 80322428 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
     /* 80322414 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
     /* 8032243C */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
@@ -522,7 +532,10 @@ public:
     /* 80317BD4 */ virtual s32 countDLSize();
     /* 80321C60 */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
     /* 80321C50 */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 80321C74 */ virtual u16 getTexNo(u32 idx) const { return mTexNo[idx]; }
+    /* 80321C74 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(2308, idx < 8, "Error : range over.");
+        return mTexNo[idx];
+    }
     /* 80321C98 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
     /* 80321C84 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
     /* 80321CAC */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
@@ -598,7 +611,10 @@ public:
     /* 80317BBC */ virtual s32 countDLSize();
     /* 803227B4 */ virtual void setTexNo(u32 idx, u16 const* no) { mTexNo[idx] = *no; }
     /* 803227A4 */ virtual void setTexNo(u32 idx, u16 no) { mTexNo[idx] = no; }
-    /* 803227C8 */ virtual u16 getTexNo(u32 idx) const { return mTexNo[idx]; }
+    /* 803227C8 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(1574, idx < 1, "Error : range over.");
+        return mTexNo[idx];
+    }
     /* 803227EC */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
     /* 803227D8 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
     /* 80322800 */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }

--- a/include/JSystem/J3DGraphBase/J3DShape.h
+++ b/include/JSystem/J3DGraphBase/J3DShape.h
@@ -2,8 +2,11 @@
 #define J3DSHAPE_H
 
 #include "JSystem/J3DGraphBase/J3DShapeDraw.h"
-#include "JSystem/J3DGraphBase/J3DShapeMtx.h"
+#include "JSystem/JUtility/JUTAssert.h"
 #include "dolphin/gx.h"
+#include "mtx.h"
+
+class J3DShapeMtx;
 
 /**
  * @ingroup jsystem-j3d
@@ -164,6 +167,50 @@ private:
     /* 0x5C */ Mtx33** mNrmMtx;
     /* 0x60 */ u32* mCurrentViewNo;
     /* 0x64 */ u32 mBumpMtxOffset;
+};
+
+typedef void (J3DShapeMtx::*J3DShapeMtx_LoadFunc)(int, u16) const;
+
+/**
+ * @ingroup jsystem-j3d
+ * 
+ */
+class J3DShapeMtx {
+public:
+    J3DShapeMtx(u16 useMtxIndex)
+        : mUseMtxIndex(useMtxIndex)
+    {}
+
+    /* 803130E4 */ void loadMtxIndx_PNGP(int, u16) const;
+    /* 80313128 */ void loadMtxIndx_PCPU(int, u16) const;
+    /* 80313188 */ void loadMtxIndx_NCPU(int, u16) const;
+    /* 803131D4 */ void loadMtxIndx_PNCPU(int, u16) const;
+
+    /* 80314798 */ virtual ~J3DShapeMtx() {}
+    /* 803147E0 */ virtual u32 getType() const { return 'SMTX'; }
+    /* 80273E08 */ virtual u32 getUseMtxNum() const { return 1; }
+    /* 8031459C */ virtual u32 getUseMtxIndex(u16) const { return mUseMtxIndex; }
+    /* 80313B94 */ virtual void load() const;
+    /* 80313BF0 */ virtual void calcNBTScale(Vec const&, f32 (*)[3][3], f32 (*)[3][3]);
+
+    static J3DShapeMtx_LoadFunc sMtxLoadPipeline[4];
+    static u16 sMtxLoadCache[10];
+    static u32 sCurrentPipeline;
+    static u8* sCurrentScaleFlag;
+    static u8 sNBTFlag;
+    static u8 sLODFlag;
+    static u32 sTexMtxLoadType;
+
+    static void setCurrentPipeline(u32 pipeline) {
+        J3D_ASSERT(91, pipeline < 4, "Error : range over.");
+        sCurrentPipeline = pipeline;
+    }
+    static void setLODFlag(u8 flag) { sLODFlag = flag; }
+    static u32 getLODFlag() { return sLODFlag; }
+    static void resetMtxLoadCache();
+
+protected:
+    /* 0x04 */ u16 mUseMtxIndex;
 };
 
 #endif /* J3DSHAPE_H */

--- a/include/JSystem/J3DGraphBase/J3DShape.h
+++ b/include/JSystem/J3DGraphBase/J3DShape.h
@@ -48,11 +48,11 @@ public:
     u32 getMtxIdxRegB() const { return mMtxIdxRegB; }
 
     inline void load() const {
-        J3DFifoWriteCPCmd(0x30, getMtxIdxRegA());  // CP_MATINDEX_A
-        J3DFifoWriteCPCmd(0x40, getMtxIdxRegB());  // CP_MATINDEX_B
+        J3DFifoWriteCPCmd(0x30, mMtxIdxRegA);  // CP_MATINDEX_A
+        J3DFifoWriteCPCmd(0x40, mMtxIdxRegB);  // CP_MATINDEX_B
         J3DFifoWriteXFCmd(0x1018, 2);
-        GXWGFifo.u32 = getMtxIdxRegA();
-        GXWGFifo.u32 = getMtxIdxRegB();
+        GXCmd1u32(mMtxIdxRegA);
+        GXCmd1u32(mMtxIdxRegB);
     }
 
     void setCurrentTexMtx(u8 param_1, u8 param_2, u8 param_3, u8 param_4,
@@ -111,7 +111,7 @@ public:
     bool checkFlag(u32 flag) const { return !!(mFlags & flag); }
     void setDrawMtxDataPointer(J3DDrawMtxData* pMtxData) { mDrawMtxData = pMtxData; }
     void setVertexDataPointer(J3DVertexData* pVtxData) { mVertexData = pVtxData; }
-    void* getVcdVatCmd() const { return mVcdVatCmd; }
+    void* getVcdVatCmd() { return mVcdVatCmd; }
     void setVcdVatCmd(void* pVatCmd) { mVcdVatCmd = (u8*)pVatCmd; }
     void show() { offFlag(J3DShpFlag_Visible); }
     void hide() { onFlag(J3DShpFlag_Visible); }
@@ -124,15 +124,14 @@ public:
     bool getNBTFlag() const { return mHasNBT; }
     u32 getBumpMtxOffset() const { return mBumpMtxOffset; }
     void setBumpMtxOffset(u32 offset) { mBumpMtxOffset = offset; }
-    GXVtxDescList* getVtxDesc() const { return mVtxDesc; }
+    GXVtxDescList* getVtxDesc() { return mVtxDesc; }
 
     J3DMaterial* getMaterial() const { return mMaterial; }
     u16 getIndex() const { return mIndex; }
-    u32 getPipeline() const { return (mFlags >> 2) & 0x07; }
     u32 getTexMtxLoadType() const { return mFlags & 0xF000; }
     u32 getMtxGroupNum() const { return mMtxGroupNum; }
-    J3DShapeDraw* getShapeDraw(u32 idx) const { return mShapeDraw[idx]; }
-    J3DShapeMtx* getShapeMtx(u32 idx) const { return mShapeMtx[idx]; }
+    J3DShapeDraw* getShapeDraw(u16 idx) { return mShapeDraw[idx]; }
+    J3DShapeMtx* getShapeMtx(u16 idx) { return mShapeMtx[idx]; }
     Vec* getMin() { return &mMin; }
     Vec* getMax() { return &mMax; }
 

--- a/include/JSystem/J3DGraphBase/J3DShapeMtx.h
+++ b/include/JSystem/J3DGraphBase/J3DShapeMtx.h
@@ -1,6 +1,7 @@
 #ifndef J3DSHAPEMTX_H
 #define J3DSHAPEMTX_H
 
+#include "JSystem/JUtility/JUTAssert.h"
 #include "dolphin/mtx.h"
 
 class J3DTexMtx;
@@ -72,9 +73,13 @@ public:
     static u8 sLODFlag;
     static u32 sTexMtxLoadType;
 
-    static void setCurrentPipeline(u32 pipeline) { sCurrentPipeline = pipeline; }
+    static void setCurrentPipeline(u32 pipeline) {
+        // TODO: needs to go in J3DShape.h for assert
+        J3D_ASSERT(91, pipeline < 4, "Error : range over.");
+        sCurrentPipeline = pipeline;
+    }
     static void setLODFlag(u8 flag) { sLODFlag = flag; }
-    static u8 getLODFlag() { return sLODFlag; }
+    static u32 getLODFlag() { return sLODFlag; }
     static void resetMtxLoadCache();
 
 protected:

--- a/include/JSystem/J3DGraphBase/J3DShapeMtx.h
+++ b/include/JSystem/J3DGraphBase/J3DShapeMtx.h
@@ -1,7 +1,7 @@
 #ifndef J3DSHAPEMTX_H
 #define J3DSHAPEMTX_H
 
-#include "JSystem/JUtility/JUTAssert.h"
+#include "JSystem/J3DGraphBase/J3DShape.h"
 #include "dolphin/mtx.h"
 
 class J3DTexMtx;
@@ -38,52 +38,6 @@ public:
 
     static J3DTexGenBlock* sTexGenBlock;
     static J3DTexMtxObj* sTexMtxObj;
-};
-
-class J3DShapeMtx;
-typedef void (J3DShapeMtx::*J3DShapeMtx_LoadFunc)(int, u16) const;
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DShapeMtx {
-public:
-    J3DShapeMtx(u16 useMtxIndex)
-        : mUseMtxIndex(useMtxIndex)
-    {}
-
-    /* 803130E4 */ void loadMtxIndx_PNGP(int, u16) const;
-    /* 80313128 */ void loadMtxIndx_PCPU(int, u16) const;
-    /* 80313188 */ void loadMtxIndx_NCPU(int, u16) const;
-    /* 803131D4 */ void loadMtxIndx_PNCPU(int, u16) const;
-
-    /* 80314798 */ virtual ~J3DShapeMtx() {}
-    /* 803147E0 */ virtual u32 getType() const { return 'SMTX'; }
-    /* 80273E08 */ virtual u32 getUseMtxNum() const { return 1; }
-    /* 8031459C */ virtual u32 getUseMtxIndex(u16) const { return mUseMtxIndex; }
-    /* 80313B94 */ virtual void load() const;
-    /* 80313BF0 */ virtual void calcNBTScale(Vec const&, f32 (*)[3][3], f32 (*)[3][3]);
-
-    static J3DShapeMtx_LoadFunc sMtxLoadPipeline[4];
-    static u16 sMtxLoadCache[10];
-    static u32 sCurrentPipeline;
-    static u8* sCurrentScaleFlag;
-    static u8 sNBTFlag;
-    static u8 sLODFlag;
-    static u32 sTexMtxLoadType;
-
-    static void setCurrentPipeline(u32 pipeline) {
-        // TODO: needs to go in J3DShape.h for assert
-        J3D_ASSERT(91, pipeline < 4, "Error : range over.");
-        sCurrentPipeline = pipeline;
-    }
-    static void setLODFlag(u8 flag) { sLODFlag = flag; }
-    static u32 getLODFlag() { return sLODFlag; }
-    static void resetMtxLoadCache();
-
-protected:
-    /* 0x04 */ u16 mUseMtxIndex;
 };
 
 class J3DShapeMtxConcatView;

--- a/include/JSystem/J3DGraphBase/J3DSys.h
+++ b/include/JSystem/J3DGraphBase/J3DSys.h
@@ -93,16 +93,19 @@ struct J3DSys {
 
     void setDrawModeXlu() { mDrawMode = XLU; }
 
-    void* getVtxPos() const { return mVtxPos; }
+    void* getVtxPos() { return mVtxPos; }
     void setVtxPos(void* pVtxPos) { mVtxPos = pVtxPos; }
 
-    void* getVtxNrm() const { return mVtxNrm; }
+    void* getVtxNrm() { return mVtxNrm; }
     void setVtxNrm(void* pVtxNrm) { mVtxNrm = pVtxNrm; }
 
     void* getVtxCol() const { return mVtxCol; }
     void setVtxCol(_GXColor* pVtxCol) { mVtxCol = pVtxCol; }
 
-    void setModel(J3DModel* pModel) { mModel = pModel; }
+    void setModel(J3DModel* pModel) {
+        J3D_ASSERT(200, pModel, "Error : null pointer.");
+        mModel = pModel;
+    }
     void setShapePacket(J3DShapePacket* pPacket) { mShapePacket = pPacket; }
     void setMatPacket(J3DMatPacket* pPacket) { mMatPacket = pPacket; }
     J3DMatPacket* getMatPacket() { return mMatPacket; }
@@ -129,6 +132,7 @@ struct J3DSys {
     }
 
     void setModelNrmMtx(Mtx33* pMtxArr) {
+        JUT_ASSERT_MSG(241, pMtxArr, "Error : null pointer.");
         mModelNrmMtx = pMtxArr;
         GXSetArray(GX_NRM_MTX_ARRAY, mModelNrmMtx, sizeof(*mModelNrmMtx));
     }
@@ -148,8 +152,8 @@ struct J3DSys {
         return mDrawBuffer[type];
     }
 
-    Mtx& getModelDrawMtx(u16 no) const { return mModelDrawMtx[no]; }
-    J3DShapePacket* getShapePacket() const { return mShapePacket; }
+    Mtx& getModelDrawMtx(u16 no) { return mModelDrawMtx[no]; }
+    J3DShapePacket* getShapePacket() { return mShapePacket; }
 
     void setViewMtx(Mtx m) { MTXCopy(m, mViewMtx); }
 

--- a/include/JSystem/J3DGraphBase/J3DTexture.h
+++ b/include/JSystem/J3DGraphBase/J3DTexture.h
@@ -2,6 +2,7 @@
 #define J3DTEXTURE_H
 
 #include "JSystem/J3DGraphBase/J3DStruct.h"
+#include "JSystem/JUtility/JUTAssert.h"
 #include "JSystem/JUtility/JUTTexture.h"
 #include "dolphin/types.h"
 
@@ -23,7 +24,10 @@ public:
     /* 803366A4 */ virtual ~J3DTexture() {}
 
     u16 getNum() const { return mNum; }
-    ResTIMG* getResTIMG(u16 entry) const { return &mpRes[entry]; }
+    ResTIMG* getResTIMG(u16 entry) const {
+        J3D_ASSERT(72, entry < mNum, "Error : range over.");
+        return &mpRes[entry];   
+    }
     void setResTIMG(u16 entry, const ResTIMG& timg) {
         mpRes[entry] = timg;
         mpRes[entry].imageOffset = ((mpRes[entry].imageOffset + (u32)&timg - (u32)(mpRes + entry)));

--- a/include/JSystem/J3DGraphBase/J3DVertex.h
+++ b/include/JSystem/J3DGraphBase/J3DVertex.h
@@ -37,7 +37,7 @@ public:
     void* getVtxNBTArray() const { return mVtxNBTArray; }
     u32 getNrmNum() const { return mNrmNum; }
     u32 getVtxNum() const { return mVtxNum; }
-    GXVtxAttrFmtList* getVtxAttrFmtList() { return mVtxAttrFmtList; }
+    GXVtxAttrFmtList* getVtxAttrFmtList() const { return mVtxAttrFmtList; }
     u8 getVtxPosFrac() { return mVtxPosFrac; }
     u8 getVtxNrmFrac() { return mVtxNrmFrac; }
     int getVtxPosType() { return mVtxPosType; }

--- a/src/JSystem/J3DGraphAnimator/J3DAnimation.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DAnimation.cpp
@@ -1120,6 +1120,7 @@ void J3DAnmTexPattern::getTexNo(u16 i_index, u16* o_texNo) const {
 /* 8032B004-8032B09C 325944 0098+00 1/1 1/1 0/0 .text
  * searchUpdateMaterialID__16J3DAnmTexPatternFP16J3DMaterialTable */
 void J3DAnmTexPattern::searchUpdateMaterialID(J3DMaterialTable* i_materialTable) {
+    J3D_ASSERT(1790, i_materialTable, "Error : null pointer.");
     for (u16 i = 0; i < mUpdateMaterialNum; i++) {
         s32 index = i_materialTable->getMaterialName()->getIndex(mUpdateMaterialName.getName(i));
         if (index != -1) {
@@ -1133,13 +1134,15 @@ void J3DAnmTexPattern::searchUpdateMaterialID(J3DMaterialTable* i_materialTable)
 /* 8032B09C-8032B0C0 3259DC 0024+00 0/0 4/4 1/1 .text
  * searchUpdateMaterialID__16J3DAnmTexPatternFP12J3DModelData   */
 void J3DAnmTexPattern::searchUpdateMaterialID(J3DModelData* i_modelData) {
+    J3D_ASSERT(1813, i_modelData, "Error : null pointer.");
     searchUpdateMaterialID(&i_modelData->getMaterialTable());
 }
 
 /* 8032B0C0-8032B1D4 325A00 0114+00 1/1 1/1 0/0 .text
  * searchUpdateMaterialID__19J3DAnmTextureSRTKeyFP16J3DMaterialTable */
 void J3DAnmTextureSRTKey::searchUpdateMaterialID(J3DMaterialTable* i_materialTable) {
-    for (u16 i = 0; i < u16(mTrackNum / 3); i++) {
+    J3D_ASSERT(1832, i_materialTable, "Error : null pointer.");
+    for (u16 i = 0; i < getUpdateMaterialNum(); i++) {
         s32 index = i_materialTable->getMaterialName()->getIndex(mUpdateMaterialName.getName(i));
         if (index != -1) {
             mUpdateMaterialID[i] = index;
@@ -1147,7 +1150,7 @@ void J3DAnmTextureSRTKey::searchUpdateMaterialID(J3DMaterialTable* i_materialTab
             mUpdateMaterialID[i] = -1;
         }
     }
-    for (u16 i = 0; i < u16(field_0x4a / 3); i++) {
+    for (u16 i = 0; i < getPostUpdateMaterialNum(); i++) {
         s32 index = i_materialTable->getMaterialName()->getIndex(mPostUpdateMaterialName.getName(i));
         if (index != -1) {
             mPostUpdateMaterialID[i] = index;
@@ -1160,6 +1163,7 @@ void J3DAnmTextureSRTKey::searchUpdateMaterialID(J3DMaterialTable* i_materialTab
 /* 8032B1D4-8032B1F8 325B14 0024+00 0/0 8/8 6/6 .text
  * searchUpdateMaterialID__19J3DAnmTextureSRTKeyFP12J3DModelData */
 void J3DAnmTextureSRTKey::searchUpdateMaterialID(J3DModelData* i_modelData) {
+    J3D_ASSERT(1871, i_modelData, "Error : null pointer.");
     searchUpdateMaterialID(&i_modelData->getMaterialTable());
 }
 
@@ -1324,6 +1328,7 @@ void J3DAnmTevRegKey::getTevKonstReg(u16 i_index, GXColor* o_color) const {
 /* 8032B780-8032B87C 3260C0 00FC+00 1/1 1/1 0/0 .text
  * searchUpdateMaterialID__15J3DAnmTevRegKeyFP16J3DMaterialTable */
 void J3DAnmTevRegKey::searchUpdateMaterialID(J3DMaterialTable* i_materialTable) {
+    J3D_ASSERT(2083, i_materialTable, "Error : null pointer.");
     for (u16 i = 0; i < mCRegUpdateMaterialNum; i++) {
         s32 index = i_materialTable->getMaterialName()->getIndex(mCRegUpdateMaterialName.getName(i));
         if (index != -1) {
@@ -1345,5 +1350,6 @@ void J3DAnmTevRegKey::searchUpdateMaterialID(J3DMaterialTable* i_materialTable) 
 /* 8032B87C-8032B8A0 3261BC 0024+00 0/0 9/9 4/4 .text
  * searchUpdateMaterialID__15J3DAnmTevRegKeyFP12J3DModelData    */
 void J3DAnmTevRegKey::searchUpdateMaterialID(J3DModelData* i_modelData) {
+    J3D_ASSERT(2119, i_modelData, "Error : null pointer.");
     searchUpdateMaterialID(&i_modelData->getMaterialTable());
 }

--- a/src/JSystem/J3DGraphAnimator/J3DCluster.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DCluster.cpp
@@ -37,7 +37,7 @@ void J3DDeformData::offAllFlag(u32 i_flag) {
 /* 8032E274-8032E298 328BB4 0024+00 0/0 1/1 0/0 .text            deform__13J3DDeformDataFP8J3DModel
  */
 void J3DDeformData::deform(J3DModel* model) {
-    J3D_ASSERT(110, model,"Error : null pointer");
+    J3D_ASSERT(110, model, "Error : null pointer");
 
     deform(model->getVertexBuffer());
 }
@@ -45,7 +45,7 @@ void J3DDeformData::deform(J3DModel* model) {
 /* 8032E298-8032E364 328BD8 00CC+00 1/1 0/0 0/0 .text deform__13J3DDeformDataFP15J3DVertexBuffer
  */
 void J3DDeformData::deform(J3DVertexBuffer* buffer) {
-    J3D_ASSERT(141, buffer,"Error : null pointer");
+    J3D_ASSERT(141, buffer, "Error : null pointer");
 
     buffer->swapVtxPosArrayPointer();
     buffer->swapVtxNrmArrayPointer();
@@ -83,7 +83,7 @@ J3DDeformer::J3DDeformer(J3DDeformData* data) {
 /* 8032E3BC-8032E4A4 328CFC 00E8+00 1/1 0/0 0/0 .text deform__11J3DDeformerFP15J3DVertexBufferUs
  */
 void J3DDeformer::deform(J3DVertexBuffer* buffer, u16 param_1) {
-    J3D_ASSERT(222, buffer,"Error : null pointer");
+    J3D_ASSERT(222, buffer, "Error : null pointer");
 
     u16 var_r31 = 0;
     if (mAnmCluster != NULL) {

--- a/src/JSystem/J3DGraphAnimator/J3DMaterialAttach.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DMaterialAttach.cpp
@@ -215,26 +215,23 @@ int J3DMaterialTable::entryTexNoAnimator(J3DAnmTexPattern* param_1) {
 
 /* 8032FCC4-8032FE70 32A604 01AC+00 0/0 14/14 6/6 .text
  * entryTexMtxAnimator__16J3DMaterialTableFP19J3DAnmTextureSRTKey */
-// NONMATCHING regalloc
-int J3DMaterialTable::entryTexMtxAnimator(J3DAnmTextureSRTKey* param_1) {
-    JUT_ASSERT_MSG(532, param_1 != NULL, "Error : null pointer.")
+int J3DMaterialTable::entryTexMtxAnimator(J3DAnmTextureSRTKey* btk) {
+    JUT_ASSERT_MSG(532, btk != NULL, "Error : null pointer.")
     int rv = 0;
-    u16 materialNum = param_1->getUpdateMaterialNum();
-    rv = createTexMtxForAnimator(param_1);
+    u16 materialNum = btk->getUpdateMaterialNum();
+    rv = createTexMtxForAnimator(btk);
     if (rv != 0) {
         return rv;
     }
     if (isLocked()) {
         return 2;
     }
-    for (u16 i = 0; i < materialNum; i++) {
-        if (param_1->isValidUpdateMaterialID(i)) {
-            u16 updateMaterialId = param_1->getUpdateMaterialID(i);
-            // Maybe helps? Makes material r26 instead of r30
-            //J3DMaterial* material = (J3DMaterial*)getMaterialNodePointer((u16)updateMaterialId);
+    for (u16 no = 0; no < materialNum; no++) {
+        if (btk->isValidUpdateMaterialID(no)) {
+            u16 updateMaterialId = btk->getUpdateMaterialID(no);
             J3DMaterial* material = getMaterialNodePointer((u16)updateMaterialId);
             J3DMaterialAnm* materialAnm = material->getMaterialAnm();
-            u8 texMtxID = param_1->getUpdateTexMtxID(i);
+            u8 texMtxID = btk->getUpdateTexMtxID(no);
             if (materialAnm == 0) {
                 rv = 1;
             } else {
@@ -242,15 +239,12 @@ int J3DMaterialTable::entryTexMtxAnimator(J3DAnmTextureSRTKey* param_1) {
                     if (material->getTexCoord(texMtxID) != NULL) {
                         material->getTexCoord(texMtxID)->setTexGenMtx((u8)texMtxID * 3 + 30);
                     }
-                    J3DTexMtxInfo& iVar3 = material->getTexMtx(texMtxID)->getTexMtxInfo();
-                    iVar3.mInfo = (iVar3.mInfo & 0x3f) | (param_1->getTexMtxCalcType() << 7);
-                    Vec* vec = param_1->getSRTCenter(i);
-                    iVar3.mCenter.x = vec->x;
-                    vec = param_1->getSRTCenter(i);
-                    iVar3.mCenter.y = vec->y;
-                    vec = param_1->getSRTCenter(i);
-                    iVar3.mCenter.z = vec->z;
-                    J3DTexMtxAnm texMtxAnm(i, param_1);
+                    J3DTexMtxInfo& tmtxinfo = material->getTexMtx(texMtxID)->getTexMtxInfo();
+                    tmtxinfo.mInfo = (tmtxinfo.mInfo & 0x3f) | (btk->getTexMtxCalcType() << 7);
+                    tmtxinfo.mCenter.x = btk->getSRTCenter(no)->x;
+                    tmtxinfo.mCenter.y = btk->getSRTCenter(no)->y;
+                    tmtxinfo.mCenter.z = btk->getSRTCenter(no)->z;
+                    J3DTexMtxAnm texMtxAnm(no, btk);
                     materialAnm->setTexMtxAnm(texMtxID, &texMtxAnm);
                 }
             }

--- a/src/JSystem/J3DGraphAnimator/J3DModel.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DModel.cpp
@@ -6,6 +6,7 @@
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
+#include "JSystem/J3DGraphBase/J3DShapeMtx.h"
 #include "dolphin/os.h"
 
 /* 80327100-80327184 321A40 0084+00 0/0 3/3 0/0 .text            initialize__8J3DModelFv */

--- a/src/JSystem/J3DGraphBase/J3DPacket.cpp
+++ b/src/JSystem/J3DGraphBase/J3DPacket.cpp
@@ -2,6 +2,7 @@
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/J3DGraphBase/J3DDrawBuffer.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
+#include "JSystem/J3DGraphBase/J3DShapeMtx.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include <dolphin/os.h>
 #include <dolphin/os.h>

--- a/src/JSystem/J3DGraphLoader/J3DShapeFactory.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DShapeFactory.cpp
@@ -5,6 +5,7 @@
 
 #include "JSystem/J3DGraphLoader/J3DShapeFactory.h"
 #include "JSystem/J3DGraphBase/J3DShape.h"
+#include "JSystem/J3DGraphBase/J3DShapeMtx.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JSupport/JSupport.h"
 #include "dolphin/os.h"

--- a/src/d/actor/d_a_npc.cpp
+++ b/src/d/actor/d_a_npc.cpp
@@ -10,127 +10,127 @@
 
 #ifdef DEBUG
 void daNpcT_cmnListenPropertyEvent(char* param_0, int* param_1, daNpcT_HIOParam* param_2) {
-    sprintf(&param_0[*param_1], "%.3ff,\t//  注目オフセット\n", param_2->unk0);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  注目オフセット\n", param_2->attention_offset);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  重力\n", param_2->unk4);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  重力\n", param_2->gravity);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  スケ−ル\n", param_2->unk8);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  スケ−ル\n", param_2->scale);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  リアル影サイズ\n", param_2->unkC);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  リアル影サイズ\n", param_2->real_shadow_size);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  体重\n", param_2->unk10);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  体重\n", param_2->weight);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  高さ\n", param_2->unk14);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  高さ\n", param_2->height);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  ひざ丈\n", param_2->unk18);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  ひざ丈\n", param_2->knee_length);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  幅\n", param_2->unk1C);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  幅\n", param_2->width);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＸ角上限\n", param_2->unk20);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＸ角上限\n", param_2->body_angleX_max);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＸ角下限\n", param_2->unk24);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＸ角下限\n", param_2->body_angleX_min);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＹ角上限\n", param_2->unk28);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＹ角上限\n", param_2->body_angleY_max);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＹ角下限\n", param_2->unk2C);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  腰のＹ角下限\n", param_2->body_angleY_min);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＸ角上限\n", param_2->unk30);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＸ角上限\n", param_2->head_angleX_max);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＸ角下限\n", param_2->unk34);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＸ角下限\n", param_2->head_angleX_min);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＹ角上限\n", param_2->unk38);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＹ角上限\n", param_2->head_angleY_max);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＹ角下限\n", param_2->unk3C);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  頭のＹ角下限\n", param_2->head_angleY_min);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  首の移動割合\n", param_2->unk40);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  首の移動割合\n", param_2->neck_rotation_ratio);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  補間フレ−ム\n", param_2->unk44);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  補間フレ−ム\n", param_2->morf_frame);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  会話距離\n", param_2->unk48);
+    sprintf(&param_0[*param_1], "%d,   \t//  会話距離\n", param_2->talk_distance);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  会話角度\n", param_2->unk4A);
+    sprintf(&param_0[*param_1], "%d,   \t//  会話角度\n", param_2->talk_angle);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  注目距離\n", param_2->unk4C);
+    sprintf(&param_0[*param_1], "%d,   \t//  注目距離\n", param_2->attention_distance);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  注目角度\n", param_2->unk4E);
+    sprintf(&param_0[*param_1], "%d,   \t//  注目角度\n", param_2->attention_angle);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  視界\n", param_2->unk50);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  視界\n", param_2->fov);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  サ−チ距離\n", param_2->unk54);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  サ−チ距離\n", param_2->search_distance);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  サ−チ高さ\n", param_2->unk58);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  サ−チ高さ\n", param_2->search_height);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  サ−チ低さ\n", param_2->unk5C);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  サ−チ低さ\n", param_2->search_depth);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  ？\n", param_2->unk60);
+    sprintf(&param_0[*param_1], "%d,   \t//  ？\n", param_2->attention_time);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  ？\n", param_2->unk62);
+    sprintf(&param_0[*param_1], "%d,   \t//  ？\n", param_2->damage_time);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  表情\n", param_2->unk64);
+    sprintf(&param_0[*param_1], "%d,   \t//  表情\n", param_2->face_expression);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  動作\n", param_2->unk66);
+    sprintf(&param_0[*param_1], "%d,   \t//  動作\n", param_2->motion);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  注視モ−ド\n", param_2->unk68);
+    sprintf(&param_0[*param_1], "%d,   \t//  注視モ−ド\n", param_2->look_mode);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  デバグモ−ドＯＮ\n", param_2->unk6A);
+    sprintf(&param_0[*param_1], "%d,   \t//  デバグモ−ドＯＮ\n", param_2->debug_mode_ON);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%d,   \t//  デバグ情報ＯＮ\n", param_2->unk6B);
+    sprintf(&param_0[*param_1], "%d,   \t//  デバグ情報ＯＮ\n", param_2->debug_info_ON);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  表情補間フレ−ム\n", param_2->unk6C);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  表情補間フレ−ム\n", param_2->expression_morf_frame);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最小ｘ\n", param_2->unk70);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最小ｘ\n", param_2->box_min_x);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最小ｙ\n", param_2->unk74);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最小ｙ\n", param_2->box_min_y);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最小ｚ\n", param_2->unk78);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最小ｚ\n", param_2->box_min_z);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最大ｘ\n", param_2->unk7C);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最大ｘ\n", param_2->box_max_x);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最大ｙ\n", param_2->unk80);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最大ｙ\n", param_2->box_max_y);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最大ｚ\n", param_2->unk84);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱最大ｚ\n", param_2->box_max_z);
     *param_1 = strlen(param_0);
 
-    sprintf(&param_0[*param_1], "%.3ff,\t//  箱オフセット\n", param_2->unk88);
+    sprintf(&param_0[*param_1], "%.3ff,\t//  箱オフセット\n", param_2->box_offset);
     *param_1 = strlen(param_0);
 }
 #endif

--- a/src/d/d_bg_parts.cpp
+++ b/src/d/d_bg_parts.cpp
@@ -1,0 +1,11 @@
+
+#include "JSystem/J3DGraphAnimator/J3DAnimation.h"
+
+static void dummy() {
+    ((J3DAnmTextureSRTKey*)0)->getUpdateMaterialID(0);
+    ((J3DAnmTextureSRTKey*)0)->getUpdateMaterialNum();
+    ((J3DAnmTevRegKey*)0)->getKRegUpdateMaterialID(0);
+    ((J3DAnmTevRegKey*)0)->getKRegUpdateMaterialNum();
+    ((J3DAnmTevRegKey*)0)->getCRegUpdateMaterialID(0);
+    ((J3DAnmTevRegKey*)0)->getCRegUpdateMaterialNum();
+}

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -4137,29 +4137,42 @@ void dFile_select3D_c::draw() {
 }
 
 /* 8019065C-8019095C 18AF9C 0300+00 2/2 0/0 0/0 .text setJ3D__16dFile_select3D_cFPCcPCcPCc */
-// NONMATCHING regswap
+// NONMATCHING extra mr
 void dFile_select3D_c::setJ3D(char const* param_0, char const* param_1, char const* param_2) {
     JKRArchive* archive = dComIfGp_getCollectResArchive();
-    J3DModelData* modelData = J3DModelLoaderDataBase::load(
-        archive->getResource('BMD ', param_0), 0x51020010);
+    J3DAnmTransform* pbck;
+    J3DAnmTevRegKey* pbrk;
+
+    void* res = archive->getResource('BMD ', param_0);
+    J3DModelData* modelData = J3DModelLoaderDataBase::load(res, 0x51020010);
+    JUT_ASSERT(8823, modelData != 0);
+
     for (u16 i = 0; i < modelData->getMaterialNum(); i++) {
         J3DMaterialAnm* material = new J3DMaterialAnm();
         modelData->getMaterialNodePointer(i)->change();
         modelData->getMaterialNodePointer(i)->setMaterialAnm(material);
     }
+
     mpModel = new J3DModel(modelData, 0, 1);
+    JUT_ASSERT(8836, mpModel != 0);
+
     if (param_1) {
-        J3DAnmTransform* pbck =
-            (J3DAnmTransform*)J3DAnmLoaderDataBase::load(archive->getResource('BCK ', param_1));
+        void* res = archive->getResource('BCK ', param_1);
+        pbck = (J3DAnmTransform*)J3DAnmLoaderDataBase::load(res);
+        JUT_ASSERT(8846, pbck != 0);
+
         mBckAnm = new mDoExt_bckAnm();
         if (mBckAnm == NULL || !mBckAnm->init(pbck, 1, 2, 1.0f, 0, -1, false)) {
             return;
         }
     }
+
     if (param_2) {
-        J3DAnmTevRegKey* pbrk =
-            (J3DAnmTevRegKey*)J3DAnmLoaderDataBase::load(archive->getResource('BRK ', param_2));
+        void* res = archive->getResource('BRK ', param_2);
+        pbrk = (J3DAnmTevRegKey*)J3DAnmLoaderDataBase::load(res);
+        JUT_ASSERT(8859, pbrk != 0);
         pbrk->searchUpdateMaterialID(modelData);
+
         mBrkAnm = new mDoExt_brkAnm();
         if (mBrkAnm == NULL || !mBrkAnm->init(modelData, pbrk, -1, 2, 1.0f, 0, -1)) {
             return;

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -2340,7 +2340,6 @@ void dMenu_Collect3D_c::draw() {
 }
 
 /* 801B6A30-801B6D30 1B1370 0300+00 2/2 0/0 0/0 .text setJ3D__17dMenu_Collect3D_cFPCcPCcPCc */
-// NONMATCHING regalloc
 void dMenu_Collect3D_c::setJ3D(const char* param_0, const char* param_1, const char* param_2) {
     JKRArchive* resArchive = dComIfGp_getCollectResArchive();
     J3DModelData* modelData = J3DModelLoaderDataBase::load(


### PR DESCRIPTION
Yesterday cadmic and I discovered that the `(void)0;` from J3D_ASSERTs ifdefed out for retail inside of inlines affects a number of things, including regalloc throughout the whole function that calls any of these inlines (e.g. dMenu_Collect3D_c::setJ3D), and instruction ordering around the places these inlines get called (e.g. J3DMaterialTable::entryTexMtxAnimator).

There's probably more of these asserts I missed, worth keeping in mind to check for missing debug asserts in the future when working on functions that call J3D inlines.