### PR TITLE
d_a_npc_zelda equivalent

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1861,7 +1861,7 @@ config.libs = [
     ActorRel(NonMatching, "d_a_npc_zant"),
     ActorRel(NonMatching, "d_a_npc_zelR"),
     ActorRel(NonMatching, "d_a_npc_zelRo"),
-    ActorRel(NonMatching, "d_a_npc_zelda"),
+    ActorRel(Equivalent, "d_a_npc_zelda"), # weak function order
     ActorRel(NonMatching, "d_a_npc_zra"),
     ActorRel(NonMatching, "d_a_npc_zrc"),
     ActorRel(NonMatching, "d_a_npc_zrz"),

--- a/include/Z2AudioLib/Z2AudioCS.h
+++ b/include/Z2AudioLib/Z2AudioCS.h
@@ -16,7 +16,7 @@ public:
     static void extensionProcess(s32, s32);
     u32 getHandleSoundID(s32);
     void start(s32, s32);
-    static void startLevel(s32, s32);
+    static int startLevel(s32, s32);
 };
 
 #endif /* Z2AUDIOCS_H */

--- a/include/d/actor/d_a_npc.h
+++ b/include/d/actor/d_a_npc.h
@@ -2,6 +2,7 @@
 #define D_A_D_A_NPC_H
 
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
+#include "SSystem/SComponent/c_counter.h"
 #include "SSystem/SComponent/c_math.h"
 #include "Z2AudioLib/Z2Creature.h"
 #include "d/actor/d_a_player.h"
@@ -55,8 +56,8 @@ public:
 
     void setNowOffsetX(f32 i_value) { mNowOffsetX = i_value; }
     void setNowOffsetY(f32 i_value) { mNowOffsetY = i_value; }
-    void onEyeMoveFlg() { mEyeMoveFlg = 1; }
-    void offEyeMoveFlg() { mEyeMoveFlg = 0; }
+    void onEyeMoveFlag() { mEyeMoveFlg = 1; }
+    void offEyeMoveFlag() { mEyeMoveFlg = 0; }
     void setMorfFrm(u8 i_value) { mMorfFrm = i_value; }
 };
 
@@ -157,7 +158,7 @@ public:
         mEyeAngle.x = field_0x132.x * (1.0f - 1.0f / param_2) +
                       sVar3 * (1.0f / param_2);
     }
-    
+
     void setEyeAngleY(cXyz param_1, s16 param_2, BOOL param_3, f32 param_4, s16 param_5) {
         cXyz cStack_50;
         s16 sVar3 = 0;
@@ -266,7 +267,7 @@ public:
         setMode(LOOK_PLAYER, FALSE);
         setDirect(isDirect);
     }
-    
+
     void lookCamera(u8 isDirect) {
         setMode(LOOK_CAMERA, FALSE);
         setDirect(isDirect);
@@ -313,8 +314,9 @@ public:
     /* 80147E3C */ void calc(BOOL);
 
     void initialize() {
+        u8 zero = 0;
         for (int i = 0; i < 2; i++) {
-            mAngle[i].setall(0);
+            mAngle[i].setall(zero);
             mPower[i] = 0.0f;
         }
         mStagger = 0;
@@ -481,7 +483,7 @@ public:
     /* 0x9C0 */ dPaPoT_c field_0x9c0;
     /* 0xA40 */ dCcD_Stts field_0xa40;
     /* 0xA7C */ u32 mFlowNodeNo;
-    /* 0xA80 */ f32 field_0xa80;
+    /* 0xA80 */ f32 mExpressionMorfFrame;
     /* 0xA84 */ f32 mMorfFrames;
     /* 0xA88 */ bool mCreating;
     /* 0xA89 */ bool mTwilight;
@@ -530,7 +532,7 @@ public:
     /* 0xDDC */ f32 mTurnCount;
     /* 0xDE0 */ f32 field_0xde0;
     /* 0xDE4 */ f32 field_0xde4;
-    /* 0xDE8 */ f32 field_0xde8;
+    /* 0xDE8 */ f32 mRealShadowSize;
     /* 0xDEC */ f32 mCylH;
     /* 0xDF0 */ f32 mWallR;
     /* 0xDF4 */ f32 mGroundH;
@@ -578,6 +580,7 @@ public:
         mpArcNames(i_arcNames),
         mFaceMotionSeqMngr(i_faceMotionSequenceData, i_faceMotionStepNum),
         mMotionSeqMngr(i_motionSequenceData, i_motionStepNum) {
+        OS_REPORT("|%06d:%x|daNpcT_c -> コンストラクト\n", g_Counter.mCounter0, this);
         initialize();
     }
 
@@ -644,9 +647,9 @@ public:
     /* 8014CC4C */ virtual s32 getHeadJointNo() { return -1; }
     /* 8014CC90 */ virtual s32 getFootLJointNo() { return -1; }
     /* 8014CC88 */ virtual s32 getFootRJointNo() { return -1; }
-    /* 8014D0A8 */ virtual s32 getEyeballLMaterialNo() { return 0; }
-    /* 8014D0B0 */ virtual s32 getEyeballRMaterialNo() { return 0; }
-    /* 8014D0B8 */ virtual s32 getEyeballMaterialNo() { return 0; }
+    /* 8014D0A8 */ virtual u16 getEyeballLMaterialNo() { return 0; }
+    /* 8014D0B0 */ virtual u16 getEyeballRMaterialNo() { return 0; }
+    /* 8014D0B8 */ virtual u16 getEyeballMaterialNo() { return 0; }
     /* 8014951C */ virtual int ctrlJoint(J3DJoint*, J3DModel*);
     /* 8014CC48 */ virtual void afterJntAnm(int) {}
     /* 8014CC24 */ virtual void setParam() {}
@@ -1222,7 +1225,7 @@ private:
     /* 0x00 */ u16 mNurbs;
     /* 0x02 */ u16 field_0x02;
     /* 0x04 */ u8 mIsReversed;
-    /* 0x05 */ bool mIsClosed;
+    /* 0x05 */ u8 mIsClosed;
     /* 0x08 */ dPnt mPoints[96];
 
 public:
@@ -1367,6 +1370,10 @@ struct daNpcT_HIOParam {
     /* 0x84 */ f32 box_max_z;
     /* 0x88 */ f32 box_offset;
 };
+
+void daNpcT_cmnGenMessage(JORMContext*, daNpcT_HIOParam* param_1);
+
+void daNpcT_cmnListenPropertyEvent(char*, int*, daNpcT_HIOParam*);
 
 struct daNpcF_HIOParam {
     /* 0x00 */ f32 attention_offset;

--- a/include/d/actor/d_a_npc_aru.h
+++ b/include/d/actor/d_a_npc_aru.h
@@ -65,7 +65,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 809575B4 */ s32 getEyeballMaterialNo();
+    /* 809575B4 */ u16 getEyeballMaterialNo();
     /* 809575BC */ s32 getHeadJointNo();
     /* 809575C4 */ s32 getNeckJointNo();
     /* 809575CC */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_bans.h
+++ b/include/d/actor/d_a_npc_bans.h
@@ -56,7 +56,7 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_evtData_c const*, char**);
-    /* 80967BE4 */ s32 getEyeballMaterialNo();
+    /* 80967BE4 */ u16 getEyeballMaterialNo();
     /* 80967BEC */ s32 getHeadJointNo();
     /* 80967BF4 */ s32 getNeckJointNo();
     /* 80967BFC */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_besu.h
+++ b/include/d/actor/d_a_npc_besu.h
@@ -90,7 +90,7 @@ public:
         // "construct"
         OS_REPORT("|%06d:%x|daNpc_Besu_c -> コンストラクト\n", g_Counter.mCounter0, this);
     }
-    /* 8053E6A8 */ s32 getEyeballMaterialNo() { return 2; }
+    /* 8053E6A8 */ u16 getEyeballMaterialNo() { return 2; }
     /* 8053E6B0 */ s32 getHeadJointNo() { return 4; }
     /* 8053E6B8 */ s32 getNeckJointNo() { return 3; }
     /* 8053E6C0 */ s32 getBackboneJointNo() { return true; }

--- a/include/d/actor/d_a_npc_bou.h
+++ b/include/d/actor/d_a_npc_bou.h
@@ -117,7 +117,7 @@ public:
     /* 809727CC */ virtual s32 getBackboneJointNo();
     /* 809727C4 */ virtual s32 getNeckJointNo();
     /* 809727BC */ virtual s32 getHeadJointNo();
-    /* 809727B4 */ virtual s32 getEyeballMaterialNo();
+    /* 809727B4 */ virtual u16 getEyeballMaterialNo();
     /* 8096DD44 */ virtual void afterJntAnm(int);
     /* 8096DDC8 */ virtual void setParam();
     /* 8096DF9C */ virtual BOOL checkChangeEvt();
@@ -206,7 +206,7 @@ private:
 STATIC_ASSERT(sizeof(daNpc_Bou_c) == 0xffc);
 
 /* 809727B4-809727BC 005914 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Bou_cFv */
-s32 daNpc_Bou_c::getEyeballMaterialNo() {
+u16 daNpc_Bou_c::getEyeballMaterialNo() {
     return 1;
 }
 

--- a/include/d/actor/d_a_npc_clerka.h
+++ b/include/d/actor/d_a_npc_clerka.h
@@ -47,7 +47,7 @@ public:
                                   daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                   daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                   daNpcT_evtData_c const*, char**);
-    /* 80995694 */ s32 getEyeballMaterialNo();
+    /* 80995694 */ u16 getEyeballMaterialNo();
     /* 8099569C */ s32 getHeadJointNo();
     /* 809956A4 */ s32 getNeckJointNo();
     /* 809956AC */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_clerkb.h
+++ b/include/d/actor/d_a_npc_clerkb.h
@@ -51,7 +51,7 @@ public:
                                   daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                   daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                   daNpcT_evtData_c const*, char**);
-    /* 809997AC */ s32 getEyeballMaterialNo();
+    /* 809997AC */ u16 getEyeballMaterialNo();
     /* 809997B4 */ s32 getHeadJointNo();
     /* 809997BC */ s32 getNeckJointNo();
     /* 809997C4 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_clerkt.h
+++ b/include/d/actor/d_a_npc_clerkt.h
@@ -45,7 +45,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 8099D068 */ s32 getEyeballMaterialNo();
+    /* 8099D068 */ u16 getEyeballMaterialNo();
     /* 8099D070 */ void checkChangeJoint(int);
     /* 8099D080 */ void checkRemoveJoint(int);
     /* 8099D090 */ s32 getBackboneJointNo();

--- a/include/d/actor/d_a_npc_doc.h
+++ b/include/d/actor/d_a_npc_doc.h
@@ -46,7 +46,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 809AA24C */ s32 getEyeballMaterialNo();
+    /* 809AA24C */ u16 getEyeballMaterialNo();
     /* 809AA254 */ s32 getHeadJointNo();
     /* 809AA25C */ s32 getNeckJointNo();
     /* 809AA264 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_fairy.h
+++ b/include/d/actor/d_a_npc_fairy.h
@@ -107,7 +107,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 809B9238 */ s32 getEyeballMaterialNo();
+    /* 809B9238 */ u16 getEyeballMaterialNo();
     /* 809B9240 */ s32 getHeadJointNo();
     /* 809B9248 */ s32 getNeckJointNo();
     /* 809B9250 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_gnd.h
+++ b/include/d/actor/d_a_npc_gnd.h
@@ -56,8 +56,8 @@ public:
                                daNpcT_evtData_c const* param_7, char** param_8) :
                                daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8)
                                 {}
-    /* 809BE40C */ s32 getEyeballRMaterialNo();
-    /* 809BE414 */ s32 getEyeballLMaterialNo();
+    /* 809BE40C */ u16 getEyeballRMaterialNo();
+    /* 809BE414 */ u16 getEyeballLMaterialNo();
     /* 809BE41C */ s32 getHeadJointNo();
     /* 809BE424 */ s32 getNeckJointNo();
     /* 809BE42C */ s32 getBackboneJointNo();

--- a/include/d/actor/d_a_npc_grm.h
+++ b/include/d/actor/d_a_npc_grm.h
@@ -50,7 +50,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 809D5F98 */ s32 getEyeballMaterialNo();
+    /* 809D5F98 */ u16 getEyeballMaterialNo();
     /* 809D5FA0 */ s32 getHeadJointNo();
     /* 809D5FA8 */ s32 getNeckJointNo();
     /* 809D5FB0 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_grmc.h
+++ b/include/d/actor/d_a_npc_grmc.h
@@ -53,7 +53,7 @@ public:
     /* 809D8FE4 */ bool getBackboneJointNo();
     /* 809D8FEC */ void checkChangeJoint(int);
     /* 809D8FFC */ void checkRemoveJoint(int);
-    /* 809D900C */ s32 getEyeballMaterialNo();
+    /* 809D900C */ u16 getEyeballMaterialNo();
 
     static void* mCutNameList;
     static u8 mCutList[12];

--- a/include/d/actor/d_a_npc_hanjo.h
+++ b/include/d/actor/d_a_npc_hanjo.h
@@ -157,7 +157,7 @@ public:
                                  daNpcT_evtData_c const* param_7, char** param_8) :
                                  daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8)
                                   {}
-    /* 80A00334 */ s32 getEyeballMaterialNo() { return 2; }
+    /* 80A00334 */ u16 getEyeballMaterialNo() { return 2; }
     /* 80A004D0 */ s32 getHeadJointNo() { return 4; }
     /* 80A004D8 */ s32 getNeckJointNo() { return 3; }
     /* 80A004E0 */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/actor/d_a_npc_hoz.h
+++ b/include/d/actor/d_a_npc_hoz.h
@@ -71,7 +71,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 80A065A4 */ s32 getEyeballMaterialNo();
+    /* 80A065A4 */ u16 getEyeballMaterialNo();
     /* 80A065AC */ s32 getHeadJointNo();
     /* 80A065B4 */ s32 getNeckJointNo();
     /* 80A065BC */ s32 getBackboneJointNo();

--- a/include/d/actor/d_a_npc_jagar.h
+++ b/include/d/actor/d_a_npc_jagar.h
@@ -146,7 +146,7 @@ public:
                                 daNpcT_evtData_c const* param_7, char** param_8) :
                                 daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8)
                                  {}
-    /* 80A1A274 */ s32 getEyeballMaterialNo() { return 1; }
+    /* 80A1A274 */ u16 getEyeballMaterialNo() { return 1; }
     /* 80A1A27C */ s32 getHeadJointNo() { return 4; }
     /* 80A1A284 */ s32 getNeckJointNo() { return 3; }
     /* 80A1A28C */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/actor/d_a_npc_kkri.h
+++ b/include/d/actor/d_a_npc_kkri.h
@@ -50,7 +50,7 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_evtData_c const*, char**);
-    /* 805533E4 */ s32 getEyeballMaterialNo();
+    /* 805533E4 */ u16 getEyeballMaterialNo();
     /* 805533EC */ s32 getHeadJointNo();
     /* 805533F4 */ s32 getNeckJointNo();
     /* 805533FC */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_kn.h
+++ b/include/d/actor/d_a_npc_kn.h
@@ -317,9 +317,9 @@ public:
     /* 80A3949C */ virtual int ctrlBtk();
     /* 80A3B7B4 */ virtual s32 getFootLJointNo();
     /* 80A3B7AC */ virtual s32 getFootRJointNo();
-    /* 80A3BD1C */ virtual int getEyeballLMaterialNo();
-    /* 80A3BD24 */ virtual s32 getEyeballRMaterialNo();
-    /* 80A3BD14 */ virtual s32 getEyeballMaterialNo();
+    /* 80A3BD1C */ virtual u16 getEyeballLMaterialNo();
+    /* 80A3BD24 */ virtual u16 getEyeballRMaterialNo();
+    /* 80A3BD14 */ virtual u16 getEyeballMaterialNo();
     /* 80A3989C */ virtual int ctrlJoint(J3DJoint*, J3DModel*);
     /* 80A3B720 */ virtual void afterJntAnm(int);
     /* 80A3B7A4 */ virtual BOOL checkChangeEvt();

--- a/include/d/actor/d_a_npc_kolin.h
+++ b/include/d/actor/d_a_npc_kolin.h
@@ -58,7 +58,7 @@ public:
     /* 8055A4A0 */ virtual s32 getHeadJointNo();
     /* 8055A4D8 */ virtual s32 getFootLJointNo();
     /* 8055A4E0 */ virtual s32 getFootRJointNo();
-    /* 8055A498 */ virtual s32 getEyeballMaterialNo();
+    /* 8055A498 */ virtual u16 getEyeballMaterialNo();
     /* 80554EBC */ virtual void afterJntAnm(int);
     /* 80554F48 */ virtual void setParam();
     /* 80555118 */ virtual BOOL checkChangeEvt();

--- a/include/d/actor/d_a_npc_kyury.h
+++ b/include/d/actor/d_a_npc_kyury.h
@@ -47,7 +47,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80A63800 */ s32 getEyeballMaterialNo();
+    /* 80A63800 */ u16 getEyeballMaterialNo();
     /* 80A63808 */ s32 getHeadJointNo();
     /* 80A63810 */ s32 getNeckJointNo();
     /* 80A63818 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_len.h
+++ b/include/d/actor/d_a_npc_len.h
@@ -50,7 +50,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 80A68DE0 */ s32 getEyeballMaterialNo();
+    /* 80A68DE0 */ u16 getEyeballMaterialNo();
     /* 80A68DE8 */ s32 getHeadJointNo();
     /* 80A68DF0 */ s32 getNeckJointNo();
     /* 80A68DF8 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_lud.h
+++ b/include/d/actor/d_a_npc_lud.h
@@ -58,7 +58,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 80A6FCD0 */ s32 getEyeballMaterialNo();
+    /* 80A6FCD0 */ u16 getEyeballMaterialNo();
     /* 80A6FCD8 */ s32 getHeadJointNo();
     /* 80A6FCE0 */ s32 getNeckJointNo();
     /* 80A6FCE8 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_maro.h
+++ b/include/d/actor/d_a_npc_maro.h
@@ -108,7 +108,7 @@ public:
                    i_arcNames) {
         OS_REPORT("|%06d:%x|daNpc_Maro_c -> コンストラクト\n", g_Counter.mCounter0, this);
     }
-    /* 80564970 */ s32 getEyeballMaterialNo();
+    /* 80564970 */ u16 getEyeballMaterialNo();
     /* 80564978 */ s32 getHeadJointNo();
     /* 80564980 */ s32 getNeckJointNo();
     /* 80564988 */ s32 getBackboneJointNo();

--- a/include/d/actor/d_a_npc_midp.h
+++ b/include/d/actor/d_a_npc_midp.h
@@ -55,8 +55,8 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_5, int param_6,
                                 daNpcT_evtData_c const* param_7, char** param_8) :
                                 daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8) {}
-    /* 80A7390C */ s32 getEyeballRMaterialNo();
-    /* 80A73914 */ s32 getEyeballLMaterialNo();
+    /* 80A7390C */ u16 getEyeballRMaterialNo();
+    /* 80A73914 */ u16 getEyeballLMaterialNo();
     /* 80A7391C */ s32 getHeadJointNo();
     /* 80A73924 */ s32 getNeckJointNo();
     /* 80A7392C */ s32 getBackboneJointNo();

--- a/include/d/actor/d_a_npc_moi.h
+++ b/include/d/actor/d_a_npc_moi.h
@@ -146,7 +146,7 @@ public:
         : daNpcT_c(i_faceMotionAnmData, i_motionAnmData, i_faceMotionSequenceData,
                    i_faceMotionStepNum, i_motionSequenceData, i_motionStepNum, i_evtData,
                    i_arcNames) {}
-    /* 80A7AE0C */ s32 getEyeballMaterialNo() { return chkMoiN() ? 4 : 2; }
+    /* 80A7AE0C */ u16 getEyeballMaterialNo() { if (chkMoiN()) { return 4; } else { return 2; } }
     /* 80A7AE3C */ s32 getHeadJointNo() { return 4; }
     /* 80A7AE44 */ s32 getNeckJointNo() { return 3; }
     /* 80A7AE4C */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/actor/d_a_npc_pachi_besu.h
+++ b/include/d/actor/d_a_npc_pachi_besu.h
@@ -80,7 +80,7 @@ public:
                                       daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                       daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                       daNpcT_evtData_c const*, char**);
-    /* 80A969C0 */ s32 getEyeballMaterialNo();
+    /* 80A969C0 */ u16 getEyeballMaterialNo();
     /* 80A969C8 */ s32 getHeadJointNo();
     /* 80A969D0 */ s32 getNeckJointNo();
     /* 80A969D8 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_pachi_maro.h
+++ b/include/d/actor/d_a_npc_pachi_maro.h
@@ -82,7 +82,7 @@ public:
                                       daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                       daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                       daNpcT_evtData_c const*, char**);
-    /* 80A9B7E0 */ s32 getEyeballMaterialNo();
+    /* 80A9B7E0 */ u16 getEyeballMaterialNo();
     /* 80A9B7E8 */ s32 getHeadJointNo();
     /* 80A9B7F0 */ s32 getNeckJointNo();
     /* 80A9B7F8 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_pachi_taro.h
+++ b/include/d/actor/d_a_npc_pachi_taro.h
@@ -98,7 +98,7 @@ public:
                                       daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                       daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                       daNpcT_evtData_c const*, char**);
-    /* 80AA1558 */ s32 getEyeballMaterialNo();
+    /* 80AA1558 */ u16 getEyeballMaterialNo();
     /* 80AA1560 */ s32 getHeadJointNo();
     /* 80AA1568 */ s32 getNeckJointNo();
     /* 80AA1570 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_post.h
+++ b/include/d/actor/d_a_npc_post.h
@@ -53,7 +53,7 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_evtData_c const*, char**);
-    /* 80AAD0D0 */ s32 getEyeballMaterialNo();
+    /* 80AAD0D0 */ u16 getEyeballMaterialNo();
     /* 80AAD0D8 */ s32 getHeadJointNo();
     /* 80AAD0E0 */ s32 getNeckJointNo();
     /* 80AAD0E8 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_pouya.h
+++ b/include/d/actor/d_a_npc_pouya.h
@@ -50,7 +50,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80AB1F54 */ s32 getEyeballMaterialNo();
+    /* 80AB1F54 */ u16 getEyeballMaterialNo();
     /* 80AB1F5C */ s32 getHeadJointNo();
     /* 80AB1F64 */ s32 getNeckJointNo();
     /* 80AB1F6C */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_raca.h
+++ b/include/d/actor/d_a_npc_raca.h
@@ -47,7 +47,7 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_evtData_c const*, char**);
-    /* 80AB8DAC */ s32 getEyeballMaterialNo();
+    /* 80AB8DAC */ u16 getEyeballMaterialNo();
     /* 80AB8DB4 */ s32 getHeadJointNo();
     /* 80AB8DBC */ s32 getNeckJointNo();
     /* 80AB8DC4 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_seira.h
+++ b/include/d/actor/d_a_npc_seira.h
@@ -66,7 +66,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80ACFC14 */ s32 getEyeballMaterialNo();
+    /* 80ACFC14 */ u16 getEyeballMaterialNo();
     /* 80ACFC1C */ s32 getHeadJointNo();
     /* 80ACFC24 */ s32 getNeckJointNo();
     /* 80ACFC2C */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_seira2.h
+++ b/include/d/actor/d_a_npc_seira2.h
@@ -58,7 +58,7 @@ public:
                                   daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                   daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                   daNpcT_evtData_c const*, char**);
-    /* 80AD4884 */ s32 getEyeballMaterialNo();
+    /* 80AD4884 */ u16 getEyeballMaterialNo();
     /* 80AD488C */ s32 getHeadJointNo();
     /* 80AD4894 */ s32 getNeckJointNo();
     /* 80AD489C */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_shaman.h
+++ b/include/d/actor/d_a_npc_shaman.h
@@ -59,7 +59,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 80AE6B1C */ s32 getEyeballMaterialNo();
+    /* 80AE6B1C */ u16 getEyeballMaterialNo();
     /* 80AE6B24 */ s32 getHeadJointNo();
     /* 80AE6B2C */ s32 getNeckJointNo();
     /* 80AE6B34 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_taro.h
+++ b/include/d/actor/d_a_npc_taro.h
@@ -163,7 +163,7 @@ public:
                    i_arcNames) {
         OS_REPORT("|%06d:%x|daNpc_Taro_c -> コンストラクト\n", g_Counter.mCounter0, this);
     }
-    /* 805715AC */ s32 getEyeballMaterialNo() { return 2; }
+    /* 805715AC */ u16 getEyeballMaterialNo() { return 2; }
     /* 805715B4 */ s32 getHeadJointNo() { return 4; }
     /* 805715BC */ s32 getNeckJointNo() { return 3; }
     /* 805715C4 */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/actor/d_a_npc_tkj.h
+++ b/include/d/actor/d_a_npc_tkj.h
@@ -45,7 +45,7 @@ public:
                               daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                               daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                               daNpcT_evtData_c const*, char**);
-    /* 805764EC */ s32 getEyeballMaterialNo();
+    /* 805764EC */ u16 getEyeballMaterialNo();
     /* 805764F4 */ s32 getHeadJointNo();
     /* 805764FC */ s32 getNeckJointNo();
     /* 80576504 */ s32 getBackboneJointNo();

