### PR TITLE
Use explicit zero-comparison in dBgS_Acch::Chk* functions

### DIFF
--- a/include/d/d_bg_s_acch.h
+++ b/include/d/d_bg_s_acch.h
@@ -46,9 +46,9 @@ public:
     f32 GetWallR() { return m_wall_r; }
     void SetWallH(f32 h) { m_wall_h = h; }
     void ClrWallHDirect() { m_flags &= ~WALL_H_DIRECT; }
-    bool ChkWallHit() { return m_flags & WALL_HIT; }
+    bool ChkWallHit() { return (m_flags & WALL_HIT) != 0; }
     s16 GetWallAngleY() { return m_wall_angle_y; }
-    bool ChkWallHDirect() { return m_flags & WALL_H_DIRECT; }
+    bool ChkWallHDirect() { return (m_flags & WALL_H_DIRECT) != 0; }
     f32 GetWallHDirect() { return m_wall_h_direct; }
     f32 GetWallRR() { return m_wall_rr; }
     void SetWallHit() { m_flags |= WALL_HIT; }
@@ -124,9 +124,9 @@ public:
     f32 GetRoofHeight() const { return m_roof_height; }
     int GetTblSize() { return m_tbl_size; }
     void SetLin() { m_lin.SetStartEnd(*pm_old_pos, *pm_pos); }
-    bool ChkGroundFind() { return m_flags & GROUND_FIND; }
-    bool ChkGroundHit() const { return m_flags & GROUND_HIT; }
-    bool ChkGroundLanding() const { return m_flags & GROUND_LANDING; }
+    bool ChkGroundFind() { return (m_flags & GROUND_FIND) != 0; }
+    bool ChkGroundHit() const { return (m_flags & GROUND_HIT) != 0; }
+    bool ChkGroundLanding() const { return (m_flags & GROUND_LANDING) != 0; }
     void ClrGroundLanding() { m_flags &= ~GROUND_LANDING; }
     void ClrGroundAway() { m_flags &= ~GROUND_AWAY; }
     void ClrWallHit() { m_flags &= ~WALL_HIT; }
@@ -136,18 +136,18 @@ public:
     u32 ChkWallHit() const { return m_flags & WALL_HIT; }
     void OffLineCheckHit() { m_flags &= ~LINE_CHECK_HIT; }
     void OffLineCheck() { m_flags &= ~LINE_CHECK; }
-    u32 ChkLineCheckNone() const { return m_flags & LINE_CHECK_NONE; }
-    u32 ChkLineCheck() const { return m_flags & LINE_CHECK; }
+    u32 ChkLineCheckNone() const { return (m_flags & LINE_CHECK_NONE) != 0; }
+    u32 ChkLineCheck() const { return (m_flags & LINE_CHECK) != 0; }
     void ClrRoofHit() { m_flags &= ~ROOF_HIT; }
     void ClrWaterHit() { m_flags &= ~WATER_HIT; }
     void SetWaterHit() { m_flags |= WATER_HIT; }
     void ClrWaterIn() { m_flags &= ~WATER_IN; }
     void SetWaterIn() { m_flags |= WATER_IN; }
     const u32 MaskWaterIn() const { return m_flags & WATER_IN; }
-    const bool ChkWaterIn() const { return MaskWaterIn();}
+    const bool ChkWaterIn() const { return MaskWaterIn() != 0; }
     void ClrGroundFind() { m_flags &= ~GROUND_FIND; }
     u32 MaskRoofHit() const { return m_flags & ROOF_HIT; }
-    bool ChkRoofHit() const { return MaskRoofHit(); }
+    bool ChkRoofHit() const { return MaskRoofHit() != 0; }
     void OffClrSpeedY() { m_flags |= CLR_SPEED_Y; }
     bool ChkClrSpeedY() const { return !(m_flags & CLR_SPEED_Y); }
     void SetGroundFind() { m_flags |= GROUND_FIND; }
@@ -155,7 +155,7 @@ public:
     void SetGroundLanding() { m_flags |= GROUND_LANDING; }
     void SetGroundAway() { m_flags |= GROUND_AWAY; }
     const u32 MaskWaterHit() const { return m_flags & WATER_HIT; }
-    const bool ChkWaterHit() const { return MaskWaterHit(); }
+    const bool ChkWaterHit() const { return MaskWaterHit() != 0; }
     void ClrWaterNone() { m_flags &= ~WATER_NONE; }
     void SetWaterCheckOffset(f32 offset) { m_wtr_chk_offset = offset; }
     void OnLineCheck() { m_flags |= LINE_CHECK; }
@@ -164,14 +164,14 @@ public:
     void SetWtrChkMode(int mode) { m_wtr_mode = mode; }
     void SetGrndNone() { m_flags |= GRND_NONE; }
     void ClrGrndNone() { m_flags &= ~GRND_NONE; }
-    bool ChkMoveBGOnly() const { return m_flags & MOVE_BG_ONLY; }
+    bool ChkMoveBGOnly() const { return (m_flags & MOVE_BG_ONLY) != 0; }
     void SetWallHit() { m_flags |= WALL_HIT; }
     void ClrWallNone() { m_flags &= ~WALL_NONE; }
     void OnLineCheckNone() { m_flags |= LINE_CHECK_NONE; }
     void OffLineCheckNone() { m_flags &= ~LINE_CHECK_NONE; }
     void SetWallNone() { m_flags |= WALL_NONE; }
     void OnLineCheckHit() { m_flags |= LINE_CHECK_HIT; }
-    bool ChkGroundAway() const { return m_flags & GROUND_AWAY; }
+    bool ChkGroundAway() const { return (m_flags & GROUND_AWAY) != 0; }
     void ClrGroundHit() { m_flags &= ~GROUND_HIT; }
 
     cM3dGCyl* GetWallBmdCylP() { return &m_wall_cyl; }

--- a/src/d/actor/d_a_obj_carry.cpp
+++ b/src/d/actor/d_a_obj_carry.cpp
@@ -3172,7 +3172,6 @@ BOOL daObjCarry_c::chkSinkObj() {
 }
 
 /* 8047573C-80476618 0067BC 0EDC+00 1/1 0/0 0/0 .text            bg_check__12daObjCarry_cFv */
-// NONMATCHING - regalloc, equivalent?
 void daObjCarry_c::bg_check() {
     bool roof_hit = mAcch.ChkRoofHit();
     bool wall_hit = mAcch.ChkWallHit();


### PR DESCRIPTION
These changes fix mismatches in `d_a_obj_carry` and `d_a_alink` and don't seem to introduce any regressions. It appears that even when the return value is coerced to a `bool`, the compiler still cares whether initial value being coerced is exactly 0/1 or not when the call is inlined.

`ChkWallHit` seems to be the odd one out here - changing it to match the other `Chk` functions _does_ cause some regressions, so it's left as-is.