--- a/include/d/actor/d_a_npc_toby.h
+++ b/include/d/actor/d_a_npc_toby.h
@@ -60,7 +60,7 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_evtData_c const*, char**);
-    /* 80B24920 */ s32 getEyeballMaterialNo();
+    /* 80B24920 */ u16 getEyeballMaterialNo();
     /* 80B24928 */ s32 getHeadJointNo();
     /* 80B24930 */ s32 getNeckJointNo();
     /* 80B24938 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_uri.h
+++ b/include/d/actor/d_a_npc_uri.h
@@ -139,7 +139,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_5,
                                int param_6, daNpcT_evtData_c const* param_7, char** param_8)
         : daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8) {}
-    /* 80B2CD44 */ s32 getEyeballMaterialNo() { return 2; }
+    /* 80B2CD44 */ u16 getEyeballMaterialNo() { return 2; }
     /* 80B2CD4C */ s32 getHeadJointNo() { return 4; }
     /* 80B2CD54 */ s32 getNeckJointNo() { return 3; }
     /* 80B2CD5C */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/actor/d_a_npc_yamid.h
+++ b/include/d/actor/d_a_npc_yamid.h
@@ -49,7 +49,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80B45F34 */ s32 getEyeballMaterialNo();
+    /* 80B45F34 */ u16 getEyeballMaterialNo();
     /* 80B45F3C */ s32 getHeadJointNo();
     /* 80B45F44 */ s32 getNeckJointNo();
     /* 80B45F4C */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_yamis.h
+++ b/include/d/actor/d_a_npc_yamis.h
@@ -49,7 +49,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80B49598 */ s32 getEyeballMaterialNo();
+    /* 80B49598 */ u16 getEyeballMaterialNo();
     /* 80B495A0 */ s32 getHeadJointNo();
     /* 80B495A8 */ s32 getNeckJointNo();
     /* 80B495B0 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_yamit.h
+++ b/include/d/actor/d_a_npc_yamit.h
@@ -52,7 +52,7 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80B4CCF8 */ s32 getEyeballMaterialNo();
+    /* 80B4CCF8 */ u16 getEyeballMaterialNo();
     /* 80B4CD00 */ s32 getHeadJointNo();
     /* 80B4CD08 */ s32 getNeckJointNo();
     /* 80B4CD10 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_yelia.h
+++ b/include/d/actor/d_a_npc_yelia.h
@@ -58,7 +58,7 @@ public:
                         : daNpcT_c(i_faceMotionAnmData, i_motionAnmData, i_faceMotionSequenceData,
                         i_faceMotionStepNum, i_motionSequenceData, i_motionStepNum, i_evtData,
                         i_arcNames) {}
-    /* 80B521E4 */ s32 getEyeballMaterialNo() { return 1; }
+    /* 80B521E4 */ u16 getEyeballMaterialNo() { return 1; }
     /* 80B521EC */ s32 getHeadJointNo() { return 4; }
     /* 80B521F4 */ s32 getNeckJointNo() { return 3; }
     /* 80B521FC */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/actor/d_a_npc_ykm.h
+++ b/include/d/actor/d_a_npc_ykm.h
@@ -73,7 +73,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 80B5D688 */ s32 getEyeballMaterialNo();
+    /* 80B5D688 */ u16 getEyeballMaterialNo();
     /* 80B5D690 */ s32 getHeadJointNo();
     /* 80B5D698 */ s32 getNeckJointNo();
     /* 80B5D6A0 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_ykw.h
+++ b/include/d/actor/d_a_npc_ykw.h
@@ -66,7 +66,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
-    /* 80B67B1C */ s32 getEyeballMaterialNo();
+    /* 80B67B1C */ u16 getEyeballMaterialNo();
     /* 80B67B24 */ s32 getHeadJointNo();
     /* 80B67B2C */ s32 getNeckJointNo();
     /* 80B67B34 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_zanb.h
+++ b/include/d/actor/d_a_npc_zanb.h
@@ -46,7 +46,7 @@ public:
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                 daNpcT_evtData_c const*, char**);
-    /* 80B6BC18 */ s32 getEyeballMaterialNo();
+    /* 80B6BC18 */ u16 getEyeballMaterialNo();
     /* 80B6BC20 */ s32 getHeadJointNo();
     /* 80B6BC28 */ s32 getNeckJointNo();
     /* 80B6BC30 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_zelR.h
+++ b/include/d/actor/d_a_npc_zelR.h
@@ -57,8 +57,8 @@ public:
                                 daNpcT_evtData_c const* param_7, char** param_8) :
                                 daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8)
                                  {}
-    /* 80B71A34 */ s32 getEyeballRMaterialNo();
-    /* 80B71A3C */ s32 getEyeballLMaterialNo();
+    /* 80B71A34 */ u16 getEyeballRMaterialNo();
+    /* 80B71A3C */ u16 getEyeballLMaterialNo();
     /* 80B71A44 */ s32 getHeadJointNo();
     /* 80B71A4C */ s32 getBackboneJointNo();
     /* 80B71A54 */ BOOL checkChangeJoint(int param_1) { return param_1 == 3; };

--- a/include/d/actor/d_a_npc_zelRo.h
+++ b/include/d/actor/d_a_npc_zelRo.h
@@ -47,8 +47,8 @@ public:
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80B74BA8 */ s32 getEyeballRMaterialNo();
-    /* 80B74BB0 */ s32 getEyeballLMaterialNo();
+    /* 80B74BA8 */ u16 getEyeballRMaterialNo();
+    /* 80B74BB0 */ u16 getEyeballLMaterialNo();
     /* 80B74BB8 */ s32 getHeadJointNo();
     /* 80B74BC0 */ s32 getNeckJointNo();
     /* 80B74BC8 */ bool getBackboneJointNo();

--- a/include/d/actor/d_a_npc_zelda.h
+++ b/include/d/actor/d_a_npc_zelda.h
@@ -3,6 +3,41 @@
 
 #include "d/actor/d_a_npc.h"
 
+class daNpc_Zelda_HIOParam {
+public:
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+STATIC_ASSERT(sizeof(daNpc_Zelda_HIOParam) == 0x8c);
+
+class daNpc_Zelda_Param_c {
+public:
+    /* 80B77F5C */ virtual ~daNpc_Zelda_Param_c();
+
+    static const daNpc_Zelda_HIOParam m;
+};
+
+class daNpc_Zelda_HIO_c
+#if DEBUG
+    : public mDoHIO_entry_c
+#endif
+{
+public:
+    daNpc_Zelda_HIO_c();
+
+    void genMessage(JORMContext* ctx);
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+#if DEBUG
+    daNpc_Zelda_HIOParam param;
+#endif
+};
+
+class daNpc_Zelda_c;
+
+typedef int (daNpc_Zelda_c::*cutFunc)(int);
+typedef int (daNpc_Zelda_c::*actionFunc)(void*);
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Zelda_c
@@ -11,64 +46,68 @@
  * @details
  *
  */
-class daNpc_Zelda_c : public fopAc_ac_c {
+class daNpc_Zelda_c : public daNpcT_c {
 public:
-    /* 80B7512C */ ~daNpc_Zelda_c();
-    /* 80B7524C */ void create();
-    /* 80B75530 */ void CreateHeap();
-    /* 80B75978 */ void Delete();
-    /* 80B759AC */ void Execute();
-    /* 80B759CC */ void Draw();
-    /* 80B75A90 */ void createHeapCallBack(fopAc_ac_c*);
-    /* 80B75AB0 */ void ctrlJointCallBack(J3DJoint*, int);
-    /* 80B75B08 */ void getType();
-    /* 80B75B28 */ bool isDelete();
+    /* 80B7512C */ virtual ~daNpc_Zelda_c();
+    u8 getPathID() {
+        return (fopAcM_GetParam(this) & 0xff00) >> 8;
+    }
+    int getFlowNodeNo() {
+        u16 pitch = home.angle.x;
+        return pitch == 0xffff ? -1 : pitch;
+    }
+    /* 80B7524C */ int create();
+    /* 80B75530 */ int CreateHeap();
+    /* 80B75978 */ int Delete();
+    /* 80B759AC */ int Execute();
+    /* 80B759CC */ int Draw();
+    /* 80B75A90 */ static int createHeapCallBack(fopAc_ac_c*);
+    /* 80B75AB0 */ static int ctrlJointCallBack(J3DJoint*, int);
+    /* 80B75B08 */ u8 getType();
+    /* 80B75B28 */ int isDelete();
     /* 80B75B30 */ void reset();
     /* 80B75C9C */ void afterJntAnm(int);
-    /* 80B75D28 */ void ctrlBtk();
-    /* 80B75E34 */ void checkChangeEvt();
+    /* 80B75D28 */ int ctrlBtk();
+    /* 80B75E34 */ int checkChangeEvt();
     /* 80B75EE8 */ void setParam();
     /* 80B76014 */ void setAfterTalkMotion();
     /* 80B76074 */ void srchActors();
-    /* 80B76078 */ void evtTalk();
-    /* 80B76118 */ void evtCutProc();
+    /* 80B76078 */ int evtTalk();
+    /* 80B76118 */ int evtCutProc();
     /* 80B761E0 */ void action();
     /* 80B762CC */ void beforeMove();
     /* 80B76344 */ void setAttnPos();
     /* 80B765D4 */ void setCollision();
-    /* 80B76774 */ bool drawDbgInfo();
-    /* 80B7677C */ void selectAction();
-    /* 80B767C4 */ void chkAction(int (daNpc_Zelda_c::*)(void*));
-    /* 80B767F0 */ void setAction(int (daNpc_Zelda_c::*)(void*));
-    /* 80B76898 */ void wait(void*);
-    /* 80B76B74 */ void talk(void*);
+    /* 80B76774 */ int drawDbgInfo();
+    /* 80B7677C */ int selectAction();
+    /* 80B767C4 */ BOOL chkAction(actionFunc);
+    /* 80B767F0 */ BOOL setAction(actionFunc);
+    /* 80B76898 */ int wait(void*);
+    /* 80B76B74 */ int talk(void*);
     /* 80B77DD8 */ daNpc_Zelda_c(daNpcT_faceMotionAnmData_c const*, daNpcT_motionAnmData_c const*,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                  daNpcT_evtData_c const*, char**);
-    /* 80B77F14 */ s32 getEyeballRMaterialNo();
-    /* 80B77F1C */ s32 getEyeballLMaterialNo();
+    /* 80B77F14 */ u16 getEyeballRMaterialNo();
+    /* 80B77F1C */ u16 getEyeballLMaterialNo();
     /* 80B77F24 */ s32 getHeadJointNo();
     /* 80B77F2C */ s32 getNeckJointNo();
-    /* 80B77F34 */ bool getBackboneJointNo();
-    /* 80B77F3C */ void checkChangeJoint(int);
-    /* 80B77F4C */ void checkRemoveJoint(int);
+    /* 80B77F34 */ s32 getBackboneJointNo();
+    /* 80B77F3C */ int checkChangeJoint(int);
+    /* 80B77F4C */ int checkRemoveJoint(int);
 
-    static void* mCutNameList;
-    static u8 mCutList[12];
+    static const char* mCutNameList;
+    static cutFunc mCutList[1];
 
 private:
-    /* 0x568 */ u8 field_0x568[0xfa0 - 0x568];
+    /* 0xE40 */ daNpc_Zelda_HIO_c* mHIO;
+    /* 0xE44 */ dCcD_Cyl mCyl;
+    /* 0xF80 */ u8 field_0xf80;
+    /* 0xF84 */ actionFunc mAction1;
+    /* 0xF90 */ actionFunc mAction2;
+    /* 0xF9C */ u8 field_0xf9c[0xfa0 - 0xf9c];
 };
 
 STATIC_ASSERT(sizeof(daNpc_Zelda_c) == 0xfa0);
-
-class daNpc_Zelda_Param_c {
-public:
-    /* 80B77F5C */ ~daNpc_Zelda_Param_c();
-
-    static u8 const m[140];
-};
-
 
 #endif /* D_A_NPC_ZELDA_H */

--- a/include/d/actor/d_a_peru.h
+++ b/include/d/actor/d_a_peru.h
@@ -68,7 +68,7 @@ public:
         : daNpcT_c(param_1, param_2, param_3, param_4, param_5, param_6, param_7, param_8) {
             OS_REPORT("|%06d:%x|daPeru_c -> コンストラクト\n", g_Counter.mCounter0, this);
         }
-    /* 80D4BEC4 */ s32 getEyeballMaterialNo() { return 1; }
+    /* 80D4BEC4 */ u16 getEyeballMaterialNo() { return 1; }
     /* 80D4BECC */ s32 getHeadJointNo() { return 4; }
     /* 80D4BED4 */ s32 getNeckJointNo() { return 3; }
     /* 80D4BEDC */ s32 getBackboneJointNo() { return 1; }

--- a/include/d/d_path.h
+++ b/include/d/d_path.h
@@ -25,7 +25,7 @@ struct dPath {
     /* 0x8 */ dPnt* m_points;
 };
 
-inline BOOL dPath_ChkClose(dPath* i_path) { return i_path->m_closed & 1; }
+inline BOOL dPath_ChkClose(const dPath* i_path) { return i_path->m_closed & 1; }
 
 dPath* dPath_GetRoomPath(int path_index, int room_no);
 dPath* dPath_GetNextRoomPath(dPath const* i_path, int room_no);

--- a/src/d/actor/d_a_npc.cpp
+++ b/src/d/actor/d_a_npc.cpp
@@ -1581,7 +1581,7 @@ BOOL daNpcT_c::ctrlBtk() {
                 field_0xe2a = 0;
             }
 
-            mpMatAnm[0]->onEyeMoveFlg();
+            mpMatAnm[0]->onEyeMoveFlag();
             return TRUE;
         }
 
@@ -1590,7 +1590,7 @@ BOOL daNpcT_c::ctrlBtk() {
             field_0xe2a = 0;
         }
 
-        mpMatAnm[0]->offEyeMoveFlg();
+        mpMatAnm[0]->offEyeMoveFlag();
     }
 
     return FALSE;
@@ -1629,11 +1629,11 @@ void daNpcT_c::ctrlFaceMotion() {
         setFaceMotionAnm(motionNo, true);
 
         if (morfFrm < 0.0f) {
-            mpMorf[0]->setMorf(field_0xa80);
-            field_0xdfc = field_0xa80;
+            mpMorf[0]->setMorf(mExpressionMorfFrame);
+            field_0xdfc = mExpressionMorfFrame;
 
             if (mpMorf[1]) {
-                mpMorf[1]->setMorf(field_0xa80);
+                mpMorf[1]->setMorf(mExpressionMorfFrame);
             }
         } else {
             mpMorf[0]->setMorf(morfFrm);
@@ -2839,6 +2839,149 @@ void daNpcT_offTmpBit(u32 i_no) {
 /* 8014CB6C-8014CBAC 1474AC 0040+00 0/0 0/0 38/38 .text            daNpcT_chkTmpBit__FUl */
 BOOL daNpcT_chkTmpBit(u32 i_no) {
     return dComIfGs_isTmpBit(dSv_event_tmp_flag_c::tempBitLabels[i_no]);
+}
+
+void daNpcT_cmnGenMessage(JORMContext* ctx, daNpcT_HIOParam* i_hioParam) {
+    ctx->genSlider("注目オフセット  ", &i_hioParam->attention_offset,
+                   0.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("重力            ", &i_hioParam->gravity,
+                   -100.0f, 100.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("スケ−ル        ", &i_hioParam->scale,
+                   0.0f, 100.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("リアル影サイズ  ", &i_hioParam->real_shadow_size,
+                   0.0f, 10000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("体重            ", &i_hioParam->weight,
+                   0.0f, 255.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("高さ            ", &i_hioParam->height,
+                   0.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("ひざ丈          ", &i_hioParam->knee_length,
+                   0.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("幅              ", &i_hioParam->width,
+                   0.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("腰のＸ角上限    ", &i_hioParam->body_angleX_max, -90.0f, 90.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("腰のＸ角下限    ", &i_hioParam->body_angleX_min, -90.0f, 90.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("腰のＹ角上限    ", &i_hioParam->body_angleY_max, -180.0f, 179.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("腰のＹ角下限    ", &i_hioParam->body_angleY_min, -180.0f, 179.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("頭のＸ角上限    ", &i_hioParam->head_angleX_max, -90.0f, 90.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("頭のＸ角下限    ", &i_hioParam->head_angleX_min, -90.0f, 90.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("頭のＹ角上限    ", &i_hioParam->head_angleY_max, -180.0f, 179.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("頭のＹ角下限    ", &i_hioParam->head_angleY_min, -180.0f, 179.0f, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("首の移動割合    ", &i_hioParam->neck_rotation_ratio,
+                   0.0f, 1.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("補間フレ－ム    ", &i_hioParam->morf_frame,
+                   0.0f, 100.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->startComboBox("会話距離        ", &i_hioParam->talk_distance,
+                   0, NULL, 0xffff, 0xffff, 0x100, 26);
+    ctx->genComboBoxItem("  50", 0);
+    ctx->genComboBoxItem(" 100", 1);
+    ctx->genComboBoxItem(" 150", 2);
+    ctx->genComboBoxItem(" 200", 3);
+    ctx->genComboBoxItem(" 250", 4);
+    ctx->genComboBoxItem(" 300", 5);
+    ctx->genComboBoxItem(" 350", 6);
+    ctx->genComboBoxItem(" 400", 7);
+    ctx->genComboBoxItem(" 450", 8);
+    ctx->genComboBoxItem(" 500", 9);
+    ctx->genComboBoxItem(" 550", 10);
+    ctx->genComboBoxItem(" 600", 11);
+    ctx->genComboBoxItem(" 650", 12);
+    ctx->genComboBoxItem(" 700", 13);
+    ctx->genComboBoxItem(" 750", 14);
+    ctx->genComboBoxItem(" 800", 15);
+    ctx->genComboBoxItem(" 850", 16);
+    ctx->genComboBoxItem(" 900", 17);
+    ctx->genComboBoxItem(" 950", 18);
+    ctx->genComboBoxItem("1000", 19);
+    ctx->endComboBox();
+    ctx->startComboBox("会話角度        ", &i_hioParam->talk_angle,
+                       0, NULL, 0xffff, 0xffff, 0x100, 26);
+    ctx->genComboBoxItem("  30", 0);
+    ctx->genComboBoxItem("  45", 1);
+    ctx->genComboBoxItem("  60", 2);
+    ctx->genComboBoxItem("  90", 3);
+    ctx->genComboBoxItem(" 110", 4);
+    ctx->genComboBoxItem(" 135", 5);
+    ctx->genComboBoxItem(" 180", 6);
+    ctx->endComboBox();
+    ctx->startComboBox("注目距離        ", &i_hioParam->attention_distance,
+                       0, NULL, 0xffff, 0xffff, 0x100, 26);
+    ctx->genComboBoxItem("  50", 0);
+    ctx->genComboBoxItem(" 100", 1);
+    ctx->genComboBoxItem(" 150", 2);
+    ctx->genComboBoxItem(" 200", 3);
+    ctx->genComboBoxItem(" 250", 4);
+    ctx->genComboBoxItem(" 300", 5);
+    ctx->genComboBoxItem(" 350", 6);
+    ctx->genComboBoxItem(" 400", 7);
+    ctx->genComboBoxItem(" 450", 8);
+    ctx->genComboBoxItem(" 500", 9);
+    ctx->genComboBoxItem(" 550", 10);
+    ctx->genComboBoxItem(" 600", 11);
+    ctx->genComboBoxItem(" 650", 12);
+    ctx->genComboBoxItem(" 700", 13);
+    ctx->genComboBoxItem(" 750", 14);
+    ctx->genComboBoxItem(" 800", 15);
+    ctx->genComboBoxItem(" 850", 16);
+    ctx->genComboBoxItem(" 900", 17);
+    ctx->genComboBoxItem(" 950", 18);
+    ctx->genComboBoxItem("1000", 19);
+    ctx->endComboBox();
+    ctx->startComboBox("注目角度        ", &i_hioParam->attention_angle,
+                       0, NULL, 0xffff, 0xffff, 0x100, 26);
+    ctx->genComboBoxItem("  30", 0);
+    ctx->genComboBoxItem("  45", 1);
+    ctx->genComboBoxItem("  60", 2);
+    ctx->genComboBoxItem("  90", 3);
+    ctx->genComboBoxItem(" 110", 4);
+    ctx->genComboBoxItem(" 135", 5);
+    ctx->genComboBoxItem(" 180", 6);
+    ctx->endComboBox();
+    ctx->genSlider("視界            ", &i_hioParam->fov,
+                   0.0f, 180.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("サ－チ距離      ", &i_hioParam->search_distance,
+                   0.0f, 10000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("サ－チ高さ      ", &i_hioParam->search_height,
+                   -10000.0f, 10000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("サ－チ低さ      ", &i_hioParam->search_depth,
+                   -10000.0f, 10000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("？              ", &i_hioParam->attention_time,
+                   0, 10000, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("？              ", &i_hioParam->damage_time,
+                   0, 10000, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("表情            ", &i_hioParam->face_expression,
+                   0, 0xff, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("動作            ", &i_hioParam->motion,
+                   0, 0xff, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("注視モ－ド      ", &i_hioParam->look_mode,
+                   0, 0xff, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genCheckBox("デバグモ－ドＯＮ", &i_hioParam->debug_mode_ON, 1, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genCheckBox("デバグ情報ＯＮ  ", &i_hioParam->debug_info_ON, 1, 0, NULL,
+                   0xffff, 0xffff, 512, 24);
+    ctx->genSlider("表情補間フレ－ム", &i_hioParam->expression_morf_frame,
+                   0.0f, 100.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱最小ｘ        ", &i_hioParam->box_min_x,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱最小ｙ        ", &i_hioParam->box_min_y,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱最小ｚ        ", &i_hioParam->box_min_z,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱最大ｘ        ", &i_hioParam->box_max_x,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱最大ｙ        ", &i_hioParam->box_max_y,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱最大ｚ        ", &i_hioParam->box_max_z,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
+    ctx->genSlider("箱オフセット    ", &i_hioParam->box_offset,
+                   -1000.0f, 1000.0f, 0, NULL, 0xffff, 0xffff, 512, 24);
 }
 
 /* 80392680-803926B0 01ECE0 0030+00 1/1 0/0 4/4 .rodata          mCcDObjData__8daNpcT_c */

--- a/src/d/actor/d_a_npc_aru.cpp
+++ b/src/d/actor/d_a_npc_aru.cpp
@@ -117,7 +117,7 @@ extern "C" void func_809573B0(void* _this, f32, f32);
 extern "C" void __sinit_d_a_npc_aru_cpp();
 extern "C" void
 __ct__11daNpc_Aru_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_Aru_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_Aru_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Aru_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Aru_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Aru_cFv();
@@ -1884,7 +1884,7 @@ daNpc_Aru_c::daNpc_Aru_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 809575B4-809575BC 005F14 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Aru_cFv */
-s32 daNpc_Aru_c::getEyeballMaterialNo() {
+u16 daNpc_Aru_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_bans.cpp
+++ b/src/d/actor/d_a_npc_bans.cpp
@@ -108,7 +108,7 @@ extern "C" void func_809679F4(void* _this, u8*);
 extern "C" void __sinit_d_a_npc_bans_cpp();
 extern "C" void
 __ct__12daNpc_Bans_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__12daNpc_Bans_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_Bans_cFv();
 extern "C" s32 getHeadJointNo__12daNpc_Bans_cFv();
 extern "C" s32 getNeckJointNo__12daNpc_Bans_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_Bans_cFv();
@@ -1662,7 +1662,7 @@ daNpc_Bans_c::daNpc_Bans_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80967BE4-80967BEC 005404 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_Bans_cFv */
-s32 daNpc_Bans_c::getEyeballMaterialNo() {
+u16 daNpc_Bans_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_besu.cpp
+++ b/src/d/actor/d_a_npc_besu.cpp
@@ -498,7 +498,7 @@ int daNpc_Besu_c::Draw() {
         material->setMaterialAnm(matAnm);
     }
 
-    return draw(FALSE, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return draw(FALSE, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 805379FC-80537A1C 000C9C 0020+00 1/1 0/0 0/0 .text
@@ -740,12 +740,12 @@ void daNpc_Besu_c::setParam() {
 
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Besu_Param_c::m.common.knee_length);
-    field_0xde8 = daNpc_Besu_Param_c::m.common.real_shadow_size;
+    mRealShadowSize = daNpc_Besu_Param_c::m.common.real_shadow_size;
     if (chkNurse()) {
-        field_0xde8 = 500.0f;
+        mRealShadowSize = 500.0f;
     }
 
-    field_0xa80 = daNpc_Besu_Param_c::m.common.expression_morf_frame;
+    mExpressionMorfFrame = daNpc_Besu_Param_c::m.common.expression_morf_frame;
     mMorfFrames = daNpc_Besu_Param_c::m.common.morf_frame;
     gravity = daNpc_Besu_Param_c::m.common.gravity;
 }

--- a/src/d/actor/d_a_npc_bou.cpp
+++ b/src/d/actor/d_a_npc_bou.cpp
@@ -288,7 +288,7 @@ int daNpc_Bou_c::Draw() {
         J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 8096D8A0-8096D8C0 000A00 0020+00 1/1 0/0 0/0 .text
@@ -480,8 +480,8 @@ void daNpc_Bou_c::setParam() {
     mAttnFovY = daNpc_Bou_Param_c::m.field_0x50;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Bou_Param_c::m.field_0x18);
-    field_0xde8 = daNpc_Bou_Param_c::m.field_0x0c;
-    field_0xa80 = daNpc_Bou_Param_c::m.field_0x6c;
+    mRealShadowSize = daNpc_Bou_Param_c::m.field_0x0c;
+    mExpressionMorfFrame = daNpc_Bou_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Bou_Param_c::m.field_0x44;
     gravity = daNpc_Bou_Param_c::m.field_0x04;
 }

--- a/src/d/actor/d_a_npc_clerka.cpp
+++ b/src/d/actor/d_a_npc_clerka.cpp
@@ -98,7 +98,7 @@ extern "C" void func_80995544(void* _this, int*);
 extern "C" void __sinit_d_a_npc_clerka_cpp();
 extern "C" void
 __ct__14daNpc_clerkA_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__14daNpc_clerkA_cFv();
+extern "C" u16 getEyeballMaterialNo__14daNpc_clerkA_cFv();
 extern "C" s32 getHeadJointNo__14daNpc_clerkA_cFv();
 extern "C" s32 getNeckJointNo__14daNpc_clerkA_cFv();
 extern "C" bool getBackboneJointNo__14daNpc_clerkA_cFv();
@@ -1302,7 +1302,7 @@ daNpc_clerkA_c::daNpc_clerkA_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80995694-8099569C 003254 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__14daNpc_clerkA_cFv */
-s32 daNpc_clerkA_c::getEyeballMaterialNo() {
+u16 daNpc_clerkA_c::getEyeballMaterialNo() {
     return 3;
 }
 

--- a/src/d/actor/d_a_npc_clerkb.cpp
+++ b/src/d/actor/d_a_npc_clerkb.cpp
@@ -101,7 +101,7 @@ extern "C" void __sinit_d_a_npc_clerkb_cpp();
 extern "C" void
 __ct__14daNpc_clerkB_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
 extern "C" void __dt__5csXyzFv();
-extern "C" s32 getEyeballMaterialNo__14daNpc_clerkB_cFv();
+extern "C" u16 getEyeballMaterialNo__14daNpc_clerkB_cFv();
 extern "C" s32 getHeadJointNo__14daNpc_clerkB_cFv();
 extern "C" s32 getNeckJointNo__14daNpc_clerkB_cFv();
 extern "C" bool getBackboneJointNo__14daNpc_clerkB_cFv();
@@ -1367,7 +1367,7 @@ extern "C" void __dt__5csXyzFv() {
 }
 
 /* 809997AC-809997B4 00396C 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__14daNpc_clerkB_cFv */
-s32 daNpc_clerkB_c::getEyeballMaterialNo() {
+u16 daNpc_clerkB_c::getEyeballMaterialNo() {
     return 3;
 }
 

--- a/src/d/actor/d_a_npc_clerkt.cpp
+++ b/src/d/actor/d_a_npc_clerkt.cpp
@@ -95,7 +95,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_clerkt_cpp();
 extern "C" void
 __ct__13daNpcClerkT_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpcClerkT_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpcClerkT_cFv();
 extern "C" void checkChangeJoint__13daNpcClerkT_cFi();
 extern "C" void checkRemoveJoint__13daNpcClerkT_cFi();
 extern "C" s32 getBackboneJointNo__13daNpcClerkT_cFv();
@@ -1252,7 +1252,7 @@ daNpcClerkT_c::daNpcClerkT_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 8099D068-8099D070 003008 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpcClerkT_cFv */
-s32 daNpcClerkT_c::getEyeballMaterialNo() {
+u16 daNpcClerkT_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_doc.cpp
+++ b/src/d/actor/d_a_npc_doc.cpp
@@ -94,7 +94,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_doc_cpp();
 extern "C" void
 __ct__11daNpc_Doc_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_Doc_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_Doc_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Doc_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Doc_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Doc_cFv();
@@ -1430,7 +1430,7 @@ daNpc_Doc_c::daNpc_Doc_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 809AA24C-809AA254 0036AC 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Doc_cFv */
-s32 daNpc_Doc_c::getEyeballMaterialNo() {
+u16 daNpc_Doc_c::getEyeballMaterialNo() {
     return 4;
 }
 

--- a/src/d/actor/d_a_npc_fairy.cpp
+++ b/src/d/actor/d_a_npc_fairy.cpp
@@ -161,7 +161,7 @@ __ct__13daNpc_Fairy_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPC
 extern "C" void __dt__12J3DFrameCtrlFv();
 extern "C" void __dt__8cM3dGCylFv();
 extern "C" void __dt__8cM3dGAabFv();
-extern "C" s32 getEyeballMaterialNo__13daNpc_Fairy_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_Fairy_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_Fairy_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_Fairy_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_Fairy_cFv();
@@ -2699,7 +2699,7 @@ extern "C" void __dt__8cM3dGAabFv() {
 }
 
 /* 809B9238-809B9240 007818 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_Fairy_cFv */
-s32 daNpc_Fairy_c::getEyeballMaterialNo() {
+u16 daNpc_Fairy_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_fairy_seirei.cpp
+++ b/src/d/actor/d_a_npc_fairy_seirei.cpp
@@ -177,8 +177,8 @@ void daNpc_FairySeirei_c::setParam() {
     mAttnFovY = daNpc_FairySeirei_Param_c::m[20];
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_FairySeirei_Param_c::m[6]);
-    field_0xde8 = daNpc_FairySeirei_Param_c::m[3];
-    field_0xa80 = daNpc_FairySeirei_Param_c::m[27];
+    mRealShadowSize = daNpc_FairySeirei_Param_c::m[3];
+    mExpressionMorfFrame = daNpc_FairySeirei_Param_c::m[27];
     mMorfFrames = daNpc_FairySeirei_Param_c::m[17];
     gravity = daNpc_FairySeirei_Param_c::m[1];
 }

--- a/src/d/actor/d_a_npc_gnd.cpp
+++ b/src/d/actor/d_a_npc_gnd.cpp
@@ -78,7 +78,7 @@ extern "C" bool checkChangeJoint__8daNpcT_cFi();
 extern "C" bool checkRemoveJoint__8daNpcT_cFi();
 extern "C" s32 getFootLJointNo__8daNpcT_cFv();
 extern "C" s32 getFootRJointNo__8daNpcT_cFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" bool checkChangeEvt__8daNpcT_cFv();
 extern "C" bool evtEndProc__8daNpcT_cFv();
 extern "C" void afterMoved__8daNpcT_cFv();
@@ -98,8 +98,8 @@ extern "C" void
 __ct__11daNpc_Gnd_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
 extern "C" void __dt__8cM3dGCylFv();
 extern "C" void __dt__8cM3dGAabFv();
-extern "C" s32 getEyeballRMaterialNo__11daNpc_Gnd_cFv();
-extern "C" s32 getEyeballLMaterialNo__11daNpc_Gnd_cFv();
+extern "C" u16 getEyeballRMaterialNo__11daNpc_Gnd_cFv();
+extern "C" u16 getEyeballLMaterialNo__11daNpc_Gnd_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Gnd_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Gnd_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Gnd_cFv();
@@ -715,7 +715,7 @@ int daNpc_Gnd_c::Draw() {
         J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 809BBF44-809BBF64 000A24 0020+00 1/1 0/0 0/0 .text
@@ -1205,12 +1205,12 @@ REGISTER_CTORS(0x809BE268, __sinit_d_a_npc_gnd_cpp);
 // }
 
 /* 809BE40C-809BE414 002EEC 0008+00 1/0 0/0 0/0 .text getEyeballRMaterialNo__11daNpc_Gnd_cFv */
-s32 daNpc_Gnd_c::getEyeballRMaterialNo() {
+u16 daNpc_Gnd_c::getEyeballRMaterialNo() {
     return 3;
 }
 
 /* 809BE414-809BE41C 002EF4 0008+00 1/0 0/0 0/0 .text getEyeballLMaterialNo__11daNpc_Gnd_cFv */
-s32 daNpc_Gnd_c::getEyeballLMaterialNo() {
+u16 daNpc_Gnd_c::getEyeballLMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_grm.cpp
+++ b/src/d/actor/d_a_npc_grm.cpp
@@ -54,7 +54,7 @@ __ct__11daNpc_grM_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ2
 extern "C" void __dt__8cM3dGCylFv();
 extern "C" void __dt__8cM3dGAabFv();
 extern "C" void __dt__4cXyzFv();
-extern "C" s32 getEyeballMaterialNo__11daNpc_grM_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_grM_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_grM_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_grM_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_grM_cFv();
@@ -982,7 +982,7 @@ extern "C" void __dt__4cXyzFv() {
 }
 
 /* 809D5F98-809D5FA0 002018 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_grM_cFv */
-s32 daNpc_grM_c::getEyeballMaterialNo() {
+u16 daNpc_grM_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_grmc.cpp
+++ b/src/d/actor/d_a_npc_grmc.cpp
@@ -57,7 +57,7 @@ extern "C" s32 getNeckJointNo__12daNpc_grMC_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_grMC_cFv();
 extern "C" void checkChangeJoint__12daNpc_grMC_cFi();
 extern "C" void checkRemoveJoint__12daNpc_grMC_cFi();
-extern "C" s32 getEyeballMaterialNo__12daNpc_grMC_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_grMC_cFv();
 extern "C" void __dt__18daNpc_grMC_Param_cFv();
 extern "C" static void func_809D905C();
 extern "C" static void func_809D9064();
@@ -1004,7 +1004,7 @@ void daNpc_grMC_c::checkRemoveJoint(int param_0) {
 }
 
 /* 809D900C-809D9014 001CEC 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_grMC_cFv */
-s32 daNpc_grMC_c::getEyeballMaterialNo() {
+u16 daNpc_grMC_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_hanjo.cpp
+++ b/src/d/actor/d_a_npc_hanjo.cpp
@@ -340,7 +340,7 @@ int daNpc_Hanjo_c::Draw() {
         J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 809F9C20-809F9C40 000C80 0020+00 1/1 0/0 0/0 .text
@@ -486,8 +486,8 @@ void daNpc_Hanjo_c::setParam() {
     mAttnFovY = daNpc_Hanjo_Param_c::m.field_0x50;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Hanjo_Param_c::m.field_0x18);
-    field_0xde8 = daNpc_Hanjo_Param_c::m.field_0x0c;
-    field_0xa80 = daNpc_Hanjo_Param_c::m.field_0x6c;
+    mRealShadowSize = daNpc_Hanjo_Param_c::m.field_0x0c;
+    mExpressionMorfFrame = daNpc_Hanjo_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Hanjo_Param_c::m.field_0x44;
     gravity = daNpc_Hanjo_Param_c::m.field_0x04;
 }

--- a/src/d/actor/d_a_npc_hoz.cpp
+++ b/src/d/actor/d_a_npc_hoz.cpp
@@ -116,7 +116,7 @@ extern "C" void func_80A063B4(void* _this, int*);
 extern "C" void __sinit_d_a_npc_hoz_cpp();
 extern "C" void
 __ct__11daNpc_Hoz_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_Hoz_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_Hoz_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Hoz_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Hoz_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Hoz_cFv();
@@ -1770,7 +1770,7 @@ daNpc_Hoz_c::daNpc_Hoz_c(daNpcT_faceMotionAnmData_c const* param_1,
 }
 
 /* 80A065A4-80A065AC 005184 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Hoz_cFv */
-s32 daNpc_Hoz_c::getEyeballMaterialNo() {
+u16 daNpc_Hoz_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_jagar.cpp
+++ b/src/d/actor/d_a_npc_jagar.cpp
@@ -304,7 +304,7 @@ int daNpc_Jagar_c::Draw() {
         J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 80A15034-80A15054 000A14 0020+00 1/1 0/0 0/0 .text            createHeapCallBack__13daNpc_Jagar_cFP10fopAc_ac_c */
@@ -460,8 +460,8 @@ void daNpc_Jagar_c::setParam() {
     mAttnFovY = daNpc_Jagar_Param_c::m.field_0x50;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Jagar_Param_c::m.field_0x18);
-    field_0xde8 = daNpc_Jagar_Param_c::m.field_0x0c;
-    field_0xa80 = daNpc_Jagar_Param_c::m.field_0x6c;
+    mRealShadowSize = daNpc_Jagar_Param_c::m.field_0x0c;
+    mExpressionMorfFrame = daNpc_Jagar_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Jagar_Param_c::m.field_0x44;
     gravity = daNpc_Jagar_Param_c::m.field_0x04;
 }

--- a/src/d/actor/d_a_npc_kakashi.cpp
+++ b/src/d/actor/d_a_npc_kakashi.cpp
@@ -76,7 +76,7 @@ extern "C" s32 getFootLJointNo__8daNpcT_cFv();
 extern "C" s32 getFootRJointNo__8daNpcT_cFv();
 extern "C" bool getEyeballLMaterialNo__8daNpcT_cFv();
 extern "C" bool getEyeballRMaterialNo__8daNpcT_cFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" void afterJntAnm__8daNpcT_cFi();
 extern "C" void setAfterTalkMotion__8daNpcT_cFv();
 extern "C" void afterMoved__8daNpcT_cFv();

--- a/src/d/actor/d_a_npc_kkri.cpp
+++ b/src/d/actor/d_a_npc_kkri.cpp
@@ -105,7 +105,7 @@ extern "C" void func_805531EC(void* _this, int, int);
 extern "C" void __sinit_d_a_npc_kkri_cpp();
 extern "C" void
 __ct__12daNpc_Kkri_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__12daNpc_Kkri_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_Kkri_cFv();
 extern "C" s32 getHeadJointNo__12daNpc_Kkri_cFv();
 extern "C" s32 getNeckJointNo__12daNpc_Kkri_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_Kkri_cFv();
@@ -1490,7 +1490,7 @@ daNpc_Kkri_c::daNpc_Kkri_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 805533E4-805533EC 004124 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_Kkri_cFv */
-s32 daNpc_Kkri_c::getEyeballMaterialNo() {
+u16 daNpc_Kkri_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_kn.cpp
+++ b/src/d/actor/d_a_npc_kn.cpp
@@ -3561,17 +3561,17 @@ daNpc_Kn_c::daNpc_Kn_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80A3BD14-80A3BD1C 0113F4 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__10daNpc_Kn_cFv */
-s32 daNpc_Kn_c::getEyeballMaterialNo() {
+u16 daNpc_Kn_c::getEyeballMaterialNo() {
     return false;
 }
 
 /* 80A3BD1C-80A3BD24 0113FC 0008+00 1/0 0/0 0/0 .text getEyeballLMaterialNo__10daNpc_Kn_cFv */
-int daNpc_Kn_c::getEyeballLMaterialNo() {
+u16 daNpc_Kn_c::getEyeballLMaterialNo() {
     return false;
 }
 
 /* 80A3BD24-80A3BD2C 011404 0008+00 1/0 0/0 0/0 .text getEyeballRMaterialNo__10daNpc_Kn_cFv */
-s32 daNpc_Kn_c::getEyeballRMaterialNo() {
+u16 daNpc_Kn_c::getEyeballRMaterialNo() {
     return false;
 }
 

--- a/src/d/actor/d_a_npc_kn_base.inc
+++ b/src/d/actor/d_a_npc_kn_base.inc
@@ -424,7 +424,7 @@ int daNpc_Kn_c::ctrlBtk() {
                 field_0xe31 = 0;
             }
 
-            mpMatAnm->onEyeMoveFlg();
+            mpMatAnm->onEyeMoveFlag();
             return 1;
         }
 
@@ -433,7 +433,7 @@ int daNpc_Kn_c::ctrlBtk() {
             field_0xe31 = 0;
         }
 
-        mpMatAnm->offEyeMoveFlg();
+        mpMatAnm->offEyeMoveFlag();
     }
 
     return 0;

--- a/src/d/actor/d_a_npc_knj.cpp
+++ b/src/d/actor/d_a_npc_knj.cpp
@@ -56,7 +56,7 @@ extern "C" void __dt__12dBgS_AcchCirFv();
 extern "C" void __dt__10dCcD_GSttsFv();
 extern "C" void __dt__12dBgS_ObjAcchFv();
 extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();
 extern "C" bool checkChangeJoint__8daNpcT_cFi();
 extern "C" bool checkRemoveJoint__8daNpcT_cFi();

--- a/src/d/actor/d_a_npc_kolin.cpp
+++ b/src/d/actor/d_a_npc_kolin.cpp
@@ -96,8 +96,8 @@ extern "C" void __dt__12J3DFrameCtrlFv();
 extern "C" void setEyeAngleY__15daNpcT_JntAnm_cF4cXyzsifs();
 extern "C" void setEyeAngleX__15daNpcT_JntAnm_cF4cXyzfs();
 extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();
-extern "C" bool getEyeballLMaterialNo__8daNpcT_cFv();
-extern "C" bool getEyeballRMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballLMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballRMaterialNo__8daNpcT_cFv();
 extern "C" bool evtEndProc__8daNpcT_cFv();
 extern "C" void afterMoved__8daNpcT_cFv();
 extern "C" bool chkXYItems__8daNpcT_cFv();
@@ -114,7 +114,7 @@ extern "C" void func_8055A1E0(void* _this, int, int);
 extern "C" void __sinit_d_a_npc_kolin_cpp();
 extern "C" void
 __ct__13daNpc_Kolin_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_Kolin_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_Kolin_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_Kolin_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_Kolin_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_Kolin_cFv();
@@ -2023,14 +2023,14 @@ extern "C" void ctrlSubFaceMotion__8daNpcT_cFi() {
 /* 8055A10C-8055A114 00620C 0008+00 1/0 0/0 0/0 .text            getEyeballLMaterialNo__8daNpcT_cFv
  */
 // bool daNpcT_c::getEyeballLMaterialNo() {
-extern "C" bool getEyeballLMaterialNo__8daNpcT_cFv() {
+extern "C" u16 getEyeballLMaterialNo__8daNpcT_cFv() {
     return false;
 }
 
 /* 8055A114-8055A11C 006214 0008+00 1/0 0/0 0/0 .text            getEyeballRMaterialNo__8daNpcT_cFv
  */
 // bool daNpcT_c::getEyeballRMaterialNo() {
-extern "C" bool getEyeballRMaterialNo__8daNpcT_cFv() {
+extern "C" u16 getEyeballRMaterialNo__8daNpcT_cFv() {
     return false;
 }
 
@@ -2138,7 +2138,7 @@ REGISTER_CTORS(0x8055A25C, __sinit_d_a_npc_kolin_cpp);
 } */
 
 /* 8055A498-8055A4A0 006598 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_Kolin_cFv */
-s32 daNpc_Kolin_c::getEyeballMaterialNo() {
+u16 daNpc_Kolin_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_kolinb.cpp
+++ b/src/d/actor/d_a_npc_kolinb.cpp
@@ -66,7 +66,7 @@ extern "C" void __dt__12dBgS_AcchCirFv();
 extern "C" void __dt__10dCcD_GSttsFv();
 extern "C" void __dt__12dBgS_ObjAcchFv();
 extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();
 extern "C" s32 getFootLJointNo__8daNpcT_cFv();
 extern "C" s32 getFootRJointNo__8daNpcT_cFv();

--- a/src/d/actor/d_a_npc_kyury.cpp
+++ b/src/d/actor/d_a_npc_kyury.cpp
@@ -98,7 +98,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_kyury_cpp();
 extern "C" void
 __ct__13daNpc_Kyury_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_Kyury_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_Kyury_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_Kyury_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_Kyury_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_Kyury_cFv();
@@ -1391,7 +1391,7 @@ daNpc_Kyury_c::daNpc_Kyury_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80A63800-80A63808 003820 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_Kyury_cFv */
-s32 daNpc_Kyury_c::getEyeballMaterialNo() {
+u16 daNpc_Kyury_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_len.cpp
+++ b/src/d/actor/d_a_npc_len.cpp
@@ -101,7 +101,7 @@ extern "C" void func_80A68BD0(void* _this, int, int);
 extern "C" void __sinit_d_a_npc_len_cpp();
 extern "C" void
 __ct__11daNpc_Len_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_Len_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_Len_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Len_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Len_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Len_cFv();
@@ -1542,7 +1542,7 @@ daNpc_Len_c::daNpc_Len_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80A68DE0-80A68DE8 004BA0 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Len_cFv */
-s32 daNpc_Len_c::getEyeballMaterialNo() {
+u16 daNpc_Len_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_lud.cpp
+++ b/src/d/actor/d_a_npc_lud.cpp
@@ -108,7 +108,7 @@ extern "C" void func_80A6FAD4(void* _this, int*);
 extern "C" void __sinit_d_a_npc_lud_cpp();
 extern "C" void
 __ct__11daNpc_Lud_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_Lud_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_Lud_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Lud_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Lud_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Lud_cFv();
@@ -1721,7 +1721,7 @@ daNpc_Lud_c::daNpc_Lud_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80A6FCD0-80A6FCD8 005210 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Lud_cFv */
-s32 daNpc_Lud_c::getEyeballMaterialNo() {
+u16 daNpc_Lud_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_maro.cpp
+++ b/src/d/actor/d_a_npc_maro.cpp
@@ -362,7 +362,7 @@ int daNpc_Maro_c::Draw() {
         J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 8055BFA0-8055BFC0 000B00 0020+00 1/1 0/0 0/0 .text
@@ -691,8 +691,8 @@ void daNpc_Maro_c::setParam() {
     mAttnFovY = daNpc_Maro_Param_c::m.common.fov;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Maro_Param_c::m.common.knee_length);
-    field_0xde8 = daNpc_Maro_Param_c::m.common.real_shadow_size;
-    field_0xa80 = daNpc_Maro_Param_c::m.common.expression_morf_frame;
+    mRealShadowSize = daNpc_Maro_Param_c::m.common.real_shadow_size;
+    mExpressionMorfFrame = daNpc_Maro_Param_c::m.common.expression_morf_frame;
     mMorfFrames = daNpc_Maro_Param_c::m.common.morf_frame;
     gravity = daNpc_Maro_Param_c::m.common.gravity;
 }
@@ -3478,7 +3478,7 @@ static int daNpc_Maro_IsDelete(void* i_this) {
 static daNpc_Maro_Param_c l_HIO;
 
 /* 80564970-80564978 0094D0 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_Maro_cFv */
-s32 daNpc_Maro_c::getEyeballMaterialNo() {
+u16 daNpc_Maro_c::getEyeballMaterialNo() {
     return 1;
 }
 

--- a/src/d/actor/d_a_npc_midp.cpp
+++ b/src/d/actor/d_a_npc_midp.cpp
@@ -230,7 +230,7 @@ int daNpc_midP_c::Draw() {
         modelData->getMaterialNodePointer(getEyeballRMaterialNo())->setMaterialAnm(mpMatAnm[1]);
     }
 
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 0.0f, 1, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 0.0f, 1, 0, 0);
 }
 
 /* 80A715D4-80A715F4 000A54 0020+00 1/1 0/0 0/0 .text   createHeapCallBack__12daNpc_midP_cFP10fopAc_ac_c */
@@ -312,8 +312,8 @@ BOOL daNpc_midP_c::ctrlBtk() {
                 field_0xe2a = 0;
             }
 
-            mpMatAnm[0]->onEyeMoveFlg();
-            mpMatAnm[1]->onEyeMoveFlg();
+            mpMatAnm[0]->onEyeMoveFlag();
+            mpMatAnm[1]->onEyeMoveFlag();
             return TRUE;
         }
 
@@ -323,8 +323,8 @@ BOOL daNpc_midP_c::ctrlBtk() {
             field_0xe2a = 0;
         }
 
-        mpMatAnm[0]->offEyeMoveFlg();
-        mpMatAnm[1]->offEyeMoveFlg();
+        mpMatAnm[0]->offEyeMoveFlag();
+        mpMatAnm[1]->offEyeMoveFlag();
     }
 
     return FALSE;
@@ -352,8 +352,8 @@ void daNpc_midP_c::setParam() {
     mAttnFovY = daNpc_midP_Param_c::m.mAttnFovY;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_midP_Param_c::m.mWallH);
-    field_0xde8 = daNpc_midP_Param_c::m.field_0x0c;
-    field_0xa80 = daNpc_midP_Param_c::m.field_0x6c;
+    mRealShadowSize = daNpc_midP_Param_c::m.field_0x0c;
+    mExpressionMorfFrame = daNpc_midP_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_midP_Param_c::m.mMorfFrames;
     gravity = daNpc_midP_Param_c::m.mGravity;
 }
@@ -647,12 +647,12 @@ static u8 lit_3811[12];
 static u8 l_HIO[4];
 
 /* 80A7390C-80A73914 002D8C 0008+00 1/0 0/0 0/0 .text getEyeballRMaterialNo__12daNpc_midP_cFv */
-s32 daNpc_midP_c::getEyeballRMaterialNo() {
+u16 daNpc_midP_c::getEyeballRMaterialNo() {
     return 3;
 }
 
 /* 80A73914-80A7391C 002D94 0008+00 1/0 0/0 0/0 .text getEyeballLMaterialNo__12daNpc_midP_cFv */
-s32 daNpc_midP_c::getEyeballLMaterialNo() {
+u16 daNpc_midP_c::getEyeballLMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_moi.cpp
+++ b/src/d/actor/d_a_npc_moi.cpp
@@ -438,7 +438,7 @@ int daNpc_Moi_c::Draw() {
         }
     }
 
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 80A74B80-80A74BA0 000D20 0020+00 1/1 0/0 0/0 .text
@@ -664,17 +664,17 @@ void daNpc_Moi_c::setParam() {
     }
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Moi_Param_c::m.field_0x18);
-    field_0xde8 = daNpc_Moi_Param_c::m.field_0x0c;
+    mRealShadowSize = daNpc_Moi_Param_c::m.field_0x0c;
     if (mType == TYPE_1) {
-        field_0xde8 = 600.0f;
+        mRealShadowSize = 600.0f;
     } else if (mType == TYPE_2) {
-        field_0xde8 = 600.0f;
+        mRealShadowSize = 600.0f;
         if (field_0x166d) {
-            field_0xde8 = 800.0f;
+            mRealShadowSize = 800.0f;
         }
     }
     gravity = daNpc_Moi_Param_c::m.field_0x04;
-    field_0xa80 = daNpc_Moi_Param_c::m.field_0x6c;
+    mExpressionMorfFrame = daNpc_Moi_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Moi_Param_c::m.field_0x44;
     if (mType == TYPE_3) {
         mAcch.SetGrndNone();

--- a/src/d/actor/d_a_npc_pachi_besu.cpp
+++ b/src/d/actor/d_a_npc_pachi_besu.cpp
@@ -129,7 +129,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_pachi_besu_cpp();
 extern "C" void
 __ct__18daNpc_Pachi_Besu_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__18daNpc_Pachi_Besu_cFv();
+extern "C" u16 getEyeballMaterialNo__18daNpc_Pachi_Besu_cFv();
 extern "C" s32 getHeadJointNo__18daNpc_Pachi_Besu_cFv();
 extern "C" s32 getNeckJointNo__18daNpc_Pachi_Besu_cFv();
 extern "C" bool getBackboneJointNo__18daNpc_Pachi_Besu_cFv();
@@ -1931,7 +1931,7 @@ daNpc_Pachi_Besu_c::daNpc_Pachi_Besu_c(
 
 /* 80A969C0-80A969C8 003D40 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__18daNpc_Pachi_Besu_cFv
  */
-s32 daNpc_Pachi_Besu_c::getEyeballMaterialNo() {
+u16 daNpc_Pachi_Besu_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_pachi_maro.cpp
+++ b/src/d/actor/d_a_npc_pachi_maro.cpp
@@ -129,7 +129,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_pachi_maro_cpp();
 extern "C" void
 __ct__18daNpc_Pachi_Maro_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__18daNpc_Pachi_Maro_cFv();
+extern "C" u16 getEyeballMaterialNo__18daNpc_Pachi_Maro_cFv();
 extern "C" s32 getHeadJointNo__18daNpc_Pachi_Maro_cFv();
 extern "C" s32 getNeckJointNo__18daNpc_Pachi_Maro_cFv();
 extern "C" bool getBackboneJointNo__18daNpc_Pachi_Maro_cFv();
@@ -1691,7 +1691,7 @@ daNpc_Pachi_Maro_c::daNpc_Pachi_Maro_c(
 
 /* 80A9B7E0-80A9B7E8 003C40 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__18daNpc_Pachi_Maro_cFv
  */
-s32 daNpc_Pachi_Maro_c::getEyeballMaterialNo() {
+u16 daNpc_Pachi_Maro_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_pachi_taro.cpp
+++ b/src/d/actor/d_a_npc_pachi_taro.cpp
@@ -146,7 +146,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_pachi_taro_cpp();
 extern "C" void
 __ct__18daNpc_Pachi_Taro_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__18daNpc_Pachi_Taro_cFv();
+extern "C" u16 getEyeballMaterialNo__18daNpc_Pachi_Taro_cFv();
 extern "C" s32 getHeadJointNo__18daNpc_Pachi_Taro_cFv();
 extern "C" s32 getNeckJointNo__18daNpc_Pachi_Taro_cFv();
 extern "C" bool getBackboneJointNo__18daNpc_Pachi_Taro_cFv();
@@ -2352,7 +2352,7 @@ daNpc_Pachi_Taro_c::daNpc_Pachi_Taro_c(
 
 /* 80AA1558-80AA1560 0053B8 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__18daNpc_Pachi_Taro_cFv
  */
-s32 daNpc_Pachi_Taro_c::getEyeballMaterialNo() {
+u16 daNpc_Pachi_Taro_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_post.cpp
+++ b/src/d/actor/d_a_npc_post.cpp
@@ -102,7 +102,7 @@ extern "C" void func_80AACF2C(void* _this, f32, f32);
 extern "C" void __sinit_d_a_npc_post_cpp();
 extern "C" void
 __ct__12daNpc_Post_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__12daNpc_Post_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_Post_cFv();
 extern "C" s32 getHeadJointNo__12daNpc_Post_cFv();
 extern "C" s32 getNeckJointNo__12daNpc_Post_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_Post_cFv();
@@ -1705,7 +1705,7 @@ daNpc_Post_c::daNpc_Post_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80AAD0D0-80AAD0D8 004530 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_Post_cFv */
-s32 daNpc_Post_c::getEyeballMaterialNo() {
+u16 daNpc_Post_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_pouya.cpp
+++ b/src/d/actor/d_a_npc_pouya.cpp
@@ -99,7 +99,7 @@ extern "C" void func_80AB1DDC(void* _this, int*);
 extern "C" void __sinit_d_a_npc_pouya_cpp();
 extern "C" void
 __ct__13daNpc_Pouya_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_Pouya_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_Pouya_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_Pouya_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_Pouya_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_Pouya_cFv();
@@ -1586,7 +1586,7 @@ daNpc_Pouya_c::daNpc_Pouya_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80AB1F54-80AB1F5C 004294 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_Pouya_cFv */
-s32 daNpc_Pouya_c::getEyeballMaterialNo() {
+u16 daNpc_Pouya_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_raca.cpp
+++ b/src/d/actor/d_a_npc_raca.cpp
@@ -98,7 +98,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_raca_cpp();
 extern "C" void
 __ct__12daNpc_Raca_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__12daNpc_Raca_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_Raca_cFv();
 extern "C" s32 getHeadJointNo__12daNpc_Raca_cFv();
 extern "C" s32 getNeckJointNo__12daNpc_Raca_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_Raca_cFv();
@@ -1263,7 +1263,7 @@ daNpc_Raca_c::daNpc_Raca_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80AB8DAC-80AB8DB4 0031EC 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_Raca_cFv */
-s32 daNpc_Raca_c::getEyeballMaterialNo() {
+u16 daNpc_Raca_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_saru.cpp
+++ b/src/d/actor/d_a_npc_saru.cpp
@@ -302,7 +302,7 @@ int daNpc_Saru_c::Execute() {
 
 /* 80AC0AA8-80AC0AEC 000768 0044+00 1/1 0/0 0/0 .text            Draw__12daNpc_Saru_cFv */
 int daNpc_Saru_c::Draw() {
-    return draw(FALSE, FALSE, field_0xde8, NULL, 100.0f, FALSE, FALSE, FALSE);
+    return draw(FALSE, FALSE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
 }
 
 /* 80AC0AEC-80AC0B0C 0007AC 0020+00 1/1 0/0 0/0 .text            createHeapCallBack__12daNpc_Saru_cFP10fopAc_ac_c */
@@ -463,8 +463,8 @@ void daNpc_Saru_c::setParam() {
     mAttnFovY = daNpc_Saru_Param_c::m.mAttnFovy;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Saru_Param_c::m.mWallH);
-    field_0xde8 = daNpc_Saru_Param_c::m.field_0x0c;
-    field_0xa80 = daNpc_Saru_Param_c::m.field_0x6c;
+    mRealShadowSize = daNpc_Saru_Param_c::m.field_0x0c;
+    mExpressionMorfFrame = daNpc_Saru_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Saru_Param_c::m.mMorfFrames;
     gravity = daNpc_Saru_Param_c::m.mGravity;
 }

--- a/src/d/actor/d_a_npc_seib.cpp
+++ b/src/d/actor/d_a_npc_seib.cpp
@@ -201,7 +201,7 @@ int daNpc_seiB_c::Draw() {
         mdlData_p->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
 
-    return draw(FALSE, TRUE, field_0xde8, NULL, 100.0f, FALSE, FALSE, FALSE);
+    return draw(FALSE, TRUE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
 }
 
 /* 80AC5608-80AC5628 000608 0020+00 1/1 0/0 0/0 .text
@@ -269,9 +269,9 @@ void daNpc_seiB_c::setParam() {
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(mpParam->m.mWallH);
 
-    field_0xde8 = mpParam->m.field_0xc;
+    mRealShadowSize = mpParam->m.field_0xc;
     gravity = mpParam->m.mGravity;
-    field_0xa80 = mpParam->m.field_0x6c;
+    mExpressionMorfFrame = mpParam->m.field_0x6c;
     mMorfFrames = mpParam->m.mMorfFrames;
 }
 

--- a/src/d/actor/d_a_npc_seic.cpp
+++ b/src/d/actor/d_a_npc_seic.cpp
@@ -220,7 +220,7 @@ int daNpc_seiC_c::Draw() {
         J3DMaterial* material = modelData->getMaterialNodePointer(getEyeballMaterialNo());
         material->setMaterialAnm(matAnm);
     }
-    return draw(FALSE, TRUE, field_0xde8, NULL, 100.0f, FALSE, FALSE, FALSE);
+    return draw(FALSE, TRUE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
 }
 
 /* 80AC7A68-80AC7A88 000608 0020+00 1/1 0/0 0/0 .text            createHeapCallBack__12daNpc_seiC_cFP10fopAc_ac_c */
@@ -290,9 +290,9 @@ void daNpc_seiC_c::setParam() {
     mWallR = daNpc_seiC_Param_c::m.mWallR;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_seiC_Param_c::m.mWallH);
-    field_0xde8 = daNpc_seiC_Param_c::m.field_0x0c;
+    mRealShadowSize = daNpc_seiC_Param_c::m.field_0x0c;
     gravity = daNpc_seiC_Param_c::m.mGravity;
-    field_0xa80 = daNpc_seiC_Param_c::m.field_0x6c;
+    mExpressionMorfFrame = daNpc_seiC_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_seiC_Param_c::m.mMorfFrames;
 }
 

--- a/src/d/actor/d_a_npc_seid.cpp
+++ b/src/d/actor/d_a_npc_seid.cpp
@@ -221,7 +221,7 @@ int daNpc_seiD_c::Draw() {
         J3DMaterial* material = modelData->getMaterialNodePointer(getEyeballMaterialNo());
         material->setMaterialAnm(matAnm);
     }
-    return draw(FALSE, TRUE, field_0xde8, NULL, 100.0f, FALSE, FALSE, FALSE);
+    return draw(FALSE, TRUE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
 }
 
 /* 80AC9BA8-80AC9BC8 000608 0020+00 1/1 0/0 0/0 .text            createHeapCallBack__12daNpc_seiD_cFP10fopAc_ac_c */
@@ -289,9 +289,9 @@ void daNpc_seiD_c::setParam() {
     mWallR = daNpc_seiD_Param_c::m.mWallR;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_seiD_Param_c::m.mWallH);
-    field_0xde8 = daNpc_seiD_Param_c::m.field_0x0c;
+    mRealShadowSize = daNpc_seiD_Param_c::m.field_0x0c;
     gravity = daNpc_seiD_Param_c::m.mGravity;
-    field_0xa80 = daNpc_seiD_Param_c::m.field_0x6c;
+    mExpressionMorfFrame = daNpc_seiD_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_seiD_Param_c::m.mMorfFrames;
 }
 

--- a/src/d/actor/d_a_npc_seira.cpp
+++ b/src/d/actor/d_a_npc_seira.cpp
@@ -112,7 +112,7 @@ extern "C" void func_80ACFA44(void* _this, int, int);
 extern "C" void __sinit_d_a_npc_seira_cpp();
 extern "C" void
 __ct__13daNpc_Seira_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_Seira_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_Seira_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_Seira_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_Seira_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_Seira_cFv();
@@ -1690,7 +1690,7 @@ daNpc_Seira_c::daNpc_Seira_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80ACFC14-80ACFC1C 004534 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_Seira_cFv */
-s32 daNpc_Seira_c::getEyeballMaterialNo() {
+u16 daNpc_Seira_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_seira2.cpp
+++ b/src/d/actor/d_a_npc_seira2.cpp
@@ -109,7 +109,7 @@ extern "C" void func_80AD46D4(void* _this, int, int);
 extern "C" void __sinit_d_a_npc_seira2_cpp();
 extern "C" void
 __ct__14daNpc_Seira2_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__14daNpc_Seira2_cFv();
+extern "C" u16 getEyeballMaterialNo__14daNpc_Seira2_cFv();
 extern "C" s32 getHeadJointNo__14daNpc_Seira2_cFv();
 extern "C" s32 getNeckJointNo__14daNpc_Seira2_cFv();
 extern "C" bool getBackboneJointNo__14daNpc_Seira2_cFv();
@@ -1565,7 +1565,7 @@ daNpc_Seira2_c::daNpc_Seira2_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80AD4884-80AD488C 003D64 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__14daNpc_Seira2_cFv */
-s32 daNpc_Seira2_c::getEyeballMaterialNo() {
+u16 daNpc_Seira2_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_seirei.cpp
+++ b/src/d/actor/d_a_npc_seirei.cpp
@@ -60,7 +60,7 @@ extern "C" void __dt__12dBgS_AcchCirFv();
 extern "C" void __dt__10dCcD_GSttsFv();
 extern "C" void __dt__12dBgS_ObjAcchFv();
 extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();
 extern "C" bool checkChangeJoint__8daNpcT_cFi();
 extern "C" bool checkRemoveJoint__8daNpcT_cFi();

--- a/src/d/actor/d_a_npc_shaman.cpp
+++ b/src/d/actor/d_a_npc_shaman.cpp
@@ -111,7 +111,7 @@ extern "C" void
 __ct__11daNpc_Sha_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
 extern "C" void __dt__8cM3dGCylFv();
 extern "C" void __dt__8cM3dGAabFv();
-extern "C" s32 getEyeballMaterialNo__11daNpc_Sha_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_Sha_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_Sha_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_Sha_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_Sha_cFv();
@@ -271,7 +271,6 @@ extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
 extern "C" extern void* __vt__9cCcD_Stts[8];
 extern "C" extern void* __vt__14J3DMaterialAnm[4];
 extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" extern u8 g_Counter[12 + 4 /* padding */];
 extern "C" u8 mAudioMgrPtr__10Z2AudioMgr[4 + 4 /* padding */];
 extern "C" void __register_global_object();
 
@@ -1955,7 +1954,7 @@ extern "C" void __dt__8cM3dGAabFv() {
 }
 
 /* 80AE6B1C-80AE6B24 003E3C 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_Sha_cFv */
-s32 daNpc_Sha_c::getEyeballMaterialNo() {
+u16 daNpc_Sha_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_sola.cpp
+++ b/src/d/actor/d_a_npc_sola.cpp
@@ -58,7 +58,7 @@ extern "C" void __dt__12dBgS_AcchCirFv();
 extern "C" void __dt__10dCcD_GSttsFv();
 extern "C" void __dt__12dBgS_ObjAcchFv();
 extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" void setEyeAngleY__15daNpcT_JntAnm_cF4cXyzsifs();
 extern "C" void setEyeAngleX__15daNpcT_JntAnm_cF4cXyzfs();
 extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();

--- a/src/d/actor/d_a_npc_taro.cpp
+++ b/src/d/actor/d_a_npc_taro.cpp
@@ -520,7 +520,7 @@ int daNpc_Taro_c::Draw() {
         material->setMaterialAnm(matAnm);
     }
 
-    return draw(FALSE, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return draw(FALSE, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 805669F8-80566A18 000C58 0020+00 1/1 0/0 0/0 .text
@@ -780,11 +780,11 @@ void daNpc_Taro_c::setParam() {
     }
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Taro_Param_c::m.mWallH);
-    field_0xde8 = daNpc_Taro_Param_c::m.field_0x0c;
+    mRealShadowSize = daNpc_Taro_Param_c::m.field_0x0c;
     if (&daNpc_Taro_c::practice == mAction) {
-        field_0xde8 = 500.0f;
+        mRealShadowSize = 500.0f;
     }
-    field_0xa80 = daNpc_Taro_Param_c::m.field_0x6c;
+    mExpressionMorfFrame = daNpc_Taro_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Taro_Param_c::m.mMorfFrames;
     gravity = daNpc_Taro_Param_c::m.mGravity;
 }

--- a/src/d/actor/d_a_npc_tkj.cpp
+++ b/src/d/actor/d_a_npc_tkj.cpp
@@ -97,7 +97,7 @@ extern "C" void
 __ct__10daNpcTkj_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
 extern "C" void __dt__8cM3dGCylFv();
 extern "C" void __dt__8cM3dGAabFv();
-extern "C" s32 getEyeballMaterialNo__10daNpcTkj_cFv();
+extern "C" u16 getEyeballMaterialNo__10daNpcTkj_cFv();
 extern "C" s32 getHeadJointNo__10daNpcTkj_cFv();
 extern "C" s32 getNeckJointNo__10daNpcTkj_cFv();
 extern "C" s32 getBackboneJointNo__10daNpcTkj_cFv();
@@ -1204,7 +1204,7 @@ extern "C" void __dt__8cM3dGAabFv() {
 }
 
 /* 805764EC-805764F4 002EAC 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__10daNpcTkj_cFv */
-s32 daNpcTkj_c::getEyeballMaterialNo() {
+u16 daNpcTkj_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_toby.cpp
+++ b/src/d/actor/d_a_npc_toby.cpp
@@ -106,7 +106,7 @@ extern "C" void func_80B24728(void* _this, int*);
 extern "C" void __sinit_d_a_npc_toby_cpp();
 extern "C" void
 __ct__12daNpc_Toby_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__12daNpc_Toby_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_Toby_cFv();
 extern "C" s32 getHeadJointNo__12daNpc_Toby_cFv();
 extern "C" s32 getNeckJointNo__12daNpc_Toby_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_Toby_cFv();
@@ -2062,7 +2062,7 @@ daNpc_Toby_c::daNpc_Toby_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B24920-80B24928 0063C0 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_Toby_cFv */
-s32 daNpc_Toby_c::getEyeballMaterialNo() {
+u16 daNpc_Toby_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_uri.cpp
+++ b/src/d/actor/d_a_npc_uri.cpp
@@ -334,7 +334,7 @@ int daNpc_Uri_c::Draw() {
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
 
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 80B27174-80B27194 000AB4 0020+00 1/1 0/0 0/0 .text
@@ -525,9 +525,9 @@ void daNpc_Uri_c::setParam() {
     mAttnFovY = daNpc_Uri_Param_c::m.field_0x50;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Uri_Param_c::m.field_0x18);
-    field_0xde8 = daNpc_Uri_Param_c::m.field_0x0c;
+    mRealShadowSize = daNpc_Uri_Param_c::m.field_0x0c;
     gravity = daNpc_Uri_Param_c::m.field_0x04;
-    field_0xa80 = daNpc_Uri_Param_c::m.field_0x6c;
+    mExpressionMorfFrame = daNpc_Uri_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Uri_Param_c::m.field_0x44;
     if (mType == TYPE_4) {
         mAcch.SetGrndNone();

--- a/src/d/actor/d_a_npc_yamid.cpp
+++ b/src/d/actor/d_a_npc_yamid.cpp
@@ -99,7 +99,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_yamid_cpp();
 extern "C" void
 __ct__13daNpc_yamiD_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_yamiD_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_yamiD_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_yamiD_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_yamiD_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_yamiD_cFv();
@@ -1220,7 +1220,7 @@ daNpc_yamiD_c::daNpc_yamiD_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B45F34-80B45F3C 0030D4 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_yamiD_cFv */
-s32 daNpc_yamiD_c::getEyeballMaterialNo() {
+u16 daNpc_yamiD_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_yamis.cpp
+++ b/src/d/actor/d_a_npc_yamis.cpp
@@ -99,7 +99,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_yamis_cpp();
 extern "C" void
 __ct__13daNpc_yamiS_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_yamiS_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_yamiS_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_yamiS_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_yamiS_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_yamiS_cFv();
@@ -1220,7 +1220,7 @@ daNpc_yamiS_c::daNpc_yamiS_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B49598-80B495A0 003118 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_yamiS_cFv */
-s32 daNpc_yamiS_c::getEyeballMaterialNo() {
+u16 daNpc_yamiS_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_yamit.cpp
+++ b/src/d/actor/d_a_npc_yamit.cpp
@@ -101,7 +101,7 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_yamit_cpp();
 extern "C" void
 __ct__13daNpc_yamiT_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__13daNpc_yamiT_cFv();
+extern "C" u16 getEyeballMaterialNo__13daNpc_yamiT_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_yamiT_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_yamiT_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_yamiT_cFv();
@@ -1236,7 +1236,7 @@ daNpc_yamiT_c::daNpc_yamiT_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B4CCF8-80B4CD00 0031F8 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__13daNpc_yamiT_cFv */
-s32 daNpc_yamiT_c::getEyeballMaterialNo() {
+u16 daNpc_yamiT_c::getEyeballMaterialNo() {
     return true;
 }
 

--- a/src/d/actor/d_a_npc_yelia.cpp
+++ b/src/d/actor/d_a_npc_yelia.cpp
@@ -488,7 +488,7 @@ int daNpc_Yelia_c::Draw() {
         J3DModelData* model_data = mpMorf[0]->getModel()->getModelData();
         model_data->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return draw(FALSE, FALSE, field_0xde8, NULL, 100.0f, FALSE, FALSE, FALSE);
+    return draw(FALSE, FALSE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
 }
 
 /* 80B4DD08-80B4DD28 000AE8 0020+00 1/1 0/0 0/0 .text
@@ -631,9 +631,9 @@ void daNpc_Yelia_c::setParam() {
     }
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(l_HIO.m.mWallH);
-    field_0xde8 = l_HIO.m.mShadowDepth;
+    mRealShadowSize = l_HIO.m.mShadowDepth;
     gravity = l_HIO.m.mGravity;
-    field_0xa80 = l_HIO.m.field_0x6c;
+    mExpressionMorfFrame = l_HIO.m.field_0x6c;
     mMorfFrames = l_HIO.m.mMorfFrames;
     if (mType == TYPE_TWILIGHT || mType == TYPE_AFTER_ESCORT) {
         mAcch.SetGrndNone();

--- a/src/d/actor/d_a_npc_ykm.cpp
+++ b/src/d/actor/d_a_npc_ykm.cpp
@@ -127,7 +127,7 @@ extern "C" void func_80B5D394(void* _this, int, int);
 extern "C" void __sinit_d_a_npc_ykm_cpp();
 extern "C" void
 __ct__11daNpc_ykM_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_ykM_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_ykM_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_ykM_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_ykM_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_ykM_cFv();
@@ -2683,7 +2683,7 @@ daNpc_ykM_c::daNpc_ykM_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B5D688-80B5D690 00A288 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_ykM_cFv */
-s32 daNpc_ykM_c::getEyeballMaterialNo() {
+u16 daNpc_ykM_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_ykw.cpp
+++ b/src/d/actor/d_a_npc_ykw.cpp
@@ -118,7 +118,7 @@ extern "C" void func_80B678EC(void* _this, f32, f32);
 extern "C" void __sinit_d_a_npc_ykw_cpp();
 extern "C" void
 __ct__11daNpc_ykW_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballMaterialNo__11daNpc_ykW_cFv();
+extern "C" u16 getEyeballMaterialNo__11daNpc_ykW_cFv();
 extern "C" s32 getHeadJointNo__11daNpc_ykW_cFv();
 extern "C" s32 getNeckJointNo__11daNpc_ykW_cFv();
 extern "C" bool getBackboneJointNo__11daNpc_ykW_cFv();
@@ -2483,7 +2483,7 @@ daNpc_ykW_c::daNpc_ykW_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B67B1C-80B67B24 008CFC 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__11daNpc_ykW_cFv */
-s32 daNpc_ykW_c::getEyeballMaterialNo() {
+u16 daNpc_ykW_c::getEyeballMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_zanb.cpp
+++ b/src/d/actor/d_a_npc_zanb.cpp
@@ -95,7 +95,7 @@ extern "C" void
 __ct__12daNpc_zanB_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
 extern "C" void __dt__8cM3dGCylFv();
 extern "C" void __dt__8cM3dGAabFv();
-extern "C" s32 getEyeballMaterialNo__12daNpc_zanB_cFv();
+extern "C" u16 getEyeballMaterialNo__12daNpc_zanB_cFv();
 extern "C" s32 getHeadJointNo__12daNpc_zanB_cFv();
 extern "C" s32 getNeckJointNo__12daNpc_zanB_cFv();
 extern "C" bool getBackboneJointNo__12daNpc_zanB_cFv();
@@ -1201,7 +1201,7 @@ extern "C" void __dt__8cM3dGAabFv() {
 }
 
 /* 80B6BC18-80B6BC20 002DD8 0008+00 1/0 0/0 0/0 .text getEyeballMaterialNo__12daNpc_zanB_cFv */
-s32 daNpc_zanB_c::getEyeballMaterialNo() {
+u16 daNpc_zanB_c::getEyeballMaterialNo() {
     return 4;
 }
 

--- a/src/d/actor/d_a_npc_zant.cpp
+++ b/src/d/actor/d_a_npc_zant.cpp
@@ -187,7 +187,7 @@ int daNpc_Zant_c::Draw() {
         J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
         modelData->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 0.0f, 1, 0, 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 0.0f, 1, 0, 0);
 }
 
 /* 80B6C7E8-80B6C808 000728 0020+00 1/1 0/0 0/0 .text createHeapCallBack__12daNpc_Zant_cFP10fopAc_ac_c */
@@ -283,9 +283,9 @@ void daNpc_Zant_c::setParam() {
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daNpc_Zant_Param_c::m.field_0x18);
 
-    field_0xde8 = daNpc_Zant_Param_c::m.field_0xc;
+    mRealShadowSize = daNpc_Zant_Param_c::m.field_0xc;
     gravity = daNpc_Zant_Param_c::m.field_0x4;
-    field_0xa80 = daNpc_Zant_Param_c::m.field_0x6c;
+    mExpressionMorfFrame = daNpc_Zant_Param_c::m.field_0x6c;
     mMorfFrames = daNpc_Zant_Param_c::m.field_0x44;
 }
 

--- a/src/d/actor/d_a_npc_zelR.cpp
+++ b/src/d/actor/d_a_npc_zelR.cpp
@@ -245,7 +245,7 @@ int daNpc_ZelR_c::Draw() {
         modelData->getMaterialNodePointer(getEyeballRMaterialNo())->setMaterialAnm(mpMatAnm[1]);
     }
     
-    return daNpcT_c::draw(0, 1, field_0xde8, NULL, 100.0f, 0, 0, 0);
+    return daNpcT_c::draw(0, 1, mRealShadowSize, NULL, 100.0f, 0, 0, 0);
 }
 
 /* 80B6F77C-80B6F79C 000A3C 0020+00 1/1 0/0 0/0 .text       createHeapCallBack__12daNpc_ZelR_cFP10fopAc_ac_c */
@@ -344,8 +344,8 @@ BOOL daNpc_ZelR_c::ctrlBtk() {
             mpMatAnm[1]->setNowOffsetX(cM_ssin(mJntAnm.getEyeAngleY()) * 0.2f);
             mpMatAnm[1]->setNowOffsetY(cM_ssin(mJntAnm.getEyeAngleX()) * 0.2f);
 
-            mpMatAnm[0]->onEyeMoveFlg();
-            mpMatAnm[1]->onEyeMoveFlg();
+            mpMatAnm[0]->onEyeMoveFlag();
+            mpMatAnm[1]->onEyeMoveFlag();
             return TRUE;
         }
 
@@ -355,8 +355,8 @@ BOOL daNpc_ZelR_c::ctrlBtk() {
             field_0xe2a = 0;
         }
 
-        mpMatAnm[0]->offEyeMoveFlg();
-        mpMatAnm[1]->offEyeMoveFlg();
+        mpMatAnm[0]->offEyeMoveFlag();
+        mpMatAnm[1]->offEyeMoveFlag();
 
     }
 
@@ -381,9 +381,9 @@ void daNpc_ZelR_c::setParam() {
     mWallR = l_HIO.m.mWallR;
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(l_HIO.m.mWallH);
-    field_0xde8 = l_HIO.m.field_0xc;
+    mRealShadowSize = l_HIO.m.field_0xc;
     gravity = l_HIO.m.mGravity;
-    field_0xa80 = l_HIO.m.field_0x6c;
+    mExpressionMorfFrame = l_HIO.m.field_0x6c;
     mMorfFrames = l_HIO.m.mMorfFrames;
 }
 
@@ -648,12 +648,12 @@ static int daNpc_ZelR_IsDelete(void* param_0) {
 }
 
 /* 80B71A34-80B71A3C 002CF4 0008+00 1/0 0/0 0/0 .text getEyeballRMaterialNo__12daNpc_ZelR_cFv */
-s32 daNpc_ZelR_c::getEyeballRMaterialNo() {
+u16 daNpc_ZelR_c::getEyeballRMaterialNo() {
     return 3;
 }
 
 /* 80B71A3C-80B71A44 002CFC 0008+00 1/0 0/0 0/0 .text getEyeballLMaterialNo__12daNpc_ZelR_cFv */
-s32 daNpc_ZelR_c::getEyeballLMaterialNo() {
+u16 daNpc_ZelR_c::getEyeballLMaterialNo() {
     return 2;
 }
 

--- a/src/d/actor/d_a_npc_zelRo.cpp
+++ b/src/d/actor/d_a_npc_zelRo.cpp
@@ -79,7 +79,7 @@ extern "C" void setEyeAngleX__15daNpcT_JntAnm_cF4cXyzfs();
 extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();
 extern "C" s32 getFootLJointNo__8daNpcT_cFv();
 extern "C" s32 getFootRJointNo__8daNpcT_cFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
+extern "C" u16 getEyeballMaterialNo__8daNpcT_cFv();
 extern "C" bool checkChangeEvt__8daNpcT_cFv();
 extern "C" bool evtEndProc__8daNpcT_cFv();
 extern "C" void afterMoved__8daNpcT_cFv();
@@ -98,8 +98,8 @@ extern "C" void changeBtk__8daNpcT_cFPiPi();
 extern "C" void __sinit_d_a_npc_zelRo_cpp();
 extern "C" void
 __ct__13daNpc_ZelRo_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" s32 getEyeballRMaterialNo__13daNpc_ZelRo_cFv();
-extern "C" s32 getEyeballLMaterialNo__13daNpc_ZelRo_cFv();
+extern "C" u16 getEyeballRMaterialNo__13daNpc_ZelRo_cFv();
+extern "C" u16 getEyeballLMaterialNo__13daNpc_ZelRo_cFv();
 extern "C" s32 getHeadJointNo__13daNpc_ZelRo_cFv();
 extern "C" s32 getNeckJointNo__13daNpc_ZelRo_cFv();
 extern "C" bool getBackboneJointNo__13daNpc_ZelRo_cFv();
@@ -1171,12 +1171,12 @@ daNpc_ZelRo_c::daNpc_ZelRo_c(daNpcT_faceMotionAnmData_c const* param_0,
 }
 
 /* 80B74BA8-80B74BB0 002CE8 0008+00 1/0 0/0 0/0 .text getEyeballRMaterialNo__13daNpc_ZelRo_cFv */
-s32 daNpc_ZelRo_c::getEyeballRMaterialNo() {
+u16 daNpc_ZelRo_c::getEyeballRMaterialNo() {
     return 7;
 }
 
 /* 80B74BB0-80B74BB8 002CF0 0008+00 1/0 0/0 0/0 .text getEyeballLMaterialNo__13daNpc_ZelRo_cFv */
-s32 daNpc_ZelRo_c::getEyeballLMaterialNo() {
+u16 daNpc_ZelRo_c::getEyeballLMaterialNo() {
     return 6;
 }
 

--- a/src/d/actor/d_a_npc_zelda.cpp
+++ b/src/d/actor/d_a_npc_zelda.cpp
@@ -4,1176 +4,832 @@
 */
 
 #include "d/actor/d_a_npc_zelda.h"
-#include "dol2asm.h"
+#include "JSystem/JHostIO/JORFile.h"
+#include "SSystem/SComponent/c_counter.h"
+#include "d/actor/d_a_hozelda.h"
+#include "d/d_debug_viewer.h"
 
-//
-// Forward References:
-//
+UNK_REL_DATA
 
-extern "C" void __dt__13daNpc_Zelda_cFv();
-extern "C" void create__13daNpc_Zelda_cFv();
-extern "C" void CreateHeap__13daNpc_Zelda_cFv();
-extern "C" void __dt__15J3DTevKColorAnmFv();
-extern "C" void __ct__15J3DTevKColorAnmFv();
-extern "C" void __dt__14J3DTevColorAnmFv();
-extern "C" void __ct__14J3DTevColorAnmFv();
-extern "C" void __dt__11J3DTexNoAnmFv();
-extern "C" void __ct__11J3DTexNoAnmFv();
-extern "C" void __dt__12J3DTexMtxAnmFv();
-extern "C" void __ct__12J3DTexMtxAnmFv();
-extern "C" void __dt__14J3DMatColorAnmFv();
-extern "C" void __ct__14J3DMatColorAnmFv();
-extern "C" void Delete__13daNpc_Zelda_cFv();
-extern "C" void Execute__13daNpc_Zelda_cFv();
-extern "C" void Draw__13daNpc_Zelda_cFv();
-extern "C" void createHeapCallBack__13daNpc_Zelda_cFP10fopAc_ac_c();
-extern "C" void ctrlJointCallBack__13daNpc_Zelda_cFP8J3DJointi();
-extern "C" void getType__13daNpc_Zelda_cFv();
-extern "C" bool isDelete__13daNpc_Zelda_cFv();
-extern "C" void reset__13daNpc_Zelda_cFv();
-extern "C" void afterJntAnm__13daNpc_Zelda_cFi();
-extern "C" void ctrlBtk__13daNpc_Zelda_cFv();
-extern "C" void checkChangeEvt__13daNpc_Zelda_cFv();
-extern "C" void setParam__13daNpc_Zelda_cFv();
-extern "C" void setAfterTalkMotion__13daNpc_Zelda_cFv();
-extern "C" void srchActors__13daNpc_Zelda_cFv();
-extern "C" void evtTalk__13daNpc_Zelda_cFv();
-extern "C" void evtCutProc__13daNpc_Zelda_cFv();
-extern "C" void action__13daNpc_Zelda_cFv();
-extern "C" void beforeMove__13daNpc_Zelda_cFv();
-extern "C" void setAttnPos__13daNpc_Zelda_cFv();
-extern "C" void setCollision__13daNpc_Zelda_cFv();
-extern "C" bool drawDbgInfo__13daNpc_Zelda_cFv();
-extern "C" void selectAction__13daNpc_Zelda_cFv();
-extern "C" void chkAction__13daNpc_Zelda_cFM13daNpc_Zelda_cFPCvPvPv_i();
-extern "C" void setAction__13daNpc_Zelda_cFM13daNpc_Zelda_cFPCvPvPv_i();
-extern "C" void wait__13daNpc_Zelda_cFPv();
-extern "C" void talk__13daNpc_Zelda_cFPv();
-extern "C" static void daNpc_Zelda_Create__FPv();
-extern "C" static void daNpc_Zelda_Delete__FPv();
-extern "C" static void daNpc_Zelda_Execute__FPv();
-extern "C" static void daNpc_Zelda_Draw__FPv();
-extern "C" static bool daNpc_Zelda_IsDelete__FPv();
-extern "C" void calc__11J3DTexNoAnmCFPUs();
-extern "C" void __dt__10cCcD_GSttsFv();
-extern "C" void __dt__8daNpcT_cFv();
-extern "C" void __dt__4cXyzFv();
-extern "C" void __dt__5csXyzFv();
-extern "C" void
-__ct__8daNpcT_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" void __ct__5csXyzFv();
-extern "C" void __dt__15daNpcT_JntAnm_cFv();
-extern "C" void __ct__4cXyzFv();
-extern "C" void __dt__18daNpcT_ActorMngr_cFv();
-extern "C" void __dt__22daNpcT_MotionSeqMngr_cFv();
-extern "C" void __dt__12dBgS_AcchCirFv();
-extern "C" void __dt__10dCcD_GSttsFv();
-extern "C" void __dt__12dBgS_ObjAcchFv();
-extern "C" void __dt__12J3DFrameCtrlFv();
-extern "C" void setEyeAngleY__15daNpcT_JntAnm_cF4cXyzsifs();
-extern "C" void setEyeAngleX__15daNpcT_JntAnm_cF4cXyzfs();
-extern "C" void ctrlSubFaceMotion__8daNpcT_cFi();
-extern "C" s32 getFootLJointNo__8daNpcT_cFv();
-extern "C" s32 getFootRJointNo__8daNpcT_cFv();
-extern "C" s32 getEyeballMaterialNo__8daNpcT_cFv();
-extern "C" bool evtEndProc__8daNpcT_cFv();
-extern "C" void afterMoved__8daNpcT_cFv();
-extern "C" bool chkXYItems__8daNpcT_cFv();
-extern "C" void decTmr__8daNpcT_cFv();
-extern "C" void drawOtherMdl__8daNpcT_cFv();
-extern "C" void drawGhost__8daNpcT_cFv();
-extern "C" bool afterSetFaceMotionAnm__8daNpcT_cFiifi();
-extern "C" bool afterSetMotionAnm__8daNpcT_cFiifi();
-extern "C" void getFaceMotionAnm__8daNpcT_cF26daNpcT_faceMotionAnmData_c();
-extern "C" void getMotionAnm__8daNpcT_cF22daNpcT_motionAnmData_c();
-extern "C" void changeAnm__8daNpcT_cFPiPi();
-extern "C" void changeBck__8daNpcT_cFPiPi();
-extern "C" void changeBtp__8daNpcT_cFPiPi();
-extern "C" void changeBtk__8daNpcT_cFPiPi();
-extern "C" void __sinit_d_a_npc_zelda_cpp();
-extern "C" void
-__ct__13daNpc_Zelda_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc();
-extern "C" void __dt__8cM3dGCylFv();
-extern "C" void __dt__8cM3dGAabFv();
-extern "C" s32 getEyeballRMaterialNo__13daNpc_Zelda_cFv();
-extern "C" s32 getEyeballLMaterialNo__13daNpc_Zelda_cFv();
-extern "C" s32 getHeadJointNo__13daNpc_Zelda_cFv();
-extern "C" s32 getNeckJointNo__13daNpc_Zelda_cFv();
-extern "C" bool getBackboneJointNo__13daNpc_Zelda_cFv();
-extern "C" void checkChangeJoint__13daNpc_Zelda_cFi();
-extern "C" void checkRemoveJoint__13daNpc_Zelda_cFi();
-extern "C" void __dt__19daNpc_Zelda_Param_cFv();
-extern "C" static void func_80B77FA4();
-extern "C" static void func_80B77FAC();
-extern "C" u8 const m__19daNpc_Zelda_Param_c[140];
-extern "C" extern char const* const d_a_npc_zelda__stringBase0;
-extern "C" void* mCutNameList__13daNpc_Zelda_c;
-extern "C" u8 mCutList__13daNpc_Zelda_c[12];
+#if DEBUG
+#define HIO_PARAM(i_this) (i_this->mHIO->param)
+#else
+#define HIO_PARAM(_) (daNpc_Zelda_Param_c::m)
+#endif
 
-//
-// External References:
-//
+static u32 l_bmdData[2] = { 11, 1 };
 
-extern "C" void mDoMtx_YrotS__FPA4_fs();
-extern "C" void mDoMtx_YrotM__FPA4_fs();
-extern "C" void mDoMtx_ZrotM__FPA4_fs();
-extern "C" void
-__ct__16mDoExt_McaMorfSOFP12J3DModelDataP25mDoExt_McaMorfCallBack1_cP25mDoExt_McaMorfCallBack2_cP15J3DAnmTransformifiiP10Z2CreatureUlUl();
-extern "C" void stopZelAnime__16mDoExt_McaMorfSOFv();
-extern "C" void __ct__10fopAc_ac_cFv();
-extern "C" void __dt__10fopAc_ac_cFv();
-extern "C" void fopAcM_entrySolidHeap__FP10fopAc_ac_cPFP10fopAc_ac_c_iUl();
-extern "C" void fopAcM_setCullSizeBox__FP10fopAc_ac_cffffff();
-extern "C" void dComIfGs_wolfeye_effect_check__Fv();
-extern "C" void getRes__14dRes_control_cFPCclP11dRes_info_ci();
-extern "C" void reset__14dEvt_control_cFv();
-extern "C" void getMyStaffId__16dEvent_manager_cFPCcP10fopAc_ac_ci();
-extern "C" void getMyActIdx__16dEvent_manager_cFiPCPCciii();
-extern "C" void cutEnd__16dEvent_manager_cFi();
-extern "C" void ChkPresentEnd__16dEvent_manager_cFv();
-extern "C" void __ct__12dBgS_AcchCirFv();
-extern "C" void SetWallR__12dBgS_AcchCirFf();
-extern "C" void __dt__9dBgS_AcchFv();
-extern "C" void __ct__9dBgS_AcchFv();
-extern "C" void Set__9dBgS_AcchFP4cXyzP4cXyzP10fopAc_ac_ciP12dBgS_AcchCirP4cXyzP5csXyzP5csXyz();
-extern "C" void CrrPos__9dBgS_AcchFR4dBgS();
-extern "C" void __ct__11dBgS_GndChkFv();
-extern "C" void __dt__11dBgS_GndChkFv();
-extern "C" void __ct__11dBgS_LinChkFv();
-extern "C" void __dt__11dBgS_LinChkFv();
-extern "C" void SetObj__16dBgS_PolyPassChkFv();
-extern "C" void __ct__10dCcD_GSttsFv();
-extern "C" void Init__9dCcD_SttsFiiP10fopAc_ac_c();
-extern "C" void __ct__12dCcD_GObjInfFv();
-extern "C" void __dt__12dCcD_GObjInfFv();
-extern "C" void Set__8dCcD_CylFRC11dCcD_SrcCyl();
-extern "C" void initialize__18daNpcT_ActorMngr_cFv();
-extern "C" void entry__18daNpcT_ActorMngr_cFP10fopAc_ac_c();
-extern "C" void remove__18daNpcT_ActorMngr_cFv();
-extern "C" void getActorP__18daNpcT_ActorMngr_cFv();
-extern "C" void initialize__15daNpcT_MatAnm_cFv();
-extern "C" void initialize__22daNpcT_MotionSeqMngr_cFv();
-extern "C" void initialize__15daNpcT_JntAnm_cFv();
-extern "C" void setParam__15daNpcT_JntAnm_cFP10fopAc_ac_cP8J3DModelP4cXyziiiffffffffffP4cXyz();
-extern "C" void calcJntRad__15daNpcT_JntAnm_cFfff();
-extern "C" void calc__19daNpcT_DmgStagger_cFi();
-extern "C" void tgHitCallBack__8daNpcT_cFP10fopAc_ac_cP12dCcD_GObjInfP10fopAc_ac_cP12dCcD_GObjInf();
-extern "C" void loadRes__8daNpcT_cFPCScPPCc();
-extern "C" void deleteRes__8daNpcT_cFPCScPPCc();
-extern "C" void execute__8daNpcT_cFv();
-extern "C" void draw__8daNpcT_cFiifP11_GXColorS10fiii();
-extern "C" void setEnvTevColor__8daNpcT_cFv();
-extern "C" void setRoomNo__8daNpcT_cFv();
-extern "C" void setMtx__8daNpcT_cFv();
-extern "C" void ctrlJoint__8daNpcT_cFP8J3DJointP8J3DModel();
-extern "C" void evtProc__8daNpcT_cFv();
-extern "C" void setFootPos__8daNpcT_cFv();
-extern "C" void setFootPrtcl__8daNpcT_cFP4cXyzff();
-extern "C" bool checkCullDraw__8daNpcT_cFv();
-extern "C" void twilight__8daNpcT_cFv();
-extern "C" void evtOrder__8daNpcT_cFv();
-extern "C" void evtChange__8daNpcT_cFv();
-extern "C" void clrParam__8daNpcT_cFv();
-extern "C" void setFaceMotionAnm__8daNpcT_cFib();
-extern "C" void setMotionAnm__8daNpcT_cFifi();
-extern "C" void setAngle__8daNpcT_cF5csXyz();
-extern "C" void setAngle__8daNpcT_cFs();
-extern "C" void chkActorInSight__8daNpcT_cFP10fopAc_ac_cfs();
-extern "C" void srchPlayerActor__8daNpcT_cFv();
-extern "C" void step__8daNpcT_cFsiiii();
-extern "C" void initTalk__8daNpcT_cFiPP10fopAc_ac_c();
-extern "C" void talkProc__8daNpcT_cFPiiPP10fopAc_ac_ci();
-extern "C" void daNpcT_getDistTableIdx__Fii();
-extern "C" void __ct__10dMsgFlow_cFv();
-extern "C" void __dt__10dMsgFlow_cFv();
-extern "C" void getEventId__10dMsgFlow_cFPi();
-extern "C" void Set__4cCcSFP8cCcD_Obj();
-extern "C" void __pl__4cXyzCFRC3Vec();
-extern "C" void __mi__4cXyzCFRC3Vec();
-extern "C" void cM_atan2s__Fff();
-extern "C" void cM_rndF__Ff();
-extern "C" void __ct__11cBgS_GndChkFv();
-extern "C" void __dt__11cBgS_GndChkFv();
-extern "C" void __dt__13cBgS_PolyInfoFv();
-extern "C" void __dt__8cM3dGCirFv();
-extern "C" void SetC__8cM3dGCylFRC4cXyz();
-extern "C" void SetH__8cM3dGCylFf();
-extern "C" void SetR__8cM3dGCylFf();
-extern "C" void __ct__10Z2CreatureFv();
-extern "C" void __dt__10Z2CreatureFv();
-extern "C" void init__10Z2CreatureFP3VecP3VecUcUc();
-extern "C" void* __nw__FUl();
-extern "C" void __dl__FPv();
-extern "C" void init__12J3DFrameCtrlFs();
-extern "C" void getTexNo__16J3DAnmTexPatternCFUsPUs();
-extern "C" void initialize__14J3DMaterialAnmFv();
-extern "C" void __destroy_arr();
-extern "C" void __construct_array();
-extern "C" void __ptmf_test();
-extern "C" void __ptmf_cmpr();
-extern "C" void __ptmf_scall();
-extern "C" void _savegpr_22();
-extern "C" void _savegpr_27();
-extern "C" void _savegpr_28();
-extern "C" void _savegpr_29();
-extern "C" void _restgpr_22();
-extern "C" void _restgpr_27();
-extern "C" void _restgpr_28();
-extern "C" void _restgpr_29();
-extern "C" extern u8 const __ptmf_null[12 + 4 /* padding */];
-extern "C" extern void* __vt__8dCcD_Cyl[36];
-extern "C" extern void* __vt__9dCcD_Stts[11];
-extern "C" u8 mCcDCyl__8daNpcT_c[68];
-extern "C" extern void* __vt__8daNpcT_c[49];
-extern "C" extern void* __vt__15daNpcT_MatAnm_c[4 + 1 /* padding */];
-extern "C" extern void* __vt__12cCcD_CylAttr[25];
-extern "C" extern void* __vt__14cCcD_ShapeAttr[22];
-extern "C" extern void* __vt__9cCcD_Stts[8];
-extern "C" extern void* __vt__14J3DMaterialAnm[4];
-extern "C" u8 now__14mDoMtx_stack_c[48];
-extern "C" u8 sincosTable___5JMath[65536];
-extern "C" void __register_global_object();
-
-//
-// Declarations:
-//
-
-/* ############################################################################################## */
-/* 80B780C4-80B780C4 0000FC 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
 #pragma push
 #pragma force_active on
-SECTION_DEAD static char const* const stringBase_80B780C4 = "";
-SECTION_DEAD static char const* const stringBase_80B780C5 = "NO_RESPONSE";
-SECTION_DEAD static char const* const stringBase_80B780D1 = "Zelda";
-#pragma pop
-
-/* 80B780D8-80B780E4 000000 000C+00 1/1 0/0 0/0 .data            cNullVec__6Z2Calc */
-SECTION_DATA static u8 cNullVec__6Z2Calc[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-
-/* 80B780E4-80B780F8 00000C 0004+10 0/0 0/0 0/0 .data            @1787 */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u32 lit_1787[1 + 4 /* padding */] = {
-    0x02000201,
-    /* padding */
-    0x40080000,
-    0x00000000,
-    0x3FE00000,
-    0x00000000,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
 };
 #pragma pop
 
-/* 80B780F8-80B78100 000020 0008+00 1/1 0/0 0/0 .data            l_bmdData */
-SECTION_DATA static u8 l_bmdData[8] = {
-    0x00, 0x00, 0x00, 0x0B, 0x00, 0x00, 0x00, 0x01,
+static char* l_resNameList[2] = {
+    "",
+    "Zelda"
 };
 
-/* 80B78100-80B78110 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_zelda__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_zelda__stringBase0) + 0x1),
-    (void*)NULL,
-};
-#pragma pop
-
-/* 80B78110-80B78118 -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_zelda__stringBase0,
-    (void*)(((char*)&d_a_npc_zelda__stringBase0) + 0xD),
+static s8 l_loadResPtrn0[2] = {
+    1, -1,
 };
 
-/* 80B78118-80B7811C 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
-SECTION_DATA static u16 l_loadResPtrn0[1 + 1 /* padding */] = {
-    0x01FF,
-    /* padding */
-    0x0000,
+static s8* l_loadResPtrnList[2] = {
+    &l_loadResPtrn0[0],
+    &l_loadResPtrn0[0],
 };
 
-/* 80B7811C-80B78124 -00001 0008+00 1/2 0/0 0/0 .data            l_loadResPtrnList */
-SECTION_DATA static void* l_loadResPtrnList[2] = {
-    (void*)&l_loadResPtrn0,
-    (void*)&l_loadResPtrn0,
+static daNpcT_faceMotionAnmData_c l_faceMotionAnmData[3] = {
+    {-1, 0, 0, 17, 2, 1, 1},
+    {-1, 0, 0, 18, 2, 1, 0},
+    {6, 0, 1, 17, 2, 1, 1},
 };
 
-/* 80B78124-80B78178 00004C 0054+00 0/1 0/0 0/0 .data            l_faceMotionAnmData */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 l_faceMotionAnmData[84] = {
-    0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x11, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-    0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x12, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-    0x00, 0x11, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
-};
-#pragma pop
-
-/* 80B78178-80B781B0 0000A0 0038+00 0/1 0/0 0/0 .data            l_motionAnmData */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 l_motionAnmData[56] = {
-    0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-    0x00, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
-    0x00, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-};
-#pragma pop
-
-/* 80B781B0-80B781E0 0000D8 0030+00 0/1 0/0 0/0 .data            l_faceMotionSequenceData */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 l_faceMotionSequenceData[48] = {
-    0x00, 0x02, 0xFF, 0x01, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-    0x00, 0x01, 0xFF, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-    0x00, 0x00, 0xFF, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-};
-#pragma pop
-
-/* 80B781E0-80B78200 000108 0020+00 0/1 0/0 0/0 .data            l_motionSequenceData */
-#pragma push
-#pragma force_active on
-SECTION_DATA static u8 l_motionSequenceData[32] = {
-    0x00, 0x00, 0xFF, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-    0x00, 0x01, 0xFF, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-};
-#pragma pop
-
-/* 80B78200-80B78204 -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__13daNpc_Zelda_c */
-SECTION_DATA void* daNpc_Zelda_c::mCutNameList = (void*)&d_a_npc_zelda__stringBase0;
-
-/* 80B78204-80B78210 00012C 000C+00 2/2 0/0 0/0 .data            mCutList__13daNpc_Zelda_c */
-SECTION_DATA u8 daNpc_Zelda_c::mCutList[12] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+static daNpcT_motionAnmData_c l_motionAnmData[2] = {
+    {8, 2, 1, 14, 0, 1, 1, 0},
+    {7, 2, 1, 14, 0, 1, 0, 0},
 };
 
-/* 80B78210-80B7821C -00001 000C+00 1/1 0/0 0/0 .data            @4555 */
-SECTION_DATA static void* lit_4555[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)talk__13daNpc_Zelda_cFPv,
+static daNpcT_MotionSeqMngr_c::sequenceStepData_c l_faceMotionSequenceData[12] = {
+    {2, -1, 1}, {-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0}, {1, -1, 0}, {-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0},
+    {0, -1, 0}, {-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0},
 };
 
-/* 80B7821C-80B78228 -00001 000C+00 1/1 0/0 0/0 .data            @4631 */
-SECTION_DATA static void* lit_4631[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)talk__13daNpc_Zelda_cFPv,
+static daNpcT_MotionSeqMngr_c::sequenceStepData_c l_motionSequenceData[8] = {
+    {0, -1, 0}, {-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0}, {1, -1, 0}, {-1, 0, 0}, {-1, 0, 0}, {-1, 0, 0},
 };
 
-/* 80B78228-80B78234 -00001 000C+00 1/1 0/0 0/0 .data            @4636 */
-SECTION_DATA static void* lit_4636[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)talk__13daNpc_Zelda_cFPv,
-};
+const char* daNpc_Zelda_c::mCutNameList = "";
+cutFunc daNpc_Zelda_c::mCutList[1] = { 0 };
 
-/* 80B78234-80B78240 -00001 000C+00 1/1 0/0 0/0 .data            @4865 */
-SECTION_DATA static void* lit_4865[3] = {
-    (void*)NULL,
-    (void*)0xFFFFFFFF,
-    (void*)wait__13daNpc_Zelda_cFPv,
-};
+#if DEBUG
+static daNpc_Zelda_HIO_c l_HIO;
+#else
+static daNpc_Zelda_Param_c l_HIO;
+#endif
 
-/* 80B78240-80B78260 -00001 0020+00 1/0 0/0 0/0 .data            daNpc_Zelda_MethodTable */
-static actor_method_class daNpc_Zelda_MethodTable = {
-    (process_method_func)daNpc_Zelda_Create__FPv,
-    (process_method_func)daNpc_Zelda_Delete__FPv,
-    (process_method_func)daNpc_Zelda_Execute__FPv,
-    (process_method_func)daNpc_Zelda_IsDelete__FPv,
-    (process_method_func)daNpc_Zelda_Draw__FPv,
-};
+#if DEBUG
+daNpc_Zelda_HIO_c::daNpc_Zelda_HIO_c() {
+    param = daNpc_Zelda_Param_c::m;
+}
 
-/* 80B78260-80B78290 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_NPC_ZELDA */
-extern actor_process_profile_definition g_profile_NPC_ZELDA = {
-  fpcLy_CURRENT_e,          // mLayerID
-  7,                        // mListID
-  fpcPi_CURRENT_e,          // mListPrio
-  PROC_NPC_ZELDA,           // mProcName
-  &g_fpcLf_Method.base,    // sub_method
-  sizeof(daNpc_Zelda_c),    // mSize
-  0,                        // mSizeOther
-  0,                        // mParameters
-  &g_fopAc_Method.base,     // sub_method
-  384,                      // mPriority
-  &daNpc_Zelda_MethodTable, // sub_method
-  0x00040108,               // mStatus
-  fopAc_NPC_e,              // mActorType
-  fopAc_CULLBOX_CUSTOM_e,   // cullType
-};
+void daNpc_Zelda_HIO_c::genMessage(JORMContext* ctx) {
+    daNpcT_cmnGenMessage(ctx, &param.common);
+    ctx->genButton
+              ("ファイル書き出し",0x40000002,0,NULL,0xffff,0xffff,0x200,0x18);
+}
 
-/* 80B78290-80B7829C 0001B8 000C+00 2/2 0/0 0/0 .data            __vt__11J3DTexNoAnm */
-SECTION_DATA extern void* __vt__11J3DTexNoAnm[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)calc__11J3DTexNoAnmCFPUs,
-};
+void daNpc_Zelda_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    char auStack_7e0[2004];
 
-/* 80B7829C-80B782A8 0001C4 000C+00 3/3 0/0 0/0 .data            __vt__12J3DFrameCtrl */
-SECTION_DATA extern void* __vt__12J3DFrameCtrl[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__12J3DFrameCtrlFv,
-};
+    JORReflexible::listenPropertyEvent(event);
 
-/* 80B782A8-80B782CC 0001D0 0024+00 3/3 0/0 0/0 .data            __vt__12dBgS_ObjAcch */
-SECTION_DATA extern void* __vt__12dBgS_ObjAcch[9] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__12dBgS_ObjAcchFv,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80B77FAC,
-    (void*)NULL,
-    (void*)NULL,
-    (void*)func_80B77FA4,
-};
-
-/* 80B782CC-80B782D8 0001F4 000C+00 2/2 0/0 0/0 .data            __vt__12dBgS_AcchCir */
-SECTION_DATA extern void* __vt__12dBgS_AcchCir[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__12dBgS_AcchCirFv,
-};
-
-/* 80B782D8-80B782E4 000200 000C+00 3/3 0/0 0/0 .data            __vt__10cCcD_GStts */
-SECTION_DATA extern void* __vt__10cCcD_GStts[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__10cCcD_GSttsFv,
-};
-
-/* 80B782E4-80B782F0 00020C 000C+00 2/2 0/0 0/0 .data            __vt__10dCcD_GStts */
-SECTION_DATA extern void* __vt__10dCcD_GStts[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__10dCcD_GSttsFv,
-};
-
-/* 80B782F0-80B782FC 000218 000C+00 3/3 0/0 0/0 .data            __vt__22daNpcT_MotionSeqMngr_c */
-SECTION_DATA extern void* __vt__22daNpcT_MotionSeqMngr_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__22daNpcT_MotionSeqMngr_cFv,
-};
-
-/* 80B782FC-80B78308 000224 000C+00 4/4 0/0 0/0 .data            __vt__18daNpcT_ActorMngr_c */
-SECTION_DATA extern void* __vt__18daNpcT_ActorMngr_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__18daNpcT_ActorMngr_cFv,
-};
-
-/* 80B78308-80B78314 000230 000C+00 3/3 0/0 0/0 .data            __vt__15daNpcT_JntAnm_c */
-SECTION_DATA extern void* __vt__15daNpcT_JntAnm_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__15daNpcT_JntAnm_cFv,
-};
-
-/* 80B78314-80B78320 00023C 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGAab */
-SECTION_DATA extern void* __vt__8cM3dGAab[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGAabFv,
-};
-
-/* 80B78320-80B7832C 000248 000C+00 3/3 0/0 0/0 .data            __vt__8cM3dGCyl */
-SECTION_DATA extern void* __vt__8cM3dGCyl[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__8cM3dGCylFv,
-};
-
-/* 80B7832C-80B783F0 000254 00C4+00 2/2 0/0 0/0 .data            __vt__13daNpc_Zelda_c */
-SECTION_DATA extern void* __vt__13daNpc_Zelda_c[49] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__13daNpc_Zelda_cFv,
-    (void*)ctrlBtk__13daNpc_Zelda_cFv,
-    (void*)ctrlSubFaceMotion__8daNpcT_cFi,
-    (void*)checkChangeJoint__13daNpc_Zelda_cFi,
-    (void*)checkRemoveJoint__13daNpc_Zelda_cFi,
-    (void*)getBackboneJointNo__13daNpc_Zelda_cFv,
-    (void*)getNeckJointNo__13daNpc_Zelda_cFv,
-    (void*)getHeadJointNo__13daNpc_Zelda_cFv,
-    (void*)getFootLJointNo__8daNpcT_cFv,
-    (void*)getFootRJointNo__8daNpcT_cFv,
-    (void*)getEyeballLMaterialNo__13daNpc_Zelda_cFv,
-    (void*)getEyeballRMaterialNo__13daNpc_Zelda_cFv,
-    (void*)getEyeballMaterialNo__8daNpcT_cFv,
-    (void*)ctrlJoint__8daNpcT_cFP8J3DJointP8J3DModel,
-    (void*)afterJntAnm__13daNpc_Zelda_cFi,
-    (void*)setParam__13daNpc_Zelda_cFv,
-    (void*)checkChangeEvt__13daNpc_Zelda_cFv,
-    (void*)evtTalk__13daNpc_Zelda_cFv,
-    (void*)evtEndProc__8daNpcT_cFv,
-    (void*)evtCutProc__13daNpc_Zelda_cFv,
-    (void*)setAfterTalkMotion__13daNpc_Zelda_cFv,
-    (void*)evtProc__8daNpcT_cFv,
-    (void*)action__13daNpc_Zelda_cFv,
-    (void*)beforeMove__13daNpc_Zelda_cFv,
-    (void*)afterMoved__8daNpcT_cFv,
-    (void*)setAttnPos__13daNpc_Zelda_cFv,
-    (void*)setFootPos__8daNpcT_cFv,
-    (void*)setCollision__13daNpc_Zelda_cFv,
-    (void*)setFootPrtcl__8daNpcT_cFP4cXyzff,
-    (void*)checkCullDraw__8daNpcT_cFv,
-    (void*)twilight__8daNpcT_cFv,
-    (void*)chkXYItems__8daNpcT_cFv,
-    (void*)evtOrder__8daNpcT_cFv,
-    (void*)decTmr__8daNpcT_cFv,
-    (void*)clrParam__8daNpcT_cFv,
-    (void*)drawDbgInfo__13daNpc_Zelda_cFv,
-    (void*)drawOtherMdl__8daNpcT_cFv,
-    (void*)drawGhost__8daNpcT_cFv,
-    (void*)afterSetFaceMotionAnm__8daNpcT_cFiifi,
-    (void*)afterSetMotionAnm__8daNpcT_cFiifi,
-    (void*)getFaceMotionAnm__8daNpcT_cF26daNpcT_faceMotionAnmData_c,
-    (void*)getMotionAnm__8daNpcT_cF22daNpcT_motionAnmData_c,
-    (void*)changeAnm__8daNpcT_cFPiPi,
-    (void*)changeBck__8daNpcT_cFPiPi,
-    (void*)changeBtp__8daNpcT_cFPiPi,
-    (void*)changeBtk__8daNpcT_cFPiPi,
-    (void*)setMotionAnm__8daNpcT_cFifi,
-};
+    JORFile aJStack_910;
+    switch (reinterpret_cast<u32>(event->id)) {
+    case 0x40000002:
+        if (aJStack_910.open(6, "", NULL, NULL, NULL) != 0) {
+            memset(auStack_7e0, 0, 2000);
+            int retval = 0;
+            daNpcT_cmnListenPropertyEvent(auStack_7e0, &retval, &param.common);
+            aJStack_910.writeData(auStack_7e0, retval);
+            aJStack_910.close();
+            OS_REPORT("write append success!::%6d\n", retval);
+        } else {
+            OS_REPORT("write append failure!\n");
+        }
+        break;
+    }
+}
+#endif
 
 /* 80B7512C-80B7524C 0000EC 0120+00 1/0 0/0 0/0 .text            __dt__13daNpc_Zelda_cFv */
 daNpc_Zelda_c::~daNpc_Zelda_c() {
-    // NONMATCHING
+    OS_REPORT("|%06d:%x|daNpc_Zelda_c -> デストラクト\n", g_Counter.mCounter0, this);
+
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mHIO != NULL) {
+        mHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[field_0xf80], (const char**)l_resNameList);
 }
 
 /* ############################################################################################## */
 /* 80B77FC8-80B78054 000000 008C+00 7/7 0/0 0/0 .rodata          m__19daNpc_Zelda_Param_c */
-SECTION_RODATA u8 const daNpc_Zelda_Param_c::m[140] = {
-    0x43, 0x3E, 0x00, 0x00, 0xC0, 0x40, 0x00, 0x00, 0x3F, 0x80, 0x00, 0x00, 0x43, 0xC8, 0x00, 0x00,
-    0x43, 0x7F, 0x00, 0x00, 0x43, 0x2A, 0x00, 0x00, 0x42, 0x0C, 0x00, 0x00, 0x41, 0xF0, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x41, 0x20, 0x00, 0x00, 0xC1, 0x20, 0x00, 0x00,
-    0x41, 0xF0, 0x00, 0x00, 0xC1, 0x20, 0x00, 0x00, 0x42, 0x34, 0x00, 0x00, 0xC2, 0x34, 0x00, 0x00,
-    0x3F, 0x19, 0x99, 0x9A, 0x41, 0x40, 0x00, 0x00, 0x00, 0x03, 0x00, 0x06, 0x00, 0x05, 0x00, 0x06,
-    0x42, 0xDC, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x3C, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x80, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80B77FC8, &daNpc_Zelda_Param_c::m);
-
-/* 80B78054-80B7805C 00008C 0008+00 0/1 0/0 0/0 .rodata          heapSize$3959 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const heapSize[8] = {
-    0x00, 0x00, 0x8F, 0xE0, 0x00, 0x00, 0x8F, 0xE0,
-};
-COMPILER_STRIP_GATE(0x80B78054, &heapSize);
-#pragma pop
-
-/* 80B7805C-80B78060 000094 0004+00 0/1 0/0 0/0 .rodata          @4032 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4032 = -200.0f;
-COMPILER_STRIP_GATE(0x80B7805C, &lit_4032);
-#pragma pop
-
-/* 80B78060-80B78064 000098 0004+00 0/1 0/0 0/0 .rodata          @4033 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4033 = -100.0f;
-COMPILER_STRIP_GATE(0x80B78060, &lit_4033);
-#pragma pop
-
-/* 80B78064-80B78068 00009C 0004+00 0/1 0/0 0/0 .rodata          @4034 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4034 = 200.0f;
-COMPILER_STRIP_GATE(0x80B78064, &lit_4034);
-#pragma pop
-
-/* 80B78068-80B7806C 0000A0 0004+00 0/1 0/0 0/0 .rodata          @4035 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4035 = 300.0f;
-COMPILER_STRIP_GATE(0x80B78068, &lit_4035);
-#pragma pop
-
-/* 80B7806C-80B78070 0000A4 0004+00 0/1 0/0 0/0 .rodata          @4036 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4036 = -1000000000.0f;
-COMPILER_STRIP_GATE(0x80B7806C, &lit_4036);
-#pragma pop
+const daNpc_Zelda_HIOParam daNpc_Zelda_Param_c::m = {{
+    190.0f, // attention_offset
+    -3.0f, // gravity
+    1.0f, // scale
+    400.0f, // real_shadow_size
+    255.0f, // weight
+    170.0f, // height
+    35.0f, // knee_length
+    30.0f, // width
+    0.0f, // body_angleX_max
+    0.0f, // body_angleX_min
+    10.0f, // body_angleY_max
+    -10.0f, // body_angleY_min
+    30.0f, // head_angleX_max
+    -10.0f, // head_angleX_min
+    45.0f, // head_angleY_max
+    -45.0f, // head_angleY_min
+    0.6f, // neck_rotation_ratio
+    12.0f, // morf_frame
+    3, // talk_distance
+    6, // talk_angle
+    5, // attention_distance
+    6, // attention_angle
+    110.0f, // fov
+    0.0f, // search_distance
+    0.0f, // search_height
+    0.0f, // search_depth
+    60, // attention_time
+    8, // damage_time
+    0, // face_expression
+    0, // motion
+    0, // look_mode
+    FALSE, // debug_mode_ON
+    FALSE, // debug_info_ON
+    4.0f, // expression_morf_frame
+    0.0f, // box_min_x
+    0.0f, // box_min_y
+    0.0f, // box_min_z
+    0.0f, // box_max_x
+    0.0f, // box_max_y
+    0.0f, // box_max_z
+    0.0f, // box_offset
+}};
 
 /* 80B7524C-80B75530 00020C 02E4+00 1/1 0/0 0/0 .text            create__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::create() {
-    // NONMATCHING
+int daNpc_Zelda_c::create() {
+    static u32 const heapSize[2] = {
+        0x8FE0,
+        0x8FE0,
+    };
+
+    fopAcM_SetupActor2(this, daNpc_Zelda_c, (daNpcT_faceMotionAnmData_c*)l_faceMotionAnmData,
+        (daNpcT_motionAnmData_c*)l_motionAnmData,
+        (daNpcT_MotionSeqMngr_c::sequenceStepData_c*)l_faceMotionSequenceData, 4,
+        (daNpcT_MotionSeqMngr_c::sequenceStepData_c*)l_motionSequenceData, 4,
+        l_evtList, l_resNameList);
+
+    field_0xf80 = getType();
+
+    mFlowNodeNo = getFlowNodeNo();
+
+    mTwilight = false;
+
+    s32 loadResult = loadRes(l_loadResPtrnList[field_0xf80], (const char**)l_resNameList);
+    if (loadResult == cPhs_COMPLEATE_e) {
+        OS_REPORT("\t(%s:%d) flowNo:%d, PathNo:%02x<%08x> ", fopAcM_getProcNameString(this),
+            field_0xf80, mFlowNodeNo, getPathID(), fopAcM_GetParam(this));
+        if (isDelete()) {
+            OS_REPORT("===>isDelete:TRUE\n");
+            return cPhs_ERROR_e;
+        }
+        OS_REPORT("\n");
+        if (fopAcM_entrySolidHeap(this, createHeapCallBack, heapSize[field_0xf80]) ==
+            0)
+        {
+            return cPhs_ERROR_e;
+        }
+
+        J3DModelData* unusedModelData = mpMorf[0]->getModel()->getModelData();
+        fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
+        fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
+        fopAcM_OnStatus(this, fopAcM_STATUS_UNK_8000000);
+        mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mHIO = &l_HIO;
+        // Zelda
+        mHIO->entryHIO("ゼルダ");
+#endif
+
+        reset();
+
+        mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
+            &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
+            fopAcM_GetShapeAngle_p(this));
+
+        mCcStts.Init(HIO_PARAM(this).common.weight, 0, this);
+
+        mCyl.Set(mCcDCyl);
+        mCyl.SetStts(&mCcStts);
+        mCyl.SetTgHitCallback(tgHitCallBack);
+
+        if (field_0xf80 == 0) {
+            mAcch.SetGrndNone();
+            mAcch.SetWallNone();
+        }
+        mAcch.CrrPos(dComIfG_Bgsp());
+        mGndChk = mAcch.m_gnd;
+        mGroundH = mAcch.GetGroundH();
+        if (mGroundH != -1e9f) {
+            setEnvTevColor();
+            setRoomNo();
+        }
+
+        mCreating = true;
+        Execute();
+        mCreating = false;
+    }
+
+    return loadResult;
 }
 
-/* ############################################################################################## */
-/* 80B78070-80B78074 0000A8 0004+00 5/10 0/0 0/0 .rodata          @4190 */
-SECTION_RODATA static u8 const lit_4190[4] = {
-    0x00,
-    0x00,
-    0x00,
-    0x00,
-};
-COMPILER_STRIP_GATE(0x80B78070, &lit_4190);
+f32 dummy0() {
+    return 0.0f;
+}
 
-/* 80B78074-80B78078 0000AC 0004+00 0/2 0/0 0/0 .rodata          @4191 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4191 = 65536.0f;
-COMPILER_STRIP_GATE(0x80B78074, &lit_4191);
-#pragma pop
+f32 dummy1() {
+    return 65536.0f;
+}
 
-/* 80B78078-80B7807C 0000B0 0004+00 1/4 0/0 0/0 .rodata          @4192 */
-SECTION_RODATA static f32 const lit_4192 = 1.0f / 5.0f;
-COMPILER_STRIP_GATE(0x80B78078, &lit_4192);
-
-/* 80B7807C-80B78080 0000B4 0004+00 2/4 0/0 0/0 .rodata          @4342 */
-SECTION_RODATA static f32 const lit_4342 = 1.0f;
-COMPILER_STRIP_GATE(0x80B7807C, &lit_4342);
+f32 dummy2() {
+    return 0.2f;
+}
 
 /* 80B75530-80B757BC 0004F0 028C+00 1/1 0/0 0/0 .text            CreateHeap__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::CreateHeap() {
-    // NONMATCHING
-}
+int daNpc_Zelda_c::CreateHeap() {
+    J3DModelData* modelData = NULL;
+    J3DModel* model = NULL;
 
-/* 80B757BC-80B757F8 00077C 003C+00 1/1 0/0 0/0 .text            __dt__15J3DTevKColorAnmFv */
-// J3DTevKColorAnm::~J3DTevKColorAnm() {
-extern "C" void __dt__15J3DTevKColorAnmFv() {
-    // NONMATCHING
-}
+    // probably a fakematch? not quite sure what's going on here with the 0-offset
+    s32 unkOffset = 0;
+    s32 arcNameIdx = (*(&l_bmdData + unkOffset))[1];
+    s32 index = (*(&l_bmdData + unkOffset))[0];
 
-/* 80B757F8-80B75810 0007B8 0018+00 1/1 0/0 0/0 .text            __ct__15J3DTevKColorAnmFv */
-// J3DTevKColorAnm::J3DTevKColorAnm() {
-extern "C" void __ct__15J3DTevKColorAnmFv() {
-    // NONMATCHING
-}
+    modelData =
+        static_cast<J3DModelData*>(dComIfG_getObjectRes(l_resNameList[arcNameIdx], index));
 
-/* 80B75810-80B7584C 0007D0 003C+00 1/1 0/0 0/0 .text            __dt__14J3DTevColorAnmFv */
-// J3DTevColorAnm::~J3DTevColorAnm() {
-extern "C" void __dt__14J3DTevColorAnmFv() {
-    // NONMATCHING
-}
+    if (modelData == NULL) {
+        return 0;
+    }
 
-/* 80B7584C-80B75864 00080C 0018+00 1/1 0/0 0/0 .text            __ct__14J3DTevColorAnmFv */
-// J3DTevColorAnm::J3DTevColorAnm() {
-extern "C" void __ct__14J3DTevColorAnmFv() {
-    // NONMATCHING
-}
+    s32 temp4 = 0x11020284;
+    mpMorf[0] = new mDoExt_McaMorfSO(modelData, NULL, NULL, NULL, -1, 1.0f, 0, -1, &mSound, 0, temp4);
+    if (mpMorf[0] == NULL || mpMorf[0]->getModel() == NULL) {
+        return 0;
+    }
 
-/* 80B75864-80B758AC 000824 0048+00 1/1 0/0 0/0 .text            __dt__11J3DTexNoAnmFv */
-// J3DTexNoAnm::~J3DTexNoAnm() {
-extern "C" void __dt__11J3DTexNoAnmFv() {
-    // NONMATCHING
-}
+    model = mpMorf[0]->getModel();
+    for (u16 i = 0; i < modelData->getJointNum(); i++) {
+        modelData->getJointNodePointer(i)->setCallBack(ctrlJointCallBack);
+    }
 
-/* 80B758AC-80B758D0 00086C 0024+00 1/1 0/0 0/0 .text            __ct__11J3DTexNoAnmFv */
-// J3DTexNoAnm::J3DTexNoAnm() {
-extern "C" void __ct__11J3DTexNoAnmFv() {
-    // NONMATCHING
-}
+    model->setUserArea((u32)this);
 
-/* 80B758D0-80B7590C 000890 003C+00 1/1 0/0 0/0 .text            __dt__12J3DTexMtxAnmFv */
-// J3DTexMtxAnm::~J3DTexMtxAnm() {
-extern "C" void __dt__12J3DTexMtxAnmFv() {
-    // NONMATCHING
-}
+    for (s32 i = 0; i < 2; i++) {
+        mpMatAnm[i] = new daNpcT_MatAnm_c();
+        if (mpMatAnm[i] == NULL) {
+            return 0;
+        }
+    }
 
-/* 80B7590C-80B75924 0008CC 0018+00 1/1 0/0 0/0 .text            __ct__12J3DTexMtxAnmFv */
-// J3DTexMtxAnm::J3DTexMtxAnm() {
-extern "C" void __ct__12J3DTexMtxAnmFv() {
-    // NONMATCHING
-}
-
-/* 80B75924-80B75960 0008E4 003C+00 1/1 0/0 0/0 .text            __dt__14J3DMatColorAnmFv */
-// J3DMatColorAnm::~J3DMatColorAnm() {
-extern "C" void __dt__14J3DMatColorAnmFv() {
-    // NONMATCHING
-}
-
-/* 80B75960-80B75978 000920 0018+00 1/1 0/0 0/0 .text            __ct__14J3DMatColorAnmFv */
-// J3DMatColorAnm::J3DMatColorAnm() {
-extern "C" void __ct__14J3DMatColorAnmFv() {
-    // NONMATCHING
+    if (setFaceMotionAnm(2, false) && setMotionAnm(0, 0.0f, FALSE)) {
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 /* 80B75978-80B759AC 000938 0034+00 1/1 0/0 0/0 .text            Delete__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::Delete() {
-    // NONMATCHING
+int daNpc_Zelda_c::Delete() {
+    OS_REPORT("|%06d:%x|daNpc_Zelda_c -> Delete\n", g_Counter.mCounter0, this);
+    fpc_ProcID unusedId = fopAcM_GetID(this);
+    this->~daNpc_Zelda_c();
+    return 1;
 }
 
 /* 80B759AC-80B759CC 00096C 0020+00 2/2 0/0 0/0 .text            Execute__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::Execute() {
-    // NONMATCHING
+int daNpc_Zelda_c::Execute() {
+    return execute();
 }
 
-/* ############################################################################################## */
-/* 80B78080-80B78084 0000B8 0004+00 1/1 0/0 0/0 .rodata          @4402 */
-SECTION_RODATA static f32 const lit_4402 = 100.0f;
-COMPILER_STRIP_GATE(0x80B78080, &lit_4402);
-
 /* 80B759CC-80B75A90 00098C 00C4+00 1/1 0/0 0/0 .text            Draw__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::Draw() {
-    // NONMATCHING
+int daNpc_Zelda_c::Draw() {
+    J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
+    if (mpMatAnm[0] != NULL) {
+        modelData->getMaterialNodePointer(getEyeballLMaterialNo())->setMaterialAnm(mpMatAnm[0]);
+    }
+    if (mpMatAnm[1] != NULL) {
+        modelData->getMaterialNodePointer(getEyeballRMaterialNo())->setMaterialAnm(mpMatAnm[1]);
+    }
+
+#if DEBUG
+    return draw(chkAction(NULL), TRUE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
+#else
+    return draw(NULL, TRUE, mRealShadowSize, NULL, 100.0f, FALSE, FALSE, FALSE);
+#endif
 }
 
 /* 80B75A90-80B75AB0 000A50 0020+00 1/1 0/0 0/0 .text
  * createHeapCallBack__13daNpc_Zelda_cFP10fopAc_ac_c            */
-void daNpc_Zelda_c::createHeapCallBack(fopAc_ac_c* param_0) {
-    // NONMATCHING
+int daNpc_Zelda_c::createHeapCallBack(fopAc_ac_c* i_this) {
+    daNpc_Zelda_c* zelda = ((daNpc_Zelda_c*)i_this);
+    return zelda->CreateHeap();
 }
 
 /* 80B75AB0-80B75B08 000A70 0058+00 1/1 0/0 0/0 .text
  * ctrlJointCallBack__13daNpc_Zelda_cFP8J3DJointi               */
-void daNpc_Zelda_c::ctrlJointCallBack(J3DJoint* param_0, int param_1) {
-    // NONMATCHING
+int daNpc_Zelda_c::ctrlJointCallBack(J3DJoint* i_joint, int param_1) {
+    if (param_1 == 0) {
+        J3DModel* model = j3dSys.getModel();
+        daNpc_Zelda_c* zelda = (daNpc_Zelda_c*)model->getUserArea();
+        if (zelda != NULL) {
+            zelda->ctrlJoint(i_joint, model);
+        }
+    }
+    return 1;
 }
 
 /* 80B75B08-80B75B28 000AC8 0020+00 1/1 0/0 0/0 .text            getType__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::getType() {
-    // NONMATCHING
+u8 daNpc_Zelda_c::getType() {
+    u8 param = fopAcM_GetParam(this);
+    switch (param & 0xff) {
+    case 0:
+        return 0;
+    default:
+        return 0;
+    }
 }
 
 /* 80B75B28-80B75B30 000AE8 0008+00 1/1 0/0 0/0 .text            isDelete__13daNpc_Zelda_cFv */
-bool daNpc_Zelda_c::isDelete() {
-    return false;
+int daNpc_Zelda_c::isDelete() {
+    return 0;
 }
 
 /* 80B75B30-80B75C9C 000AF0 016C+00 1/1 0/0 0/0 .text            reset__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::reset() {
-    // NONMATCHING
+    csXyz acStack_20;
+    u32 clearSize = (u32)&field_0xf9c - (u32)&mAction1;
+
+    for (s32 i = 0; i < 2; i++) {
+        if (mpMatAnm[i] != NULL) {
+            mpMatAnm[i]->initialize();
+        }
+    }
+
+    initialize();
+
+    memset(&mAction1, 0, clearSize);
+
+    acStack_20.setall(0);
+    acStack_20.y = home.angle.y;
+    switch (field_0xf80) {
+    case 0:
+    default:
+        setAngle(acStack_20);
+        break;
+    }
 }
 
 /* 80B75C9C-80B75D28 000C5C 008C+00 1/0 0/0 0/0 .text            afterJntAnm__13daNpc_Zelda_cFi */
 void daNpc_Zelda_c::afterJntAnm(int param_0) {
-    // NONMATCHING
+    if (param_0 == 1) {
+        mDoMtx_stack_c::YrotM(mStagger.getAngleZ(1));
+        mDoMtx_stack_c::ZrotM(-mStagger.getAngleX(1));
+    } else if (param_0 == 4) {
+        mDoMtx_stack_c::YrotM(mStagger.getAngleZ(0));
+        mDoMtx_stack_c::ZrotM(-mStagger.getAngleX(0));
+    }
 }
 
-/* ############################################################################################## */
-/* 80B78084-80B78088 0000BC 0004+00 3/3 0/0 0/0 .rodata          @4551 */
-SECTION_RODATA static f32 const lit_4551 = -1.0f;
-COMPILER_STRIP_GATE(0x80B78084, &lit_4551);
-
 /* 80B75D28-80B75E34 000CE8 010C+00 1/0 0/0 0/0 .text            ctrlBtk__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::ctrlBtk() {
-    // NONMATCHING
+int daNpc_Zelda_c::ctrlBtk() {
+    if ((mpMatAnm[0] != NULL) && (mpMatAnm[1] != NULL)) {
+        if (field_0xe29 != 0) {
+            J3DAnmTextureSRTKey* btkAnm = mBtkAnm.getBtkAnm();
+            if (btkAnm != 0) {
+                mpMatAnm[0]->setNowOffsetX(cM_ssin(mJntAnm.getEyeAngleY()) * 0.2f * -1.0f);
+                mpMatAnm[0]->setNowOffsetY(cM_ssin(mJntAnm.getEyeAngleX()) * 0.2f);
+                mpMatAnm[1]->setNowOffsetX(cM_ssin(mJntAnm.getEyeAngleY()) * 0.2f);
+                mpMatAnm[1]->setNowOffsetY(cM_ssin(mJntAnm.getEyeAngleX()) * 0.2f);
+                mpMatAnm[0]->onEyeMoveFlag();
+                mpMatAnm[1]->onEyeMoveFlag();
+                return 1;
+            }
+        }
+        if (field_0xe2a != 0) {
+            mpMatAnm[0]->setMorfFrm(field_0xe2a);
+            mpMatAnm[1]->setMorfFrm(field_0xe2a);
+            field_0xe2a = 0;
+        }
+        mpMatAnm[0]->offEyeMoveFlag();
+        mpMatAnm[1]->offEyeMoveFlag();
+    }
+    return 0;
 }
 
 /* 80B75E34-80B75EE8 000DF4 00B4+00 1/0 0/0 0/0 .text            checkChangeEvt__13daNpc_Zelda_cFv
  */
-void daNpc_Zelda_c::checkChangeEvt() {
-    // NONMATCHING
+int daNpc_Zelda_c::checkChangeEvt() {
+    if (!chkAction(&daNpc_Zelda_c::talk)) {
+        mPreItemNo = 0;
+        if (dComIfGp_event_chkTalkXY()) {
+            if (dComIfGp_evmng_ChkPresentEnd()) {
+                mEvtNo = 1;
+                evtChange();
+            }
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /* 80B75EE8-80B76014 000EA8 012C+00 1/0 0/0 0/0 .text            setParam__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::setParam() {
-    // NONMATCHING
+    selectAction();
+    srchActors();
+
+#if DEBUG
+    s32 attnFlag = 0x2 | 0x40;
+#define NPC_ZELDA_SETPARAM_DIST_IDX fopAc_attn_JUEL_e
+#else
+    s32 attnFlag = 0x2 | 0x8;
+#define NPC_ZELDA_SETPARAM_DIST_IDX fopAc_attn_SPEAK_e
+#endif
+
+    s16 talkDist = HIO_PARAM(this).common.talk_distance;
+    s16 talkAngle = HIO_PARAM(this).common.talk_angle;
+    s16 attnDist = HIO_PARAM(this).common.attention_distance;
+    s16 attnAngle = HIO_PARAM(this).common.attention_angle;
+    attention_info.distances[fopAc_attn_LOCK_e] =
+        daNpcT_getDistTableIdx(attnDist, attnAngle);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[NPC_ZELDA_SETPARAM_DIST_IDX] = daNpcT_getDistTableIdx(talkDist, talkAngle);
+    attention_info.flags = attnFlag;
+    scale.set(HIO_PARAM(this).common.scale, HIO_PARAM(this).common.scale, HIO_PARAM(this).common.scale);
+    mCcStts.SetWeight(HIO_PARAM(this).common.weight);
+    mCylH = HIO_PARAM(this).common.height;
+    mWallR = HIO_PARAM(this).common.width;
+    mAttnFovY = HIO_PARAM(this).common.fov;
+    mAcchCir.SetWallR(mWallR);
+    mAcchCir.SetWallH(HIO_PARAM(this).common.knee_length);
+    mRealShadowSize = HIO_PARAM(this).common.real_shadow_size;
+    mExpressionMorfFrame = HIO_PARAM(this).common.expression_morf_frame;
+    mMorfFrames = HIO_PARAM(this).common.morf_frame;
+    gravity = HIO_PARAM(this).common.gravity;
+    if (field_0xf80 == 0) {
+        mAcch.SetGrndNone();
+        mAcch.SetWallNone();
+        gravity = 0.0f;
+    }
+    return;
 }
 
 /* 80B76014-80B76074 000FD4 0060+00 1/0 0/0 0/0 .text setAfterTalkMotion__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::setAfterTalkMotion() {
-    // NONMATCHING
+    s32 index = 2;
+    mFaceMotionSeqMngr.getNo();
+    mFaceMotionSeqMngr.setNo(index, -1.0f, 0, 0);
 }
 
 /* 80B76074-80B76078 001034 0004+00 1/1 0/0 0/0 .text            srchActors__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::srchActors() {
-    /* empty function */
+#if DEBUG
+    switch (field_0xf80) {
+    case 0:
+    default:
+    }
+#endif
 }
 
 /* 80B76078-80B76118 001038 00A0+00 1/0 0/0 0/0 .text            evtTalk__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::evtTalk() {
-    // NONMATCHING
+int daNpc_Zelda_c::evtTalk() {
+    if (chkAction(&daNpc_Zelda_c::talk)) {
+        (this->*mAction2)(NULL);
+    } else {
+        setAction(&daNpc_Zelda_c::talk);
+    }
+
+    return 1;
 }
 
 /* 80B76118-80B761E0 0010D8 00C8+00 1/0 0/0 0/0 .text            evtCutProc__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::evtCutProc() {
-    // NONMATCHING
+int daNpc_Zelda_c::evtCutProc() {
+    s32 staff_id = dComIfGp_getEventManager().getMyStaffId("Zelda", this, -1);
+    if (staff_id != -1) {
+        mStaffId = staff_id;
+        s32 actIdx = dComIfGp_getEventManager().getMyActIdx(mStaffId, &daNpc_Zelda_c::mCutNameList, 1, 0, 0);
+        if ((this->*mCutList[actIdx])(mStaffId)) {
+            dComIfGp_getEventManager().cutEnd(mStaffId);
+        }
+
+        return 1;
+    }
+
+    return 0;
 }
 
 /* 80B761E0-80B762CC 0011A0 00EC+00 1/0 0/0 0/0 .text            action__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::action() {
-    // NONMATCHING
+    if (mStagger.checkRebirth() != 0) {
+        mStagger.initialize();
+        mMode = 1;
+    }
+    if (mAction1 != NULL) {
+        if (mAction2 == mAction1) {
+            (this->*mAction2)(0);
+        }
+        else {
+            setAction(mAction1);
+        }
+    }
 }
 
 /* 80B762CC-80B76344 00128C 0078+00 1/0 0/0 0/0 .text            beforeMove__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::beforeMove() {
-    // NONMATCHING
+    if (checkHide() != 0 || mNoDraw != 0) {
+        attention_info.flags = 0;
+    }
 }
-
-/* ############################################################################################## */
-/* 80B78088-80B7808C 0000C0 0004+00 0/1 0/0 0/0 .rodata          @4744 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4744 = 10.0f;
-COMPILER_STRIP_GATE(0x80B78088, &lit_4744);
-#pragma pop
-
-/* 80B7808C-80B78090 0000C4 0004+00 0/1 0/0 0/0 .rodata          @4745 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4745 = -30.0f;
-COMPILER_STRIP_GATE(0x80B7808C, &lit_4745);
-#pragma pop
-
-/* 80B78090-80B78094 0000C8 0004+00 0/1 0/0 0/0 .rodata          @4746 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u32 const lit_4746 = 0x38C90FDB;
-COMPILER_STRIP_GATE(0x80B78090, &lit_4746);
-#pragma pop
-
-/* 80B78094-80B78098 0000CC 0004+00 0/1 0/0 0/0 .rodata          @4747 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4747 = 170.0f;
-COMPILER_STRIP_GATE(0x80B78094, &lit_4747);
-#pragma pop
-
-/* 80B78098-80B780A0 0000D0 0008+00 1/3 0/0 0/0 .rodata          @4749 */
-SECTION_RODATA static u8 const lit_4749[8] = {
-    0x43, 0x30, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80B78098, &lit_4749);
 
 /* 80B76344-80B765D4 001304 0290+00 1/0 0/0 0/0 .text            setAttnPos__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::setAttnPos() {
-    // NONMATCHING
+    s32 iVar2;
+    s32 iVar3;
+    s32 iVar4;
+    J3DModel* pJVar5;
+    Mtx* src;
+    f32 dVar6;
+
+    cXyz acStack_3c(10.0f, -30.0f, 0.0f);
+    mStagger.calc(0);
+    dVar6 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
+    pJVar5 = mpMorf[0]->getModel();
+    mJntAnm.setParam((fopAc_ac_c*)this, pJVar5, &acStack_3c,
+        getBackboneJointNo(),
+        getNeckJointNo(),
+        getHeadJointNo(),
+        HIO_PARAM(this).common.body_angleX_min,
+        HIO_PARAM(this).common.body_angleX_max,
+        HIO_PARAM(this).common.body_angleY_min,
+        HIO_PARAM(this).common.body_angleY_max,
+        HIO_PARAM(this).common.head_angleX_min,
+        HIO_PARAM(this).common.head_angleX_max,
+        HIO_PARAM(this).common.head_angleY_min,
+        HIO_PARAM(this).common.head_angleY_max,
+        HIO_PARAM(this).common.neck_rotation_ratio,
+        0.0f,
+        NULL);
+    mJntAnm.calcJntRad(0.2f, 1.0f, dVar6);
+    setMtx();
+    s32 headJointNo = getHeadJointNo();
+    pJVar5 = mpMorf[0]->getModel();
+    mDoMtx_stack_c::copy(pJVar5->getAnmMtx(headJointNo));
+    mDoMtx_stack_c::multVec(&acStack_3c, &eyePos);
+    mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
+    mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 0, 1.0f, 0);
+    acStack_3c.set(0.0f, 0.0f, 0.0f);
+    acStack_3c.y = HIO_PARAM(this).common.attention_offset;
+    if (field_0xf80 == 0) {
+        acStack_3c.set(0.0f, 170.0f, 10.0f);
+    }
+    mDoMtx_stack_c::YrotS(mCurAngle.y);
+    mDoMtx_stack_c::multVec(&acStack_3c, &acStack_3c);
+    attention_info.position = acStack_3c + current.pos;
 }
-
-/* ############################################################################################## */
-/* 80B780A0-80B780A8 0000D8 0008+00 0/1 0/0 0/0 .rodata          @4807 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4807[8] = {
-    0x3F, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80B780A0, &lit_4807);
-#pragma pop
-
-/* 80B780A8-80B780B0 0000E0 0008+00 0/1 0/0 0/0 .rodata          @4808 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4808[8] = {
-    0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80B780A8, &lit_4808);
-#pragma pop
-
-/* 80B780B0-80B780B8 0000E8 0008+00 0/1 0/0 0/0 .rodata          @4809 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static u8 const lit_4809[8] = {
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
-COMPILER_STRIP_GATE(0x80B780B0, &lit_4809);
-#pragma pop
-
-/* 80B780B8-80B780BC 0000F0 0004+00 0/1 0/0 0/0 .rodata          @4853 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4853 = 20.0f;
-COMPILER_STRIP_GATE(0x80B780B8, &lit_4853);
-#pragma pop
-
-/* 80B780BC-80B780C0 0000F4 0004+00 0/1 0/0 0/0 .rodata          @4854 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4854 = 160.0f;
-COMPILER_STRIP_GATE(0x80B780BC, &lit_4854);
-#pragma pop
-
-/* 80B780C0-80B780C4 0000F8 0004+00 0/1 0/0 0/0 .rodata          @4855 */
-#pragma push
-#pragma force_active on
-SECTION_RODATA static f32 const lit_4855 = 44.0f;
-COMPILER_STRIP_GATE(0x80B780C0, &lit_4855);
-#pragma pop
 
 /* 80B765D4-80B76774 001594 01A0+00 1/0 0/0 0/0 .text            setCollision__13daNpc_Zelda_cFv */
 void daNpc_Zelda_c::setCollision() {
-    // NONMATCHING
+    cXyz newCenter;
+    if (!mHide) {
+        u32 unused = 0x79;
+
+        u32 type = 0xd8fbfdff;
+        u32 uVar4 = 0x1f;
+
+        if (dComIfGp_event_runCheck()) {
+            type = 0;
+            uVar4 = 0;
+        } else {
+            if (mTwilight) {
+                type = 0;
+                uVar4 = 0;
+            } else {
+                if (mStagger.checkStagger()) {
+                    type = 0;
+                    uVar4 = 0;
+                }
+            }
+        }
+        mCyl.SetCoSPrm(0x79);
+        mCyl.SetTgType(type);
+        mCyl.SetTgSPrm(uVar4);
+        mCyl.OnTgNoHitMark();
+
+        newCenter.set(0.0f,0.0f,0.0f);
+        f32 cylH = mCylH;
+        f32 wallR = mWallR;
+        if (field_0xf80 == 0) {
+            newCenter.set(0.0f,0.0f,20.0f);
+            cylH = 160.0f;
+            wallR = 44.0f;
+        }
+        mDoMtx_stack_c::YrotS(mCurAngle.y);
+        mDoMtx_stack_c::multVec(&newCenter,&newCenter);
+        newCenter += current.pos;
+
+        mCyl.SetH(cylH);
+        mCyl.SetR(wallR);
+        mCyl.SetC(newCenter);
+        dComIfG_Ccsp()->Set(&mCyl);
+    }
+
+    mCyl.ClrCoHit();
+    mCyl.ClrTgHit();
 }
 
 /* 80B76774-80B7677C 001734 0008+00 1/0 0/0 0/0 .text            drawDbgInfo__13daNpc_Zelda_cFv */
-bool daNpc_Zelda_c::drawDbgInfo() {
-    return false;
+int daNpc_Zelda_c::drawDbgInfo() {
+#if DEBUG
+    const daNpc_Zelda_HIOParam* m = &daNpc_Zelda_Param_c::m;
+    if (HIO_PARAM(this).common.debug_info_ON != 0) {
+        f32 distMax1 = dComIfGp_getAttention()->getDistTable(
+            attention_info.distances[fopAc_attn_JUEL_e]).mDistMax;
+        f32 distMax2 = dComIfGp_getAttention()->getDistTable(
+            attention_info.distances[fopAc_attn_TALK_e]).mDistMax;
+        GXColor circle1Color = { 0xc8, 0x00, 0xff };
+        dDbVw_drawCircleOpa(attention_info.position, distMax1, circle1Color, 1, 0xc);
+        GXColor circle2Color = { 0xc8, 0x00, 0x00, 0xff };
+        dDbVw_drawCircleOpa(attention_info.position, distMax2, circle2Color, 1, 0xc);
+        GXColor sphere1Color = { 0x80, 0x80, 0x80, 0xa0 };
+        dDbVw_drawSphereXlu(eyePos, 18.0f, sphere1Color, 1);
+        GXColor sphere2Color = { 0x80, 0x80, 0x80, 0xa0 };
+        dDbVw_drawSphereXlu(attention_info.position, 9.0f, sphere2Color, 1);
+    }
+#endif
+    return 0;
 }
 
 /* 80B7677C-80B767C4 00173C 0048+00 1/1 0/0 0/0 .text            selectAction__13daNpc_Zelda_cFv */
-void daNpc_Zelda_c::selectAction() {
-    // NONMATCHING
+int daNpc_Zelda_c::selectAction() {
+    mAction1 = NULL;
+    mAction1 = &daNpc_Zelda_c::wait;
+    return 1;
 }
 
 /* 80B767C4-80B767F0 001784 002C+00 2/2 0/0 0/0 .text
  * chkAction__13daNpc_Zelda_cFM13daNpc_Zelda_cFPCvPvPv_i        */
-void daNpc_Zelda_c::chkAction(int (daNpc_Zelda_c::*param_0)(void*)) {
-    // NONMATCHING
+BOOL daNpc_Zelda_c::chkAction(actionFunc action) {
+    return mAction2 == action;
 }
 
 /* 80B767F0-80B76898 0017B0 00A8+00 2/2 0/0 0/0 .text
  * setAction__13daNpc_Zelda_cFM13daNpc_Zelda_cFPCvPvPv_i        */
-void daNpc_Zelda_c::setAction(int (daNpc_Zelda_c::*param_0)(void*)) {
-    // NONMATCHING
+BOOL daNpc_Zelda_c::setAction(int (daNpc_Zelda_c::*action)(void*)) {
+    mMode = 3;
+    if (mAction2) {
+        (this->*mAction2)(NULL);
+    }
+
+    mMode = 0;
+    mAction2 = action;
+    if (mAction2) {
+        (this->*mAction2)(NULL);
+    }
+
+    return TRUE;
 }
 
 /* 80B76898-80B76B74 001858 02DC+00 1/0 0/0 0/0 .text            wait__13daNpc_Zelda_cFPv */
-void daNpc_Zelda_c::wait(void* param_0) {
-    // NONMATCHING
+int daNpc_Zelda_c::wait(void* param_0) {
+    switch (mMode) {
+    case 0:
+    case 1:
+        if (!mStagger.checkStagger()) {
+            if (field_0xf80 == 0) {
+                mFaceMotionSeqMngr.setNo(1, -1.0f, 0, 0);
+                mMotionSeqMngr.setNo(1, -1.0f, 0, 0);
+            } else {
+                mFaceMotionSeqMngr.setNo(2, -1.0f, 0, 0);
+                mMotionSeqMngr.setNo(0, -1.0f, 0, 0);
+            }
+            mMode = 2;
+        }
+    case 2:
+        if (!mStagger.checkStagger()) {
+            if (field_0xf80 == 0) {
+                mPlayerActorMngr.remove();
+            }
+
+            if (mPlayerActorMngr.getActorP() != NULL && !mTwilight) {
+                mJntAnm.lookPlayer(0);
+
+                if (!chkActorInSight(mPlayerActorMngr.getActorP(), mAttnFovY, mCurAngle.y)) {
+                    mJntAnm.lookNone(0);
+                }
+
+                if (!srchPlayerActor() && home.angle.y == mCurAngle.y) {
+                    mMode = 1;
+                }
+            } else {
+                mJntAnm.lookNone(0);
+
+                if (home.angle.y != mCurAngle.y) {
+                    if (field_0xe34) {
+                        if (step(home.angle.y, -1, -1, 0xf, 0)) {
+                            mMode = 1;
+                        }
+                    } else {
+                        setAngle(home.angle.y);
+
+                        mMode = 1;
+                    }
+
+                    attention_info.flags = 0;
+                } else {
+                    srchPlayerActor();
+                }
+            }
+
+            switch (mJntAnm.getMode()) {
+            case 0:
+            default:
+                break;
+            }
+        }
+    case 3:
+    default:
+        break;
+    }
+    return 1;
 }
 
 /* 80B76B74-80B76D60 001B34 01EC+00 3/0 0/0 0/0 .text            talk__13daNpc_Zelda_cFPv */
-void daNpc_Zelda_c::talk(void* param_0) {
-    // NONMATCHING
+int daNpc_Zelda_c::talk(void* param_0) {
+    switch (mMode) {
+    case 0:
+    case 1:
+        if (!mStagger.checkStagger()) {
+            initTalk(mFlowNodeNo, NULL);
+            mMode = 2;
+        }
+    case 2:
+        if (!mStagger.checkStagger()) {
+            if (mTwilight || mPlayerAngle == mCurAngle.y || field_0xf80 == 0) {
+                if (talkProc(NULL, 0, NULL, 0)) {
+                    int retVal;
+                    u32 unused = mFlow.getEventId(&retVal);
+                    if (mFlow.checkEndFlow()) {
+                        mPlayerActorMngr.entry(daPy_getPlayerActorClass());
+
+                        dComIfGp_event_reset();
+
+                        mMode = 3;
+                    }
+                }
+
+                mJntAnm.lookPlayer(0);
+                if (mTwilight || field_0xf80 == 0) {
+                    mJntAnm.lookNone(0);
+                }
+            } else {
+                mJntAnm.lookPlayer(0);
+                step(mPlayerAngle, -1, -1, 15, 0);
+            }
+        }
+    case 3:
+    default:
+        break;
+    }
+
+    return 0;
 }
 
 /* 80B76D60-80B76D80 001D20 0020+00 1/0 0/0 0/0 .text            daNpc_Zelda_Create__FPv */
-static void daNpc_Zelda_Create(void* param_0) {
-    // NONMATCHING
+static int daNpc_Zelda_Create(void* param_0) {
+    return ((daNpc_Zelda_c*)param_0)->create();
 }
 
 /* 80B76D80-80B76DA0 001D40 0020+00 1/0 0/0 0/0 .text            daNpc_Zelda_Delete__FPv */
-static void daNpc_Zelda_Delete(void* param_0) {
-    // NONMATCHING
+static int daNpc_Zelda_Delete(void* param_0) {
+    return ((daNpc_Zelda_c*)param_0)->Delete();
 }
 
 /* 80B76DA0-80B76DC0 001D60 0020+00 1/0 0/0 0/0 .text            daNpc_Zelda_Execute__FPv */
-static void daNpc_Zelda_Execute(void* param_0) {
-    // NONMATCHING
+static int daNpc_Zelda_Execute(void* param_0) {
+    return ((daNpc_Zelda_c*)param_0)->Execute();
 }
 
 /* 80B76DC0-80B76DE0 001D80 0020+00 1/0 0/0 0/0 .text            daNpc_Zelda_Draw__FPv */
-static void daNpc_Zelda_Draw(void* param_0) {
-    // NONMATCHING
+static int daNpc_Zelda_Draw(void* param_0) {
+    return ((daNpc_Zelda_c*)param_0)->Draw();
 }
 
 /* 80B76DE0-80B76DE8 001DA0 0008+00 1/0 0/0 0/0 .text            daNpc_Zelda_IsDelete__FPv */
-static bool daNpc_Zelda_IsDelete(void* param_0) {
-    return true;
+static int daNpc_Zelda_IsDelete(void* param_0) {
+    return 1;
 }
-
-/* 80B76DE8-80B76E18 001DA8 0030+00 1/0 0/0 0/0 .text            calc__11J3DTexNoAnmCFPUs */
-// void J3DTexNoAnm::calc(u16* param_0) const {
-extern "C" void calc__11J3DTexNoAnmCFPUs() {
-    // NONMATCHING
-}
-
-/* 80B76E18-80B76E60 001DD8 0048+00 1/0 0/0 0/0 .text            __dt__10cCcD_GSttsFv */
-// cCcD_GStts::~cCcD_GStts() {
-extern "C" void __dt__10cCcD_GSttsFv() {
-    // NONMATCHING
-}
-
-/* 80B76E60-80B771E8 001E20 0388+00 1/1 0/0 0/0 .text            __dt__8daNpcT_cFv */
-// daNpcT_c::~daNpcT_c() {
-extern "C" void __dt__8daNpcT_cFv() {
-    // NONMATCHING
-}
-
-/* 80B771E8-80B77224 0021A8 003C+00 3/3 0/0 0/0 .text            __dt__4cXyzFv */
-// cXyz::~cXyz() {
-extern "C" void __dt__4cXyzFv() {
-    // NONMATCHING
-}
-
-/* 80B77224-80B77260 0021E4 003C+00 2/2 0/0 0/0 .text            __dt__5csXyzFv */
-// csXyz::~csXyz() {
-extern "C" void __dt__5csXyzFv() {
-    // NONMATCHING
-}
-
-/* 80B77260-80B77664 002220 0404+00 1/1 0/0 0/0 .text
- * __ct__8daNpcT_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc
- */
-// daNpcT_c::daNpcT_c(daNpcT_faceMotionAnmData_c const* param_0,
-//                       daNpcT_motionAnmData_c const* param_1,
-// daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_2, int param_3,
-//                          daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_4, int param_5,
-//                       daNpcT_evtData_c const* param_6, char** param_7) {
-extern "C" void __ct__8daNpcT_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc() {
-    // NONMATCHING
-}
-
-/* 80B77664-80B77668 002624 0004+00 1/1 0/0 0/0 .text            __ct__5csXyzFv */
-// csXyz::csXyz() {
-extern "C" void __ct__5csXyzFv() {
-    /* empty function */
-}
-
-/* 80B77668-80B77764 002628 00FC+00 1/0 0/0 0/0 .text            __dt__15daNpcT_JntAnm_cFv */
-// daNpcT_JntAnm_c::~daNpcT_JntAnm_c() {
-extern "C" void __dt__15daNpcT_JntAnm_cFv() {
-    // NONMATCHING
-}
-
-/* 80B77764-80B77768 002724 0004+00 1/1 0/0 0/0 .text            __ct__4cXyzFv */
-// cXyz::cXyz() {
-extern "C" void __ct__4cXyzFv() {
-    /* empty function */
-}
-
-/* 80B77768-80B777B0 002728 0048+00 1/0 0/0 0/0 .text            __dt__18daNpcT_ActorMngr_cFv */
-// daNpcT_ActorMngr_c::~daNpcT_ActorMngr_c() {
-extern "C" void __dt__18daNpcT_ActorMngr_cFv() {
-    // NONMATCHING
-}
-
-/* 80B777B0-80B777F8 002770 0048+00 1/0 0/0 0/0 .text            __dt__22daNpcT_MotionSeqMngr_cFv */
-// daNpcT_MotionSeqMngr_c::~daNpcT_MotionSeqMngr_c() {
-extern "C" void __dt__22daNpcT_MotionSeqMngr_cFv() {
-    // NONMATCHING
-}
-
-/* 80B777F8-80B77868 0027B8 0070+00 1/0 0/0 0/0 .text            __dt__12dBgS_AcchCirFv */
-// dBgS_AcchCir::~dBgS_AcchCir() {
-extern "C" void __dt__12dBgS_AcchCirFv() {
-    // NONMATCHING
-}
-
-/* 80B77868-80B778C4 002828 005C+00 1/0 0/0 0/0 .text            __dt__10dCcD_GSttsFv */
-// dCcD_GStts::~dCcD_GStts() {
-extern "C" void __dt__10dCcD_GSttsFv() {
-    // NONMATCHING
-}
-
-/* 80B778C4-80B77934 002884 0070+00 3/2 0/0 0/0 .text            __dt__12dBgS_ObjAcchFv */
-// dBgS_ObjAcch::~dBgS_ObjAcch() {
-extern "C" void __dt__12dBgS_ObjAcchFv() {
-    // NONMATCHING
-}
-
-/* 80B77934-80B7797C 0028F4 0048+00 1/0 0/0 0/0 .text            __dt__12J3DFrameCtrlFv */
-// J3DFrameCtrl::~J3DFrameCtrl() {
-extern "C" void __dt__12J3DFrameCtrlFv() {
-    // NONMATCHING
-}
-
-/* 80B7797C-80B77A98 00293C 011C+00 1/1 0/0 0/0 .text setEyeAngleY__15daNpcT_JntAnm_cF4cXyzsifs */
-// void daNpcT_JntAnm_c::setEyeAngleY(cXyz param_0, s16 param_1, int param_2, f32 param_3,
-//                                       s16 param_4) {
-extern "C" void setEyeAngleY__15daNpcT_JntAnm_cF4cXyzsifs() {
-    // NONMATCHING
-}
-
-/* 80B77A98-80B77CA0 002A58 0208+00 1/1 0/0 0/0 .text setEyeAngleX__15daNpcT_JntAnm_cF4cXyzfs */
-// void daNpcT_JntAnm_c::setEyeAngleX(cXyz param_0, f32 param_1, s16 param_2) {
-extern "C" void setEyeAngleX__15daNpcT_JntAnm_cF4cXyzfs() {
-    // NONMATCHING
-}
-
-/* 80B77CA0-80B77CA4 002C60 0004+00 1/0 0/0 0/0 .text            ctrlSubFaceMotion__8daNpcT_cFi */
-// void daNpcT_c::ctrlSubFaceMotion(int param_0) {
-extern "C" void ctrlSubFaceMotion__8daNpcT_cFi() {
-    /* empty function */
-}
-
-/* 80B77CBC-80B77CC4 002C7C 0008+00 1/0 0/0 0/0 .text            evtEndProc__8daNpcT_cFv */
-// bool daNpcT_c::evtEndProc() {
-extern "C" bool evtEndProc__8daNpcT_cFv() {
-    return true;
-}
-
-/* 80B77CC8-80B77CD0 002C88 0008+00 1/0 0/0 0/0 .text            chkXYItems__8daNpcT_cFv */
-// bool daNpcT_c::chkXYItems() {
-extern "C" bool chkXYItems__8daNpcT_cFv() {
-    return false;
-}
-
-/* 80B77CD0-80B77CE8 002C90 0018+00 1/0 0/0 0/0 .text            decTmr__8daNpcT_cFv */
-// void daNpcT_c::decTmr() {
-extern "C" void decTmr__8daNpcT_cFv() {
-    // NONMATCHING
-}
-
-/* 80B77CE8-80B77CEC 002CA8 0004+00 1/0 0/0 0/0 .text            drawOtherMdl__8daNpcT_cFv */
-// void daNpcT_c::drawOtherMdl() {
-extern "C" void drawOtherMdl__8daNpcT_cFv() {
-    /* empty function */
-}
-
-/* 80B77CEC-80B77CF0 002CAC 0004+00 1/0 0/0 0/0 .text            drawGhost__8daNpcT_cFv */
-// void daNpcT_c::drawGhost() {
-extern "C" void drawGhost__8daNpcT_cFv() {
-    /* empty function */
-}
-
-/* 80B77CF0-80B77CF8 002CB0 0008+00 1/0 0/0 0/0 .text afterSetFaceMotionAnm__8daNpcT_cFiifi */
-// bool daNpcT_c::afterSetFaceMotionAnm(int param_0, int param_1, f32 param_2, int param_3) {
-extern "C" bool afterSetFaceMotionAnm__8daNpcT_cFiifi() {
-    return true;
-}
-
-/* 80B77CF8-80B77D00 002CB8 0008+00 1/0 0/0 0/0 .text            afterSetMotionAnm__8daNpcT_cFiifi
- */
-// bool daNpcT_c::afterSetMotionAnm(int param_0, int param_1, f32 param_2, int param_3) {
-extern "C" bool afterSetMotionAnm__8daNpcT_cFiifi() {
-    return true;
-}
-
-/* 80B77D00-80B77D30 002CC0 0030+00 1/0 0/0 0/0 .text
- * getFaceMotionAnm__8daNpcT_cF26daNpcT_faceMotionAnmData_c     */
-// void daNpcT_c::getFaceMotionAnm(daNpcT_faceMotionAnmData_c param_0) {
-extern "C" void getFaceMotionAnm__8daNpcT_cF26daNpcT_faceMotionAnmData_c() {
-    // NONMATCHING
-}
-
-/* 80B77D30-80B77D60 002CF0 0030+00 1/0 0/0 0/0 .text
- * getMotionAnm__8daNpcT_cF22daNpcT_motionAnmData_c             */
-// void daNpcT_c::getMotionAnm(daNpcT_motionAnmData_c param_0) {
-extern "C" void getMotionAnm__8daNpcT_cF22daNpcT_motionAnmData_c() {
-    // NONMATCHING
-}
-
-/* 80B77D60-80B77D64 002D20 0004+00 1/0 0/0 0/0 .text            changeAnm__8daNpcT_cFPiPi */
-// void daNpcT_c::changeAnm(int* param_0, int* param_1) {
-extern "C" void changeAnm__8daNpcT_cFPiPi() {
-    /* empty function */
-}
-
-/* 80B77D64-80B77D68 002D24 0004+00 1/0 0/0 0/0 .text            changeBck__8daNpcT_cFPiPi */
-// void daNpcT_c::changeBck(int* param_0, int* param_1) {
-extern "C" void changeBck__8daNpcT_cFPiPi() {
-    /* empty function */
-}
-
-/* 80B77D68-80B77D6C 002D28 0004+00 1/0 0/0 0/0 .text            changeBtp__8daNpcT_cFPiPi */
-// void daNpcT_c::changeBtp(int* param_0, int* param_1) {
-extern "C" void changeBtp__8daNpcT_cFPiPi() {
-    /* empty function */
-}
-
-/* 80B77D6C-80B77D70 002D2C 0004+00 1/0 0/0 0/0 .text            changeBtk__8daNpcT_cFPiPi */
-// void daNpcT_c::changeBtk(int* param_0, int* param_1) {
-extern "C" void changeBtk__8daNpcT_cFPiPi() {
-    /* empty function */
-}
-
-/* ############################################################################################## */
-/* 80B783F0-80B783FC 000318 000C+00 2/2 0/0 0/0 .data            __vt__19daNpc_Zelda_Param_c */
-SECTION_DATA extern void* __vt__19daNpc_Zelda_Param_c[3] = {
-    (void*)NULL /* RTTI */,
-    (void*)NULL,
-    (void*)__dt__19daNpc_Zelda_Param_cFv,
-};
-
-/* 80B78408-80B78414 000008 000C+00 1/1 0/0 0/0 .bss             @3811 */
-static u8 lit_3811[12];
-
-/* 80B78414-80B78418 000014 0004+00 1/1 0/0 0/0 .bss             l_HIO */
-static u8 l_HIO[4];
-
-/* 80B77D70-80B77DD8 002D30 0068+00 0/0 1/0 0/0 .text            __sinit_d_a_npc_zelda_cpp */
-void __sinit_d_a_npc_zelda_cpp() {
-    // NONMATCHING
-}
-
-#pragma push
-#pragma force_active on
-REGISTER_CTORS(0x80B77D70, __sinit_d_a_npc_zelda_cpp);
-#pragma pop
 
 /* 80B77DD8-80B77E84 002D98 00AC+00 1/1 0/0 0/0 .text
  * __ct__13daNpc_Zelda_cFPC26daNpcT_faceMotionAnmData_cPC22daNpcT_motionAnmData_cPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPCQ222daNpcT_MotionSeqMngr_c18sequenceStepData_ciPC16daNpcT_evtData_cPPc
@@ -1183,29 +839,18 @@ daNpc_Zelda_c::daNpc_Zelda_c(daNpcT_faceMotionAnmData_c const* param_0,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_2,
                                  int param_3,
                                  daNpcT_MotionSeqMngr_c::sequenceStepData_c const* param_4,
-                                 int param_5, daNpcT_evtData_c const* param_6, char** param_7) {
-    // NONMATCHING
-}
-
-/* 80B77E84-80B77ECC 002E44 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGCylFv */
-// cM3dGCyl::~cM3dGCyl() {
-extern "C" void __dt__8cM3dGCylFv() {
-    // NONMATCHING
-}
-
-/* 80B77ECC-80B77F14 002E8C 0048+00 1/0 0/0 0/0 .text            __dt__8cM3dGAabFv */
-// cM3dGAab::~cM3dGAab() {
-extern "C" void __dt__8cM3dGAabFv() {
-    // NONMATCHING
+                                 int param_5, daNpcT_evtData_c const* param_6, char** param_7) :
+    daNpcT_c(param_0, param_1, param_2, param_3, param_4, param_5, param_6, param_7) {
+    OS_REPORT("|%06d:%x|daNpc_Zelda_c -> コンストラクト\n", g_Counter.mCounter0, this);
 }
 
 /* 80B77F14-80B77F1C 002ED4 0008+00 1/0 0/0 0/0 .text getEyeballRMaterialNo__13daNpc_Zelda_cFv */
-s32 daNpc_Zelda_c::getEyeballRMaterialNo() {
+u16 daNpc_Zelda_c::getEyeballRMaterialNo() {
     return 5;
 }
 
 /* 80B77F1C-80B77F24 002EDC 0008+00 1/0 0/0 0/0 .text getEyeballLMaterialNo__13daNpc_Zelda_cFv */
-s32 daNpc_Zelda_c::getEyeballLMaterialNo() {
+u16 daNpc_Zelda_c::getEyeballLMaterialNo() {
     return 4;
 }
 
@@ -1222,35 +867,49 @@ s32 daNpc_Zelda_c::getNeckJointNo() {
 }
 
 /* 80B77F34-80B77F3C 002EF4 0008+00 1/0 0/0 0/0 .text getBackboneJointNo__13daNpc_Zelda_cFv */
-bool daNpc_Zelda_c::getBackboneJointNo() {
-    return true;
+s32 daNpc_Zelda_c::getBackboneJointNo() {
+    return 1;
 }
 
 /* 80B77F3C-80B77F4C 002EFC 0010+00 1/0 0/0 0/0 .text            checkChangeJoint__13daNpc_Zelda_cFi
  */
-void daNpc_Zelda_c::checkChangeJoint(int param_0) {
-    // NONMATCHING
+int daNpc_Zelda_c::checkChangeJoint(int param_0) {
+    return param_0 == 4;
 }
 
 /* 80B77F4C-80B77F5C 002F0C 0010+00 1/0 0/0 0/0 .text            checkRemoveJoint__13daNpc_Zelda_cFi
  */
-void daNpc_Zelda_c::checkRemoveJoint(int param_0) {
-    // NONMATCHING
+int daNpc_Zelda_c::checkRemoveJoint(int param_0) {
+    return param_0 == 17;
 }
 
 /* 80B77F5C-80B77FA4 002F1C 0048+00 2/1 0/0 0/0 .text            __dt__19daNpc_Zelda_Param_cFv */
 daNpc_Zelda_Param_c::~daNpc_Zelda_Param_c() {
-    // NONMATCHING
 }
 
-/* 80B77FA4-80B77FAC 002F64 0008+00 1/0 0/0 0/0 .text            @36@__dt__12dBgS_ObjAcchFv */
-static void func_80B77FA4() {
-    // NONMATCHING
-}
+/* 80B78240-80B78260 -00001 0020+00 1/0 0/0 0/0 .data            daNpc_Zelda_MethodTable */
+static actor_method_class daNpc_Zelda_MethodTable = {
+    (process_method_func)daNpc_Zelda_Create,
+    (process_method_func)daNpc_Zelda_Delete,
+    (process_method_func)daNpc_Zelda_Execute,
+    (process_method_func)daNpc_Zelda_IsDelete,
+    (process_method_func)daNpc_Zelda_Draw,
+};
 
-/* 80B77FAC-80B77FB4 002F6C 0008+00 1/0 0/0 0/0 .text            @20@__dt__12dBgS_ObjAcchFv */
-static void func_80B77FAC() {
-    // NONMATCHING
-}
-
-/* 80B780C4-80B780C4 0000FC 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
+/* 80B78260-80B78290 -00001 0030+00 0/0 0/0 1/0 .data            g_profile_NPC_ZELDA */
+extern actor_process_profile_definition g_profile_NPC_ZELDA = {
+    fpcLy_CURRENT_e,          // mLayerID
+    7,                        // mListID
+    fpcPi_CURRENT_e,          // mListPrio
+    PROC_NPC_ZELDA,           // mProcName
+    &g_fpcLf_Method.base,    // sub_method
+    sizeof(daNpc_Zelda_c),    // mSize
+    0,                        // mSizeOther
+    0,                        // mParameters
+    &g_fopAc_Method.base,     // sub_method
+    384,                      // mPriority
+    &daNpc_Zelda_MethodTable, // sub_method
+    0x00040108,               // mStatus
+    fopAc_NPC_e,              // mActorType
+    fopAc_CULLBOX_CUSTOM_e,   // cullType
+};

--- a/src/d/actor/d_a_obj_sekizoa.cpp
+++ b/src/d/actor/d_a_obj_sekizoa.cpp
@@ -333,7 +333,7 @@ int daObj_Sekizoa_c::Draw() {
     {
         temp_int = 1;
     }
-    return daNpcT_c::draw(0, 0, field_0xde8, NULL, 0.0f, temp_int, (mType == TYPE_6), 0);
+    return daNpcT_c::draw(0, 0, mRealShadowSize, NULL, 0.0f, temp_int, (mType == TYPE_6), 0);
 }
 
 /* 80CCED74-80CCED94 000B14 0020+00 1/1 0/0 0/0 .text
@@ -503,8 +503,8 @@ void daObj_Sekizoa_c::setParam() {
 
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daObj_Sekizoa_Param_c::m.field_0x18);
-    field_0xde8 = daObj_Sekizoa_Param_c::m.field_0x0C;
-    field_0xa80 = daObj_Sekizoa_Param_c::m.field_0x6C;
+    mRealShadowSize = daObj_Sekizoa_Param_c::m.field_0x0C;
+    mExpressionMorfFrame = daObj_Sekizoa_Param_c::m.field_0x6C;
     mMorfFrames = daObj_Sekizoa_Param_c::m.field_0x44;
     gravity = daObj_Sekizoa_Param_c::m.field_0x04;
 

--- a/src/d/actor/d_a_peru.cpp
+++ b/src/d/actor/d_a_peru.cpp
@@ -346,9 +346,9 @@ void daPeru_c::reset() {
     mWallR = daPeru_Param_c::m.field_0x00[7];
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daPeru_Param_c::m.field_0x00[6]);
-    field_0xde8 = daPeru_Param_c::m.field_0x00[3];
+    mRealShadowSize = daPeru_Param_c::m.field_0x00[3];
     gravity = daPeru_Param_c::m.field_0x00[1];
-    field_0xa80 = daPeru_Param_c::m.field_0x64[2];
+    mExpressionMorfFrame = daPeru_Param_c::m.field_0x64[2];
     mMorfFrames = daPeru_Param_c::m.field_0x00[17];
     mActionFunc = NULL;
     if (mpMatAnm[0] != NULL) {
@@ -381,9 +381,9 @@ void daPeru_c::setParam() {
     mWallR = daPeru_Param_c::m.field_0x00[7];
     mAcchCir.SetWallR(mWallR);
     mAcchCir.SetWallH(daPeru_Param_c::m.field_0x00[6]);
-    field_0xde8 = daPeru_Param_c::m.field_0x00[3];
+    mRealShadowSize = daPeru_Param_c::m.field_0x00[3];
     gravity = daPeru_Param_c::m.field_0x00[1];
-    field_0xa80 = daPeru_Param_c::m.field_0x64[2];
+    mExpressionMorfFrame = daPeru_Param_c::m.field_0x64[2];
     mMorfFrames = daPeru_Param_c::m.field_0x00[17];
 }
 


### PR DESCRIPTION
`d_a_npc_zelda` should be equivalent with this PR with the only outstanding problem being weak function ordering. This PR incidentally touches a LOT of other files as a result of correcting some function names/signatures in `d_a_npc.h`, but these changes are very limited in scope.