### PR TITLE
Misc. J3D improvements

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1081,11 +1081,11 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DTransform.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DTexture.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DPacket.cpp"),
-            Object(NonMatching, "JSystem/J3DGraphBase/J3DShapeMtx.cpp"),
+            Object(MatchingFor("GZ2E01"), "JSystem/J3DGraphBase/J3DShapeMtx.cpp"),
             Object(NonMatching, "JSystem/J3DGraphBase/J3DShapeDraw.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DShape.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DMaterial.cpp", extra_cflags=['-pragma "nosyminline off"']),
-            Object(Equivalent, "JSystem/J3DGraphBase/J3DMatBlock.cpp"),
+            Object(Equivalent, "JSystem/J3DGraphBase/J3DMatBlock.cpp"), # virtual function order
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DTevs.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DDrawBuffer.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DStruct.cpp"),

--- a/include/JSystem/J3DGraphBase/J3DMatBlock.h
+++ b/include/JSystem/J3DGraphBase/J3DMatBlock.h
@@ -1,14 +1,16 @@
 #ifndef J3DMATBLOCK_H
 #define J3DMATBLOCK_H
 
+#include "JSystem/J3DGraphBase/J3DGD.h"
 #include "JSystem/J3DGraphBase/J3DTevs.h"
 #include "JSystem/J3DGraphBase/J3DTexture.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "dolphin/types.h"
+#include "global.h"
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DGXColorS10 : public GXColorS10 {
     /* 8000E460 */ J3DGXColorS10() {}
@@ -16,17 +18,15 @@ struct J3DGXColorS10 : public GXColorS10 {
     J3DGXColorS10(GXColorS10 const& color) : GXColorS10(color) {}
     J3DGXColorS10& operator=(const GXColorS10& color) {
         // FAKE match. __memcpy created issues in J3DTevBlockPatched::initialize
-        u32* src = (u32*)&color;
-        u32* tgt = (u32*)this;
-        tgt[0] = src[0];
-        tgt[1] = src[1];
+        ((u32*)this)[0] = ((u32*)&color)[0];
+        ((u32*)this)[1] = ((u32*)&color)[1];
         return *this;
     }
 };
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DGXColor : public GXColor {
     /* 8000E538 */ J3DGXColor() {}
@@ -48,7 +48,7 @@ struct J3DGXColor : public GXColor {
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DNBTScale : public J3DNBTScaleInfo {
     J3DNBTScale() {}
@@ -63,7 +63,344 @@ extern const J3DNBTScaleInfo j3dDefaultNBTScaleInfo;
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
+ */
+struct J3DColorChanInfo {
+    /* 0x0 */ u8 mEnable;
+    /* 0x1 */ u8 mMatSrc;
+    /* 0x2 */ u8 mLightMask;
+    /* 0x3 */ u8 mDiffuseFn;
+    /* 0x4 */ u8 mAttnFn;
+    /* 0x5 */ u8 mAmbSrc;
+    /* 0x6 */ u8 pad[2];
+};
+
+extern const J3DColorChanInfo j3dDefaultColorChanInfo;
+
+static inline u32 setChanCtrlMacro(u8 enable, GXColorSrc ambSrc, GXColorSrc matSrc, u32 lightMask,
+                                   GXDiffuseFn diffuseFn, GXAttnFn attnFn) {
+    return matSrc << 0 | enable << 1 | (lightMask & 0x0F) << 2 | ambSrc << 6 |
+           ((attnFn == GX_AF_SPEC) ? GX_DF_NONE : diffuseFn) << 7 | (attnFn != GX_AF_NONE) << 9 |
+           (attnFn != GX_AF_SPEC) << 10 | (lightMask >> 4 & 0x0F) << 11;
+}
+
+inline u16 calcColorChanID(u16 enable, u8 matSrc, u8 lightMask, u8 diffuseFn, u8 attnFn, u8 ambSrc) {
+    u32 reg = 0;
+    reg = (reg & ~0x0002) | enable << 1;
+    reg = (reg & ~0x0001) | matSrc;
+    reg = (reg & ~0x0040) | ambSrc << 6;
+    reg = (reg & ~0x0004) | bool(lightMask & 0x01) << 2;
+    reg = (reg & ~0x0008) | bool(lightMask & 0x02) << 3;
+    reg = (reg & ~0x0010) | bool(lightMask & 0x04) << 4;
+    reg = (reg & ~0x0020) | bool(lightMask & 0x08) << 5;
+    reg = (reg & ~0x0800) | bool(lightMask & 0x10) << 11;
+    reg = (reg & ~0x1000) | bool(lightMask & 0x20) << 12;
+    reg = (reg & ~0x2000) | bool(lightMask & 0x40) << 13;
+    reg = (reg & ~0x4000) | bool(lightMask & 0x80) << 14;
+    reg = (reg & ~0x0180) | (attnFn == GX_AF_SPEC ? 0 : diffuseFn) << 7;
+    reg = (reg & ~0x0200) | (attnFn != GX_AF_NONE) << 9;
+    reg = (reg & ~0x0400) | (attnFn != GX_AF_SPEC) << 10;
+    return reg;
+}
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+struct J3DColorChan {
+    /* 8000E47C */ J3DColorChan() {
+        setColorChanInfo(j3dDefaultColorChanInfo);
+    }
+    J3DColorChan(J3DColorChanInfo const& info) {
+        u32 ambSrc = info.mAmbSrc == 0xFF ? 0 : info.mAmbSrc;
+        mColorChanID = calcColorChanID(info.mEnable, info.mMatSrc, info.mLightMask,
+            info.mDiffuseFn, info.mAttnFn, ambSrc);
+    }
+    void setColorChanInfo(J3DColorChanInfo const& info) {
+        // Bug: It compares info.mAmbSrc (an 8 bit integer) with 0xFFFF instead of 0xFF.
+        // This inline is only called by the default constructor J3DColorChan().
+        // The J3DColorChan(const J3DColorChanInfo&) constructor does not call this inline, and instead duplicates the
+        // same logic but without the bug.
+        // See J3DMaterialFactory::newColorChan - both the bugged and correct behavior are present there, as it calls
+        // both constructors.
+        u32 ambSrc = info.mAmbSrc == 0xFFFF ? 0 : info.mAmbSrc;
+        mColorChanID = calcColorChanID(info.mEnable, info.mMatSrc, info.mLightMask,
+            info.mDiffuseFn, info.mAttnFn, ambSrc);
+    }
+    u8 getLightMask() const { return ((mColorChanID >> 2) & 0xf) | ((mColorChanID >> 11) & 0xf) << 4; }
+    void setLightMask(u8 param_1) {
+        mColorChanID = (mColorChanID & ~0x3c) | ((param_1 & 0xf) << 2);
+        mColorChanID = (mColorChanID & ~0x7800) | ((param_1 & 0xf0) << 7);
+    }
+
+    u8 getEnable() const { return (u32)(mColorChanID & 0x2) >> 1; }
+    u8 getAmbSrc() const { return (GXColorSrc)((u32)(mColorChanID & (1 << 6)) >> 6); }
+    u8 getMatSrc() const { return (GXColorSrc)(mColorChanID & 1); }
+    u8 getDiffuseFn() const { return ((u32)(mColorChanID & (3 << 7)) >> 7); }
+    // This function has to appear in J3DMatBlock.cpp because it generates extra data in .sdata2
+    inline u8 getAttnFn() const;
+
+    void load() const {
+        J3DGDWrite_u32(setChanCtrlMacro(getEnable(), (GXColorSrc)getAmbSrc(), (GXColorSrc)getMatSrc(), getLightMask(),
+                                        (GXDiffuseFn)getDiffuseFn(), (GXAttnFn)getAttnFn()));
+    }
+
+    /* 0x0 */ u16 mColorChanID;
+};
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DColorBlock {
+public:
+    /* 80317324 */ virtual void load() {}
+    /* 80317358 */ virtual void reset(J3DColorBlock*) {}
+    /* 8031733C */ virtual void patch() {}
+    /* 80317434 */ virtual void patchMatColor() {}
+    /* 8000DBD0 */ virtual void patchLight() {}
+    /* 80317340 */ virtual void diff(u32) {}
+    /* 80317438 */ virtual void diffAmbColor() {}
+    /* 8031743C */ virtual void diffMatColor() {}
+    /* 80317440 */ virtual void diffColorChan() {}
+    /* 80317444 */ virtual void diffLightObj(u32) {}
+    /* 80317304 */ virtual s32 countDLSize() { return 0; }
+    virtual u32 getType() = 0;
+    /* 80317448 */ virtual void setMatColor(u32, J3DGXColor const*) {}
+    /* 8000E0DC */ virtual void setMatColor(u32, J3DGXColor) {}
+    /* 8000E000 */ virtual J3DGXColor* getMatColor(u32) { return NULL; }
+    /* 801A4C0C */ virtual void setAmbColor(u32, J3DGXColor const*) {}
+    /* 8000E0D4 */ virtual void setAmbColor(u32, J3DGXColor) {}
+    /* 8000DFF0 */ virtual J3DGXColor* getAmbColor(u32) { return NULL; }
+    /* 8000E0E0 */ virtual void setColorChanNum(u8) {}
+    /* 8031744C */ virtual void setColorChanNum(u8 const*) {}
+    /* 8000E008 */ virtual u8 getColorChanNum() const { return 0; }
+    /* 8000E0D8 */ virtual void setColorChan(u32, J3DColorChan const&) {}
+    /* 80317450 */ virtual void setColorChan(u32, J3DColorChan const*) {}
+    /* 8000DFF8 */ virtual J3DColorChan* getColorChan(u32) { return NULL; }
+    /* 801A4C08 */ virtual void setLight(u32, J3DLightObj*) {}
+    /* 80317454 */ virtual J3DLightObj* getLight(u32) { return NULL; }
+    /* 80317460 */ virtual void setCullMode(u8 const*) {}
+    /* 8031745C */ virtual void setCullMode(u8) {}
+    /* 80317328 */ virtual u8 getCullMode() const { return 2; }
+    /* 80317464 */ virtual u32 getMatColorOffset() const { return 0; }
+    /* 8031746C */ virtual u32 getColorChanOffset() const { return 0; }
+    /* 80317474 */ virtual void setMatColorOffset(u32) {}
+    /* 80317478 */ virtual void setColorChanOffset(u32) {}
+    /* 80317138 */ virtual ~J3DColorBlock() {}
+};
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DColorBlockLightOff : public J3DColorBlock {
+public:
+    J3DColorBlockLightOff() {
+        initialize();
+    }
+    /* 8031747C */ void initialize();
+
+    /* 80317B84 */ virtual s32 countDLSize();
+    /* 80317C0C */ virtual void load();
+    /* 8031FD08 */ virtual void reset(J3DColorBlock*);
+    /* 80318EB4 */ virtual void patch();
+    /* 80318F00 */ virtual void patchMatColor();
+    /* 803190AC */ virtual void patchLight();
+    /* 80319B4C */ virtual void diff(u32);
+    /* 80319BB4 */ virtual void diffMatColor();
+    /* 80319D30 */ virtual void diffColorChan();
+    /* 80323560 */ virtual u32 getType() { return 'CLOF'; }
+    /* 80323184 */ virtual void setMatColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x121, idx >= 0 && idx < ARRAY_SIZE(mMatColor), "Error : range over.");
+        J3D_ASSERT(0x122, color != 0, "Error : null pointer.");
+        mMatColor[idx] = *color;
+    }
+    /* 80323158 */ virtual void setMatColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x128, idx >= 0 && idx < ARRAY_SIZE(mMatColor), "Error : range over.");
+        mMatColor[idx] = color;
+    }
+    /* 803231B0 */ virtual J3DGXColor* getMatColor(u32 idx) {
+        J3D_ASSERT(0x12d, idx >= 0 && idx < ARRAY_SIZE(mMatColor), "Error : range over.");
+        return &mMatColor[idx];
+    }
+    /* 803231D0 */ virtual void setColorChanNum(u8 num) { mColorChanNum = num; }
+    /* 803231C4 */ virtual void setColorChanNum(u8 const* num) {
+        J3D_ASSERT(0x137, num != 0, "Error : null pointer.");
+        mColorChanNum = *num;
+    }
+    /* 803231D8 */ virtual u8 getColorChanNum() const { return mColorChanNum; }
+    /* 803231F4 */ virtual void setColorChan(u32 idx, J3DColorChan const& chan) {
+        J3D_ASSERT(0x142, idx >= 0 && idx < ARRAY_SIZE(mColorChan), "Error : range over.");
+        mColorChan[idx] = chan;
+    }
+    /* 803231E0 */ virtual void setColorChan(u32 idx, J3DColorChan const* chan) {
+        J3D_ASSERT(0x148, idx >= 0 && idx < ARRAY_SIZE(mColorChan), "Error : range over.");
+        J3D_ASSERT(0x149, chan != 0, "Error : null pointer.");
+        mColorChan[idx] = *chan;
+    }
+    /* 80323208 */ virtual J3DColorChan* getColorChan(u32 idx) {
+        J3D_ASSERT(0x14e, idx >= 0 && idx < ARRAY_SIZE(mColorChan), "Error : range over.");
+        return &mColorChan[idx];
+    }
+    /* 80323224 */ virtual void setCullMode(u8 const* mode) {
+        J3D_ASSERT(0x154, mode != 0, "Error : null pointer.");
+        mCullMode = *mode;
+    }
+    /* 8032321C */ virtual void setCullMode(u8 mode) { mCullMode = mode; }
+    /* 80323230 */ virtual u8 getCullMode() const { return mCullMode; }
+    /* 80323238 */ virtual u32 getMatColorOffset() const { return mMatColorOffset; }
+    /* 80323240 */ virtual u32 getColorChanOffset() const { return mColorChanOffset; }
+    /* 80323248 */ virtual void setMatColorOffset(u32 offset) { mMatColorOffset = offset; }
+    /* 80323250 */ virtual void setColorChanOffset(u32 offset) { mColorChanOffset = offset; }
+    /* 803170DC */ virtual ~J3DColorBlockLightOff() {}
+
+    /* 0x04 */ J3DGXColor mMatColor[2];
+    /* 0x0C */ u8 mColorChanNum;
+    /* 0x0E */ J3DColorChan mColorChan[4];
+    /* 0x16 */ u8 mCullMode;
+    /* 0x18 */ u32 mMatColorOffset;
+    /* 0x1C */ u32 mColorChanOffset;
+};  // Size: 0x20
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DColorBlockAmbientOn : public J3DColorBlockLightOff {
+public:
+    J3DColorBlockAmbientOn() {
+        initialize();
+    }
+    /* 803174DC */ void initialize();
+
+    /* 8031816C */ virtual void load();
+    /* 8031FDE4 */ virtual void reset(J3DColorBlock*);
+    /* 80317B8C */ virtual s32 countDLSize();
+    /* 80323074 */ virtual u32 getType() { return 'CLAB'; }
+    /* 803230AC */ virtual void setAmbColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x1a3, idx >= 0 && idx < ARRAY_SIZE(mAmbColor), "Error : range over.");
+        J3D_ASSERT(0x1a4, color != 0, "Error : null pointer.");
+        mAmbColor[idx] = *color;
+    }
+    /* 80323080 */ virtual void setAmbColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x1aa, idx >= 0 && idx < ARRAY_SIZE(mAmbColor), "Error : range over.");
+        mAmbColor[idx] = color;
+    }
+    /* 803230D8 */ virtual J3DGXColor* getAmbColor(u32 idx) {
+        J3D_ASSERT(0x1af, idx >= 0 && idx < ARRAY_SIZE(mAmbColor), "Error : range over.");
+        return &mAmbColor[idx];
+    }
+    /* 803230EC */ virtual ~J3DColorBlockAmbientOn() {}
+
+    /* 0x20 */ J3DGXColor mAmbColor[2];
+};  // Size: 0x28
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DColorBlockLightOn : public J3DColorBlock {
+public:
+    J3DColorBlockLightOn() {
+        initialize();
+    }
+    /* 80317580 */ void initialize();
+
+    /* 803187F4 */ virtual void load();
+    /* 8031FF34 */ virtual void reset(J3DColorBlock*);
+    /* 803194E8 */ virtual void patch();
+    /* 80319534 */ virtual void patchMatColor();
+    /* 803196E0 */ virtual void patchLight();
+    /* 8031A13C */ virtual void diff(u32);
+    /* 8031A1DC */ virtual void diffAmbColor();
+    /* 8031A358 */ virtual void diffMatColor();
+    /* 8031A4D4 */ virtual void diffColorChan();
+    /* 8031A8E0 */ virtual void diffLightObj(u32);
+    /* 80317B94 */ virtual s32 countDLSize();
+    /* 80322E80 */ virtual u32 getType() { return 'CLON'; }
+    /* 80322EB8 */ virtual void setMatColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x1e9, idx >= 0 && idx < ARRAY_SIZE(mMatColor), "Error : range over.");
+        J3D_ASSERT(0x1ea, color != 0, "Error : null pointer.");
+        mMatColor[idx] = *color;
+    }
+    /* 80322E8C */ virtual void setMatColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x1f0, idx >= 0 && idx < ARRAY_SIZE(mMatColor), "Error : range over.");
+        mMatColor[idx] = color;
+    }
+    /* 80322EE4 */ virtual J3DGXColor* getMatColor(u32 idx) {
+        J3D_ASSERT(0x1f5, idx >= 0 && idx < ARRAY_SIZE(mMatColor), "Error : range over.");
+        return &mMatColor[idx];
+    }
+    /* 80322F24 */ virtual void setAmbColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x1fc, idx >= 0 && idx < ARRAY_SIZE(mAmbColor), "Error : range over.");
+        J3D_ASSERT(0x1fd, color != 0, "Error : null pointer.");
+        mAmbColor[idx] = *color;
+    }
+    /* 80322EF8 */ virtual void setAmbColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x203, idx >= 0 && idx < ARRAY_SIZE(mAmbColor), "Error : range over.");
+        mAmbColor[idx] = color;
+    }
+    /* 80322F50 */ virtual J3DGXColor* getAmbColor(u32 idx) {
+        J3D_ASSERT(0x208, idx >= 0 && idx < ARRAY_SIZE(mAmbColor), "Error : range over.");
+        return &mAmbColor[idx];
+    }
+    /* 80322F70 */ virtual void setColorChanNum(u8 num) { mColorChanNum = num; }
+    /* 80322F64 */ virtual void setColorChanNum(u8 const* num) {
+        J3D_ASSERT(0x212, num != 0, "Error : null pointer.");
+        mColorChanNum = *num;
+    }
+    /* 80322F78 */ virtual u8 getColorChanNum() const { return mColorChanNum; }
+    /* 80322F94 */ virtual void setColorChan(u32 idx, J3DColorChan const& chan) {
+        J3D_ASSERT(0x21d, idx >= 0 && idx < ARRAY_SIZE(mColorChan), "Error : range over.");
+        mColorChan[idx] = chan;
+    }
+    /* 80322F80 */ virtual void setColorChan(u32 idx, J3DColorChan const* chan) {
+        J3D_ASSERT(0x223, idx >= 0 && idx < ARRAY_SIZE(mColorChan), "Error : range over.");
+        J3D_ASSERT(0x224, chan != 0, "Error : null pointer.");
+        mColorChan[idx] = *chan;
+    }
+    /* 80322FA8 */ virtual J3DColorChan* getColorChan(u32 idx) {
+        J3D_ASSERT(0x229, idx >= 0 && idx < ARRAY_SIZE(mColorChan), "Error : range over.");
+        return &mColorChan[idx];
+    }
+    /* 80322FBC */ virtual void setLight(u32 idx, J3DLightObj* light) {
+        J3D_ASSERT(0x230, idx >= 0 && idx < ARRAY_SIZE(mLight), "Error : range over.");
+        mLight[idx] = light;
+    }
+    /* 80322FCC */ virtual J3DLightObj* getLight(u32 idx) {
+        J3D_ASSERT(0x235, idx >= 0 && idx < ARRAY_SIZE(mLight), "Error : range over.");
+        return mLight[idx];
+    }
+    /* 80322FE4 */ virtual void setCullMode(u8 const* mode) {
+        J3D_ASSERT(0x23b, mode != 0, "Error : null pointer.");
+        mCullMode = *mode;
+    }
+    /* 80322FDC */ virtual void setCullMode(u8 mode) {
+        mCullMode = mode;
+    }
+    /* 80322FF0 */ virtual u8 getCullMode() const {
+        return mCullMode;
+    }
+    /* 80322FF8 */ virtual u32 getMatColorOffset() const { return mMatColorOffset; }
+    /* 80323000 */ virtual u32 getColorChanOffset() const { return mColorChanOffset; }
+    /* 80323008 */ virtual void setMatColorOffset(u32 offset) { mMatColorOffset = offset; }
+    /* 80323010 */ virtual void setColorChanOffset(u32 offset) { mColorChanOffset = offset; }
+    /* 80323018 */ virtual ~J3DColorBlockLightOn() {}
+
+    /* 0x04 */ J3DGXColor mMatColor[2];
+    /* 0x0C */ J3DGXColor mAmbColor[2];
+    /* 0x14 */ u8 mColorChanNum;
+    /* 0x16 */ J3DColorChan mColorChan[4];
+    /* 0x20 */ J3DLightObj* mLight[8];
+    /* 0x40 */ u8 mCullMode;
+    /* 0x44 */ u32 mMatColorOffset;
+    /* 0x48 */ u32 mColorChanOffset;
+};  // Size: 0x4C
+
+/**
+ * @ingroup jsystem-j3d
+ *
  */
 class J3DTexGenBlock {
 public:
@@ -86,7 +423,7 @@ public:
     /* 8000DFE0 */ virtual J3DTexCoord* getTexCoord(u32) { return NULL; }
     /* 8003AB2C */ virtual void setTexMtx(u32, J3DTexMtx*) {}
     /* 8000DFD8 */ virtual J3DTexMtx* getTexMtx(u32) { return NULL; }
-    /* 80317424 */ virtual void setNBTScale(J3DNBTScale const*) {}
+    /* 80317424 */ virtual void setNBTScale(J3DNBTScale const* scale) {}
     /* 80317420 */ virtual void setNBTScale(J3DNBTScale) {}
     /* 80317334 */ virtual J3DNBTScale* getNBTScale() { return NULL; }
     /* 80317428 */ virtual u32 getTexMtxOffset() const { return 0; }
@@ -110,7 +447,7 @@ struct J3DTexGenBlockNull : public J3DTexGenBlock {
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 class J3DTexGenBlockPatched : public J3DTexGenBlock {
 public:
@@ -131,13 +468,29 @@ public:
     /* 8031AD30 */ virtual void diffTexGen();
     /* 80317B9C */ virtual s32 countDLSize();
     /* 80322E74 */ virtual u32 getType() { return 'TGPT'; }
-    /* 80322D3C */ virtual void setTexGenNum(u32 const* num) { mTexGenNum = *num; }
+    /* 80322D3C */ virtual void setTexGenNum(u32 const* num) {
+        J3D_ASSERT(0x335, num != 0, "Error : null pointer.");
+        mTexGenNum = *num;
+    }
     /* 80322D34 */ virtual void setTexGenNum(u32 num) { mTexGenNum = num; }
     /* 80322D48 */ virtual u32 getTexGenNum() const { return mTexGenNum; }
-    /* 80322D50 */ virtual void setTexCoord(u32 idx, J3DTexCoord const* coord) { mTexCoord[idx] = *coord; }
-    /* 80322D64 */ virtual J3DTexCoord* getTexCoord(u32 idx) { return & mTexCoord[idx]; }
-    /* 80322D78 */ virtual void setTexMtx(u32 idx, J3DTexMtx* mtx) { mTexMtx[idx] = mtx; }
-    /* 80322D88 */ virtual J3DTexMtx* getTexMtx(u32 idx) { return mTexMtx[idx]; }
+    /* 80322D50 */ virtual void setTexCoord(u32 idx, J3DTexCoord const* coord) {
+        J3D_ASSERT(0x344, idx >= 0 && idx < ARRAY_SIZE(mTexCoord), "Error : range over.");
+        J3D_ASSERT(0x345, coord != 0, "Error : null pointer.");
+        mTexCoord[idx] = *coord;
+    }
+    /* 80322D64 */ virtual J3DTexCoord* getTexCoord(u32 idx) {
+        J3D_ASSERT(0x34a, idx >= 0 && idx < ARRAY_SIZE(mTexCoord), "Error : range over.");
+        return &mTexCoord[idx];
+    }
+    /* 80322D78 */ virtual void setTexMtx(u32 idx, J3DTexMtx* mtx) {
+        J3D_ASSERT(0x351, idx >= 0 && idx < ARRAY_SIZE(mTexMtx), "Error : range over.");
+        mTexMtx[idx] = mtx;
+    }
+    /* 80322D88 */ virtual J3DTexMtx* getTexMtx(u32 idx) {
+        J3D_ASSERT(0x356, idx >= 0 && idx < ARRAY_SIZE(mTexMtx), "Error : range over.");
+        return mTexMtx[idx];
+    }
     /* 80322D98 */ virtual u32 getTexMtxOffset() const { return mTexMtxOffset; }
     /* 80322DA0 */ virtual void setTexMtxOffset(u32 offset) { mTexMtxOffset = offset; }
     /* 80317180 */ virtual ~J3DTexGenBlockPatched() {}
@@ -150,31 +503,7 @@ public:
 
 /**
  * @ingroup jsystem-j3d
- * 
- */
-class J3DTexGenBlockBasic : public J3DTexGenBlockPatched {
-public:
-    J3DTexGenBlockBasic() : mNBTScale(j3dDefaultNBTScaleInfo) {
-        initialize();
-    }
-    /* 803176A4 */ void initialize();
-
-    /* 803202DC */ virtual void reset(J3DTexGenBlock*);
-    /* 8031A9E8 */ virtual void load();
-    /* 8031ABC0 */ virtual void patch();
-    /* 80317BAC */ virtual s32 countDLSize();
-    /* 80322C6C */ virtual u32 getType() { return 'TGBC'; }
-    /* 80322C9C */ virtual void setNBTScale(J3DNBTScale const* scale) { mNBTScale = *scale; }
-    /* 80322C78 */ virtual void setNBTScale(J3DNBTScale scale) { mNBTScale = scale; }
-    /* 80322CC0 */ virtual J3DNBTScale* getNBTScale() { return &mNBTScale; }
-    /* 80322CC8 */ virtual ~J3DTexGenBlockBasic() {}
-
-    /* 0x5C */ J3DNBTScale mNBTScale;
-};  // Size: 0x6C
-
-/**
- * @ingroup jsystem-j3d
- * 
+ *
  */
 class J3DTexGenBlock4 : public J3DTexGenBlockPatched {
 public:
@@ -188,7 +517,10 @@ public:
     /* 8031AB18 */ virtual void patch();
     /* 80317BA4 */ virtual s32 countDLSize();
     /* 80322DA8 */ virtual u32 getType() { return 'TGB4'; }
-    /* 80322DD8 */ virtual void setNBTScale(J3DNBTScale const* scale) { mNBTScale = *scale; }
+    /* 80322DD8 */ virtual void setNBTScale(J3DNBTScale const* scale) {
+        J3D_ASSERT(0x393, scale != 0, "Error : null pointer.");
+        mNBTScale = *scale;
+    }
     /* 80322DB4 */ virtual void setNBTScale(J3DNBTScale scale) { mNBTScale = scale; }
     /* 80322DFC */ virtual J3DNBTScale* getNBTScale() { return &mNBTScale; }
     /* 80322E04 */ virtual ~J3DTexGenBlock4() {}
@@ -198,18 +530,45 @@ public:
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
+ */
+class J3DTexGenBlockBasic : public J3DTexGenBlockPatched {
+public:
+    J3DTexGenBlockBasic() : mNBTScale(j3dDefaultNBTScaleInfo) {
+        initialize();
+    }
+    /* 803176A4 */ void initialize();
+
+    /* 803202DC */ virtual void reset(J3DTexGenBlock*);
+    /* 8031A9E8 */ virtual void load();
+    /* 8031ABC0 */ virtual void patch();
+    /* 80317BAC */ virtual s32 countDLSize();
+    /* 80322C6C */ virtual u32 getType() { return 'TGBC'; }
+    /* 80322C9C */ virtual void setNBTScale(J3DNBTScale const* scale) {
+        J3D_ASSERT(0x3ca, scale != 0, "Error : null pointer.");
+        mNBTScale = *scale;
+    }
+    /* 80322C78 */ virtual void setNBTScale(J3DNBTScale scale) { mNBTScale = scale; }
+    /* 80322CC0 */ virtual J3DNBTScale* getNBTScale() { return &mNBTScale; }
+    /* 80322CC8 */ virtual ~J3DTexGenBlockBasic() {}
+
+    /* 0x5C */ J3DNBTScale mNBTScale;
+};  // Size: 0x6C
+
+/**
+ * @ingroup jsystem-j3d
+ *
  */
 class J3DTevBlock {
 public:
     /* 80317350 */ virtual void reset(J3DTevBlock*) {}
     /* 80317330 */ virtual void load() {}
     /* 8031CD44 */ virtual void diff(u32);
-    /* 80321948 */ virtual void diffTexNo() {}
-    /* 80321938 */ virtual void diffTevReg() {}
-    /* 80321944 */ virtual void diffTexCoordScale() {}
-    /* 80321940 */ virtual void diffTevStage() {}
-    /* 8032193C */ virtual void diffTevStageIndirect() {}
+    /* 80321948 */ virtual void diffTexNo();
+    /* 80321938 */ virtual void diffTevReg();
+    /* 80321944 */ virtual void diffTexCoordScale();
+    /* 80321940 */ virtual void diffTevStage();
+    /* 8032193C */ virtual void diffTevStageIndirect();
     /* 8000DBD4 */ virtual void patch() {}
     /* 8032353C */ virtual void patchTexNo() {}
     /* 80323540 */ virtual void patchTevReg() {}
@@ -264,7 +623,7 @@ protected:
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 class J3DTevBlockNull : public J3DTevBlock {
 public:
@@ -279,7 +638,7 @@ public:
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 class J3DTevBlockPatched : public J3DTevBlock {
 public:
@@ -302,37 +661,110 @@ public:
     /* 8031DFB4 */ virtual void ptrToIndex();
     /* 80322974 */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
     /* 80322998 */ virtual u32 getType() { return 'TVPT'; }
-    /* 80317BB4 */ virtual s32 countDLSize();
-    /* 803229D0 */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
-    /* 803229C0 */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 803229E4 */ virtual u16 getTexNo(u32 idx) const {
-        J3D_ASSERT(1353, idx < 8, "Error : range over.");
-        return mTexNo[idx];
+    /* 803229AC */ virtual void setTevStageNum(u8 const* num) {
+        J3D_ASSERT(0x52c, num != 0, "Error : null pointer.");
+        mTevStageNum = *num;
     }
-    /* 80322A08 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
-    /* 803229F4 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
-    /* 80322A1C */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
-    /* 80322B24 */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) { mTevColor[idx] = *color; }
-    /* 80322AF8 */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) { mTevColor[idx] = color; }
-    /* 80322B50 */ virtual J3DGXColorS10* getTevColor(u32 idx) { return &mTevColor[idx]; }
-    /* 80322B90 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) { mTevKColor[idx] = *color; }
-    /* 80322B64 */ virtual void setTevKColor(u32 idx, J3DGXColor color) { mTevKColor[idx] = color; }
-    /* 80322BBC */ virtual J3DGXColor* getTevKColor(u32 idx) { return &mTevKColor[idx]; }
-    /* 80322BDC */ virtual void setTevKColorSel(u32 idx, u8 const* sel) { mTevKColorSel[idx] = *sel; }
-    /* 80322BD0 */ virtual void setTevKColorSel(u32 idx, u8 sel) { mTevKColorSel[idx] = sel; }
-    /* 80322BEC */ virtual u8 getTevKColorSel(u32 idx) { return mTevKColorSel[idx]; }
-    /* 803229AC */ virtual void setTevStageNum(u8 const* num) { mTevStageNum = *num; }
     /* 803229A4 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
     /* 803229B8 */ virtual u8 getTevStageNum() const { return mTevStageNum; }
-    /* 80322A6C */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) { mTevStage[idx] = *stage; }
-    /* 80322A30 */ virtual void setTevStage(u32 idx, J3DTevStage stage) { mTevStage[idx] = stage; }
-    /* 80322AA8 */ virtual J3DTevStage* getTevStage(u32 idx) { return &mTevStage[idx]; }
-    /* 80322AD0 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) { mIndTevStage[idx] = *stage; }
-    /* 80322ABC */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) { mIndTevStage[idx] = stage; }
-    /* 80322AE4 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) { return &mIndTevStage[idx]; }
+    /* 80317BB4 */ virtual s32 countDLSize();
+    /* 803229D0 */ virtual void setTexNo(u32 idx, u16 const* texNo) {
+        J3D_ASSERT(0x53b, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        J3D_ASSERT(0x53c, texNo != 0, "Error : null pointer.");
+        mTexNo[idx] = *texNo;
+    }
+    /* 803229C0 */ virtual void setTexNo(u32 idx, u16 texNo) {
+        J3D_ASSERT(0x542, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        mTexNo[idx] = texNo;
+    }
+    /* 803229E4 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(1353, idx >= 0 && idx < 8, "Error : range over.");
+        return mTexNo[idx];
+    }
+    /* 80322A08 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) {
+        J3D_ASSERT(0x550, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        J3D_ASSERT(0x551, order != 0, "Error : null pointer.");
+        mTevOrder[idx] = *order;
+    }
+    /* 803229F4 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) {
+        J3D_ASSERT(0x557, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        mTevOrder[idx] = order;
+    }
+    /* 80322A1C */ virtual J3DTevOrder* getTevOrder(u32 idx) {
+        J3D_ASSERT(0x55c, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        return &mTevOrder[idx];
+    }
+    /* 80322A6C */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) {
+        J3D_ASSERT(0x563, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x564, stage != 0, "Error : null pointer.");
+        mTevStage[idx] = *stage;
+    }
+    /* 80322A30 */ virtual void setTevStage(u32 idx, J3DTevStage stage) {
+        J3D_ASSERT(0x56a, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx] = stage;
+    }
+    /* 80322AA8 */ virtual J3DTevStage* getTevStage(u32 idx) {
+        J3D_ASSERT(0x56f, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        return &mTevStage[idx];
+    }
+    /* 80322AD0 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) {
+        J3D_ASSERT(0x576, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        J3D_ASSERT(0x577, stage != 0, "Error : null pointer.");
+        mIndTevStage[idx] = *stage;
+    }
+    /* 80322ABC */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) {
+        J3D_ASSERT(0x57d, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        mIndTevStage[idx] = stage;
+    }
+    /* 80322AE4 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) {
+        J3D_ASSERT(0x582, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        return &mIndTevStage[idx];
+    }
+    /* 80322B24 */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) {
+        J3D_ASSERT(0x589, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        J3D_ASSERT(0x58a, color != 0, "Error : null pointer.");
+        mTevColor[idx] = *color;
+    }
+    /* 80322AF8 */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) {
+        J3D_ASSERT(0x590, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        mTevColor[idx] = color;
+    }
+    /* 80322B50 */ virtual J3DGXColorS10* getTevColor(u32 idx) {
+        J3D_ASSERT(0x595, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        return &mTevColor[idx];
+    }
+    /* 80322B90 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x59c, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        J3D_ASSERT(0x59d, color != 0, "Error : null pointer.");
+        mTevKColor[idx] = *color;
+    }
+    /* 80322B64 */ virtual void setTevKColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x5a3, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        mTevKColor[idx] = color;
+    }
+    /* 80322BBC */ virtual J3DGXColor* getTevKColor(u32 idx) {
+        J3D_ASSERT(0x5a8, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        return &mTevKColor[idx];
+    }
+    /* 80322BDC */ virtual void setTevKColorSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x5af, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        J3D_ASSERT(0x5b0, sel != 0, "Error : null pointer.");
+        mTevKColorSel[idx] = *sel;
+    }
+    /* 80322BD0 */ virtual void setTevKColorSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x5b6, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        mTevKColorSel[idx] = sel;
+    }
+    /* 80322BEC */ virtual u8 getTevKColorSel(u32 idx) {
+        J3D_ASSERT(0x5bb, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        return mTevKColorSel[idx];
+    }
     /* 80322BF8 */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
     /* 80322C00 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
-    /* 80322C08 */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
+    /* 80322C08 */ virtual void setTevRegOffset(u32 offset) {
+        J3D_ASSERT(0x53b, offset >= 0, "Error : range over.");
+        mTevRegOffset = offset;
+    }
     /* 80322C10 */ virtual ~J3DTevBlockPatched() {}
 
     /* 0x08 */ u16 mTexNo[8];
@@ -348,244 +780,7 @@ public:
 
 /**
  * @ingroup jsystem-j3d
- * 
- */
-class J3DTevBlock4 : public J3DTevBlock {
-public:
-    J3DTevBlock4() {
-        initialize();
-    }
-    /* 803178EC */ void initialize();
-
-    /* 8032098C */ virtual void reset(J3DTevBlock*);
-    /* 8031B4C0 */ virtual void load();
-    /* 8031D758 */ virtual void diffTexNo();
-    /* 8031D7BC */ virtual void diffTevReg();
-    /* 8031DA1C */ virtual void diffTexCoordScale();
-    /* 8031D858 */ virtual void diffTevStage();
-    /* 8031D96C */ virtual void diffTevStageIndirect();
-    /* 8031C9D0 */ virtual void patch();
-    /* 8031C6F4 */ virtual void patchTexNo();
-    /* 8031C788 */ virtual void patchTevReg();
-    /* 8031C854 */ virtual void patchTexNoAndTexCoordScale();
-    /* 80321FE8 */ virtual void ptrToIndex() {}
-    /* 80321FEC */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
-    /* 80322010 */ virtual u32 getType() { return 'TVB4'; }
-    /* 80317BCC */ virtual s32 countDLSize();
-    /* 8032202C */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
-    /* 8032201C */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 80322040 */ virtual u16 getTexNo(u32 idx) const {
-        J3D_ASSERT(2019, idx < 4, "Error : range over.");
-        return mTexNo[idx];
-    }
-    /* 80322064 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
-    /* 80322050 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
-    /* 80322078 */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
-    /* 803220B8 */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) { mTevColor[idx] = *color; }
-    /* 8032208C */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) { mTevColor[idx] = color; }
-    /* 803220E4 */ virtual J3DGXColorS10* getTevColor(u32 idx) { return &mTevColor[idx]; }
-    /* 80322124 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) { mTevKColor[idx] = *color; }
-    /* 803220F8 */ virtual void setTevKColor(u32 idx, J3DGXColor color) { mTevKColor[idx] = color; }
-    /* 80322150 */ virtual J3DGXColor* getTevKColor(u32 idx) { return &mTevKColor[idx]; }
-    /* 80322170 */ virtual void setTevKColorSel(u32 idx, u8 const* sel) { mTevKColorSel[idx] = *sel; }
-    /* 80322164 */ virtual void setTevKColorSel(u32 idx, u8 sel) { mTevKColorSel[idx] = sel; }
-    /* 80322180 */ virtual u8 getTevKColorSel(u32 idx) { return mTevKColorSel[idx]; }
-    /* 80322198 */ virtual void setTevKAlphaSel(u32 idx, u8 const* sel) { mTevKAlphaSel[idx] = *sel; }
-    /* 8032218C */ virtual void setTevKAlphaSel(u32 idx, u8 sel) { mTevKAlphaSel[idx] = sel; }
-    /* 803221A8 */ virtual u8 getTevKAlphaSel(u32 idx) { return mTevKAlphaSel[idx]; }
-    /* 803221BC */ virtual void setTevStageNum(u8 const* num) { mTevStageNum = *num; }
-    /* 803221B4 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
-    /* 803221C8 */ virtual u8 getTevStageNum() const { return mTevStageNum; }
-    /* 8032220C */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) { mTevStage[idx] = *stage; }
-    /* 803221D0 */ virtual void setTevStage(u32 idx, J3DTevStage stage) { mTevStage[idx] = stage; }
-    /* 80322248 */ virtual J3DTevStage* getTevStage(u32 idx) { return &mTevStage[idx]; }
-    /* 80322294 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo const* info) { mTevStage[idx].setTevSwapModeInfo(*info); }
-    /* 8032225C */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo info) { mTevStage[idx].setTevSwapModeInfo(info); }
-    /* 803222DC */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable const* table) { mTevSwapModeTable[idx] = *table; }
-    /* 803222CC */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable table) { mTevSwapModeTable[idx] = table; }
-    /* 803222EC */ virtual J3DTevSwapModeTable* getTevSwapModeTable(u32 idx) { return &mTevSwapModeTable[idx]; }
-    /* 80322310 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) { mIndTevStage[idx] = *stage; }
-    /* 803222FC */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) { mIndTevStage[idx] = stage; }
-    /* 80322324 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) { return &mIndTevStage[idx]; }
-    /* 80322338 */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
-    /* 80322340 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
-    /* 80322348 */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
-    /* 80322350 */ virtual ~J3DTevBlock4() {}
-
-    /* 0x08 */ u16 mTexNo[4];
-    /* 0x10 */ J3DTevOrder mTevOrder[4];
-    /* 0x20 */ u8 mTevStageNum;
-    /* 0x21 */ J3DTevStage mTevStage[4];
-    /* 0x42 */ J3DGXColorS10 mTevColor[4];
-    /* 0x62 */ J3DGXColor mTevKColor[4];
-    /* 0x72 */ u8 mTevKColorSel[4];
-    /* 0x76 */ u8 mTevKAlphaSel[4];
-    /* 0x7A */ J3DTevSwapModeTable mTevSwapModeTable[4];
-    /* 0x80 */ J3DIndTevStage mIndTevStage[4];
-    /* 0x90 */ u32 mTevRegOffset;
-};  // Size: 0x94
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DTevBlock2 : public J3DTevBlock {
-public:
-    J3DTevBlock2() {
-        initialize();
-    }
-    /* 80317810 */ void initialize();
-
-    /* 803206AC */ virtual void reset(J3DTevBlock*);
-    /* 8031AFA4 */ virtual void load();
-    /* 8031D3D0 */ virtual void diffTexNo();
-    /* 8031D434 */ virtual void diffTevReg();
-    /* 8031D694 */ virtual void diffTexCoordScale();
-    /* 8031D4D0 */ virtual void diffTevStage();
-    /* 8031D5E4 */ virtual void diffTevStageIndirect();
-    /* 8031C6A8 */ virtual void patch();
-    /* 8031C3F8 */ virtual void patchTexNo();
-    /* 8031C48C */ virtual void patchTevReg();
-    /* 8031C558 */ virtual void patchTexNoAndTexCoordScale();
-    /* 803223AC */ virtual void ptrToIndex() {}
-    /* 803223B0 */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
-    /* 803223D4 */ virtual u32 getType() { return 'TVB2'; }
-    /* 80317BC4 */ virtual s32 countDLSize();
-    /* 803223F0 */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
-    /* 803223E0 */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 80322404 */ virtual u16 getTexNo(u32 idx) const {
-        J3D_ASSERT(1730, idx < 2, "Error : range over.");
-        return mTexNo[idx];
-    }
-    /* 80322428 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
-    /* 80322414 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
-    /* 8032243C */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
-    /* 8032247C */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) { mTevColor[idx] = *color; }
-    /* 80322450 */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) { mTevColor[idx] = color; }
-    /* 803224A8 */ virtual J3DGXColorS10* getTevColor(u32 idx) { return &mTevColor[idx]; }
-    /* 803224E8 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) { mTevKColor[idx] = *color; }
-    /* 803224BC */ virtual void setTevKColor(u32 idx, J3DGXColor color) { mTevKColor[idx] = color; }
-    /* 80322514 */ virtual J3DGXColor* getTevKColor(u32 idx) { return &mTevKColor[idx]; }
-    /* 80322534 */ virtual void setTevKColorSel(u32 idx, u8 const* sel) { mTevKColorSel[idx] = *sel; }
-    /* 80322528 */ virtual void setTevKColorSel(u32 idx, u8 sel) { mTevKColorSel[idx] = sel; }
-    /* 80322544 */ virtual u8 getTevKColorSel(u32 idx) { return mTevKColorSel[idx]; }
-    /* 8032255C */ virtual void setTevKAlphaSel(u32 idx, u8 const* sel) { mTevKAlphaSel[idx] = *sel; }
-    /* 80322550 */ virtual void setTevKAlphaSel(u32 idx, u8 sel) { mTevKAlphaSel[idx] = sel; }
-    /* 8032256C */ virtual u8 getTevKAlphaSel(u32 idx) { return mTevKAlphaSel[idx]; }
-    /* 80322580 */ virtual void setTevStageNum(u8 const* num) { mTevStageNum = *num; }
-    /* 80322578 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
-    /* 8032258C */ virtual u8 getTevStageNum() const { return mTevStageNum; }
-    /* 803225D0 */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) { mTevStage[idx] = *stage; }
-    /* 80322594 */ virtual void setTevStage(u32 idx, J3DTevStage stage) { mTevStage[idx] = stage; }
-    /* 8032260C */ virtual J3DTevStage* getTevStage(u32 idx) { return &mTevStage[idx]; }
-    /* 80322658 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo const* info) { mTevStage[idx].setTevSwapModeInfo(*info); }
-    /* 80322620 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo info) { mTevStage[idx].setTevSwapModeInfo(info); }
-    /* 803226A0 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable const* table) { mTevSwapModeTable[idx] = *table; }
-    /* 80322690 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable table) { mTevSwapModeTable[idx] = table; }
-    /* 803226B0 */ virtual J3DTevSwapModeTable* getTevSwapModeTable(u32 idx) { return &mTevSwapModeTable[idx]; }
-    /* 803226D4 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) { mIndTevStage[idx] = *stage; }
-    /* 803226C0 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) { mIndTevStage[idx] = stage; }
-    /* 803226E8 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) { return &mIndTevStage[idx]; }
-    /* 803226FC */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
-    /* 80322704 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
-    /* 8032270C */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
-    /* 80322714 */ virtual ~J3DTevBlock2() {}
-
-    /* 0x08 */ u16 mTexNo[2];
-    /* 0x0C */ J3DTevOrder mTevOrder[2];
-    /* 0x14 */ J3DGXColorS10 mTevColor[4];
-    /* 0x34 */ u8 mTevStageNum;
-    /* 0x35 */ J3DTevStage mTevStage[2];
-    /* 0x45 */ J3DGXColor mTevKColor[4];
-    /* 0x55 */ u8 mTevKColorSel[2];
-    /* 0x57 */ u8 mTevKAlphaSel[2];
-    /* 0x59 */ J3DTevSwapModeTable mTevSwapModeTable[4];
-    /* 0x60 */ J3DIndTevStage mIndTevStage[2];
-    /* 0x68 */ u32 mTevRegOffset;
-};  // Size: 0x6C
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DTevBlock16 : public J3DTevBlock {
-public:
-    J3DTevBlock16() {
-        initialize();
-    }
-    /* 80317A00 */ void initialize();
-
-    /* 80320E24 */ virtual void reset(J3DTevBlock*);
-    /* 8031BA04 */ virtual void load();
-    /* 8031DB14 */ virtual void diffTexNo();
-    /* 8031DB78 */ virtual void diffTevReg();
-    /* 8031DDD8 */ virtual void diffTexCoordScale();
-    /* 8031DC14 */ virtual void diffTevStage();
-    /* 8031DD28 */ virtual void diffTevStageIndirect();
-    /* 8031CCF8 */ virtual void patch();
-    /* 8031CA1C */ virtual void patchTexNo();
-    /* 8031CAB0 */ virtual void patchTevReg();
-    /* 8031CB7C */ virtual void patchTexNoAndTexCoordScale();
-    /* 8031DED0 */ virtual void ptrToIndex();
-    /* 80321C20 */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
-    /* 80321C44 */ virtual u32 getType() { return 'TV16'; }
-    /* 80317BD4 */ virtual s32 countDLSize();
-    /* 80321C60 */ virtual void setTexNo(u32 idx, u16 const* texNo) { mTexNo[idx] = *texNo; }
-    /* 80321C50 */ virtual void setTexNo(u32 idx, u16 texNo) { mTexNo[idx] = texNo; }
-    /* 80321C74 */ virtual u16 getTexNo(u32 idx) const {
-        J3D_ASSERT(2308, idx < 8, "Error : range over.");
-        return mTexNo[idx];
-    }
-    /* 80321C98 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
-    /* 80321C84 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
-    /* 80321CAC */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
-    /* 80321CEC */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) { mTevColor[idx] = *color; }
-    /* 80321CC0 */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) { mTevColor[idx] = color; }
-    /* 80321D18 */ virtual J3DGXColorS10* getTevColor(u32 idx) { return &mTevColor[idx]; }
-    /* 80321D58 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) { mTevKColor[idx] = *color; }
-    /* 80321D2C */ virtual void setTevKColor(u32 idx, J3DGXColor color) { mTevKColor[idx] = color; }
-    /* 80321D84 */ virtual J3DGXColor* getTevKColor(u32 idx) { return &mTevKColor[idx]; }
-    /* 80321DA4 */ virtual void setTevKColorSel(u32 idx, u8 const* sel) { mTevKColorSel[idx] = *sel; }
-    /* 80321D98 */ virtual void setTevKColorSel(u32 idx, u8 sel) { mTevKColorSel[idx] = sel; }
-    /* 80321DB4 */ virtual u8 getTevKColorSel(u32 idx) { return mTevKColorSel[idx]; }
-    /* 80321DCC */ virtual void setTevKAlphaSel(u32 idx, u8 const* sel) { mTevKAlphaSel[idx] = *sel; }
-    /* 80321DC0 */ virtual void setTevKAlphaSel(u32 idx, u8 sel) { mTevKAlphaSel[idx] = sel; }
-    /* 80321DDC */ virtual u8 getTevKAlphaSel(u32 idx) { return mTevKAlphaSel[idx]; }
-    /* 80321DE8 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
-    /* 80321DF0 */ virtual void setTevStageNum(u8 const* num) { mTevStageNum = *num; }
-    /* 80321DFC */ virtual u8 getTevStageNum() const { return mTevStageNum; }
-    /* 80321E40 */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) { mTevStage[idx] = *stage; }
-    /* 80321E04 */ virtual void setTevStage(u32 idx, J3DTevStage stage) { mTevStage[idx] = stage; }
-    /* 80321E7C */ virtual J3DTevStage* getTevStage(u32 idx) { return &mTevStage[idx]; }
-    /* 80321EC8 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo const* info) { mTevStage[idx].setTevSwapModeInfo(*info); }
-    /* 80321E90 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo info) { mTevStage[idx].setTevSwapModeInfo(info); }
-    /* 80321F10 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable const* table) { mTevSwapModeTable[idx] = *table; }
-    /* 80321F00 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable table) { mTevSwapModeTable[idx] = table; }
-    /* 80321F20 */ virtual J3DTevSwapModeTable* getTevSwapModeTable(u32 idx) { return &mTevSwapModeTable[idx]; }
-    /* 80321F44 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) { mIndTevStage[idx] = *stage; }
-    /* 80321F30 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) { mIndTevStage[idx] = stage; }
-    /* 80321F58 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) { return &mIndTevStage[idx]; }
-    /* 80321F6C */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
-    /* 80321F74 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
-    /* 80321F7C */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
-    /* 80321F84 */ virtual ~J3DTevBlock16() {}
-
-    /* 0x008 */ u16 mTexNo[8];
-    /* 0x018 */ J3DTevOrder mTevOrder[16];
-    /* 0x058 */ u8 mTevStageNum;
-    /* 0x059 */ J3DTevStage mTevStage[16];
-    /* 0x0DA */ J3DGXColorS10 mTevColor[4];
-    /* 0x0FA */ J3DGXColor mTevKColor[4];
-    /* 0x10A */ u8 mTevKColorSel[16];
-    /* 0x11A */ u8 mTevKAlphaSel[16];
-    /* 0x12A */ J3DTevSwapModeTable mTevSwapModeTable[4];
-    /* 0x130 */ J3DIndTevStage mIndTevStage[16];
-    /* 0x170 */ u32 mTevRegOffset;
-};  // Size: 0x174
-
-/**
- * @ingroup jsystem-j3d
- * 
+ *
  */
 class J3DTevBlock1 : public J3DTevBlock {
 public:
@@ -609,24 +804,61 @@ public:
     /* 80322774 */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
     /* 80322798 */ virtual u32 getType() { return 'TVB1'; }
     /* 80317BBC */ virtual s32 countDLSize();
-    /* 803227B4 */ virtual void setTexNo(u32 idx, u16 const* no) { mTexNo[idx] = *no; }
-    /* 803227A4 */ virtual void setTexNo(u32 idx, u16 no) { mTexNo[idx] = no; }
+    /* 803227B4 */ virtual void setTexNo(u32 idx, u16 const* no) {
+        J3D_ASSERT(0x618, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        J3D_ASSERT(0x619, no != 0, "Error : null pointer.");
+        mTexNo[idx] = *no;
+    }
+    /* 803227A4 */ virtual void setTexNo(u32 idx, u16 no) {
+        J3D_ASSERT(0x61f, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        mTexNo[idx] = no;
+    }
     /* 803227C8 */ virtual u16 getTexNo(u32 idx) const {
-        J3D_ASSERT(1574, idx < 1, "Error : range over.");
+        J3D_ASSERT(1574, idx >= 0 && idx < 1, "Error : range over.");
         return mTexNo[idx];
     }
-    /* 803227EC */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) { mTevOrder[idx] = *order; }
-    /* 803227D8 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) { mTevOrder[idx] = order; }
-    /* 80322800 */ virtual J3DTevOrder* getTevOrder(u32 idx) { return &mTevOrder[idx]; }
+    /* 803227EC */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) {
+        J3D_ASSERT(0x62d, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        J3D_ASSERT(0x62e, order != 0, "Error : null pointer.");
+        mTevOrder[idx] = *order;
+    }
+    /* 803227D8 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) {
+        J3D_ASSERT(0x634, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        mTevOrder[idx] = order;
+    }
+    /* 80322800 */ virtual J3DTevOrder* getTevOrder(u32 idx) {
+        J3D_ASSERT(0x639, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        return &mTevOrder[idx];
+    }
     /* 80322818 */ virtual void setTevStageNum(u8 const* num) {}
     /* 80322814 */ virtual void setTevStageNum(u8 num) {}
     /* 8032281C */ virtual u8 getTevStageNum() const { return 1; }
-    /* 80322860 */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) { mTevStage[idx] = *stage; }
-    /* 80322824 */ virtual void setTevStage(u32 idx, J3DTevStage stage) { mTevStage[idx] = stage; }
-    /* 8032289C */ virtual J3DTevStage* getTevStage(u32 idx) { return &mTevStage[idx]; }
-    /* 803228C4 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) { mIndTevStage[idx] = *stage; }
-    /* 803228B0 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) { mIndTevStage[idx] = stage; }
-    /* 803228D8 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) { return &mIndTevStage[idx]; }
+    /* 80322860 */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) {
+        J3D_ASSERT(0x64b, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x64c, stage != 0, "Error : null pointer.");
+        mTevStage[idx] = *stage;
+    }
+    /* 80322824 */ virtual void setTevStage(u32 idx, J3DTevStage stage) {
+        J3D_ASSERT(0x652, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx] = stage;
+    }
+    /* 8032289C */ virtual J3DTevStage* getTevStage(u32 idx) {
+        J3D_ASSERT(0x657, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        return &mTevStage[idx];
+    }
+    /* 803228C4 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) {
+        J3D_ASSERT(0x65e, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        J3D_ASSERT(0x65f, stage != 0, "Error : null pointer.");
+        mIndTevStage[idx] = *stage;
+    }
+    /* 803228B0 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) {
+        J3D_ASSERT(0x665, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        mIndTevStage[idx] = stage;
+    }
+    /* 803228D8 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) {
+        J3D_ASSERT(0x66a, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        return &mIndTevStage[idx];
+    }
     /* 803228EC */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
     /* 803228F4 */ virtual ~J3DTevBlock1() {}
 
@@ -636,6 +868,534 @@ public:
     /* 0x18 */ J3DIndTevStage mIndTevStage[1];
 };  // Size: 0x1C
 
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DTevBlock2 : public J3DTevBlock {
+public:
+    J3DTevBlock2() {
+        initialize();
+    }
+    /* 80317810 */ void initialize();
+
+    /* 803206AC */ virtual void reset(J3DTevBlock*);
+    /* 8031AFA4 */ virtual void load();
+    /* 8031D3D0 */ virtual void diffTexNo();
+    /* 8031D434 */ virtual void diffTevReg();
+    /* 8031D694 */ virtual void diffTexCoordScale();
+    /* 8031D4D0 */ virtual void diffTevStage();
+    /* 8031D5E4 */ virtual void diffTevStageIndirect();
+    /* 8031C6A8 */ virtual void patch();
+    /* 8031C3F8 */ virtual void patchTexNo();
+    /* 8031C48C */ virtual void patchTevReg();
+    /* 8031C558 */ virtual void patchTexNoAndTexCoordScale();
+    /* 803223AC */ virtual void ptrToIndex() {}
+    /* 803223B0 */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
+    /* 803223D4 */ virtual u32 getType() { return 'TVB2'; }
+    /* 80317BC4 */ virtual s32 countDLSize();
+    /* 803223F0 */ virtual void setTexNo(u32 idx, u16 const* texNo) {
+        J3D_ASSERT(0x6b4, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        J3D_ASSERT(0x6b5, texNo != 0, "Error : null pointer.");
+        mTexNo[idx] = *texNo;
+    }
+    /* 803223E0 */ virtual void setTexNo(u32 idx, u16 texNo) {
+        J3D_ASSERT(0x6bb, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        mTexNo[idx] = texNo;
+    }
+    /* 80322404 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(0x6c2, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        return mTexNo[idx];
+    }
+    /* 80322428 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) {
+        J3D_ASSERT(0x6c9, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        J3D_ASSERT(0x6ca, order != 0, "Error : null pointer.");
+        mTevOrder[idx] = *order;
+    }
+    /* 80322414 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) {
+        J3D_ASSERT(0x6d0, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        mTevOrder[idx] = order;
+    }
+    /* 8032243C */ virtual J3DTevOrder* getTevOrder(u32 idx) {
+        J3D_ASSERT(0x6d5, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        return &mTevOrder[idx];
+    }
+    /* 8032247C */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) {
+        J3D_ASSERT(0x6dc, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        J3D_ASSERT(0x6dd, color != 0, "Error : null pointer.");
+        mTevColor[idx] = *color;
+    }
+    /* 80322450 */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) {
+        J3D_ASSERT(0x6e3, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        mTevColor[idx] = color;
+    }
+    /* 803224A8 */ virtual J3DGXColorS10* getTevColor(u32 idx) {
+        J3D_ASSERT(0x6e8, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        return &mTevColor[idx];
+    }
+    /* 803224E8 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x6ef, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        J3D_ASSERT(0x6f0, color != 0, "Error : null pointer.");
+        mTevKColor[idx] = *color;
+    }
+    /* 803224BC */ virtual void setTevKColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x6f6, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        mTevKColor[idx] = color;
+    }
+    /* 80322514 */ virtual J3DGXColor* getTevKColor(u32 idx) {
+        J3D_ASSERT(0x6fb, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        return &mTevKColor[idx];
+    }
+    /* 80322534 */ virtual void setTevKColorSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x702, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        J3D_ASSERT(0x703, sel != 0, "Error : null pointer.");
+        mTevKColorSel[idx] = *sel;
+    }
+    /* 80322528 */ virtual void setTevKColorSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x709, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        mTevKColorSel[idx] = sel;
+    }
+    /* 80322544 */ virtual u8 getTevKColorSel(u32 idx) {
+        J3D_ASSERT(0x70e, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        return mTevKColorSel[idx];
+    }
+    /* 8032255C */ virtual void setTevKAlphaSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x715, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        J3D_ASSERT(0x716, sel != 0, "Error : null pointer.");
+        mTevKAlphaSel[idx] = *sel;
+    }
+    /* 80322550 */ virtual void setTevKAlphaSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x71c, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        mTevKAlphaSel[idx] = sel;
+    }
+    /* 8032256C */ virtual u8 getTevKAlphaSel(u32 idx) {
+        J3D_ASSERT(0x721, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        return mTevKAlphaSel[idx];
+    }
+    /* 80322580 */ virtual void setTevStageNum(u8 const* num) {
+        J3D_ASSERT(0x727, num != 0, "Error : null pointer.");
+        mTevStageNum = *num;
+    }
+    /* 80322578 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
+    /* 8032258C */ virtual u8 getTevStageNum() const { return mTevStageNum; }
+    /* 803225D0 */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) {
+        J3D_ASSERT(0x736, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x737, stage != 0, "Error : null pointer.");
+        mTevStage[idx] = *stage;
+    }
+    /* 80322594 */ virtual void setTevStage(u32 idx, J3DTevStage stage) {
+        J3D_ASSERT(0x73d, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx] = stage;
+    }
+    /* 8032260C */ virtual J3DTevStage* getTevStage(u32 idx) {
+        J3D_ASSERT(0x742, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        return &mTevStage[idx];
+    }
+    /* 80322658 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo const* info) {
+        J3D_ASSERT(0x749, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x74a, info != 0, "Error : null pointer.");
+        mTevStage[idx].setTevSwapModeInfo(*info);
+    }
+    /* 80322620 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo info) {
+        J3D_ASSERT(0x750, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx].setTevSwapModeInfo(info);
+    }
+    /* 803226A0 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable const* table) {
+        J3D_ASSERT(0x757, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        J3D_ASSERT(0x758, table != 0, "Error : null pointer.");
+        mTevSwapModeTable[idx] = *table;
+    }
+    /* 80322690 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable table) {
+        J3D_ASSERT(0x75e, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        mTevSwapModeTable[idx] = table;
+    }
+    /* 803226B0 */ virtual J3DTevSwapModeTable* getTevSwapModeTable(u32 idx) {
+        J3D_ASSERT(0x763, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        return &mTevSwapModeTable[idx];
+    }
+    /* 803226D4 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) {
+        J3D_ASSERT(0x76a, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        J3D_ASSERT(0x76b, stage != 0, "Error : null pointer.");
+        mIndTevStage[idx] = *stage;
+    }
+    /* 803226C0 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) {
+        J3D_ASSERT(0x771, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        mIndTevStage[idx] = stage;
+    }
+    /* 803226E8 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) {
+        J3D_ASSERT(0x776, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        return &mIndTevStage[idx];
+    }
+    /* 803226FC */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
+    /* 80322704 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
+    /* 8032270C */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
+    /* 80322714 */ virtual ~J3DTevBlock2() {}
+
+    /* 0x08 */ u16 mTexNo[2];
+    /* 0x0C */ J3DTevOrder mTevOrder[2];
+    /* 0x14 */ J3DGXColorS10 mTevColor[4];
+    /* 0x34 */ u8 mTevStageNum;
+    /* 0x35 */ J3DTevStage mTevStage[2];
+    /* 0x45 */ J3DGXColor mTevKColor[4];
+    /* 0x55 */ u8 mTevKColorSel[2];
+    /* 0x57 */ u8 mTevKAlphaSel[2];
+    /* 0x59 */ J3DTevSwapModeTable mTevSwapModeTable[4];
+    /* 0x60 */ J3DIndTevStage mIndTevStage[2];
+    /* 0x68 */ u32 mTevRegOffset;
+};  // Size: 0x6C
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DTevBlock4 : public J3DTevBlock {
+public:
+    J3DTevBlock4() {
+        initialize();
+    }
+    /* 803178EC */ void initialize();
+
+    /* 8032098C */ virtual void reset(J3DTevBlock*);
+    /* 8031B4C0 */ virtual void load();
+    /* 8031D758 */ virtual void diffTexNo();
+    /* 8031D7BC */ virtual void diffTevReg();
+    /* 8031DA1C */ virtual void diffTexCoordScale();
+    /* 8031D858 */ virtual void diffTevStage();
+    /* 8031D96C */ virtual void diffTevStageIndirect();
+    /* 8031C9D0 */ virtual void patch();
+    /* 8031C6F4 */ virtual void patchTexNo();
+    /* 8031C788 */ virtual void patchTevReg();
+    /* 8031C854 */ virtual void patchTexNoAndTexCoordScale();
+    /* 80321FE8 */ virtual void ptrToIndex() {}
+    /* 80321FEC */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
+    /* 80322010 */ virtual u32 getType() { return 'TVB4'; }
+    /* 80317BCC */ virtual s32 countDLSize();
+    /* 8032202C */ virtual void setTexNo(u32 idx, u16 const* texNo) {
+        J3D_ASSERT(0x7d5, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        J3D_ASSERT(0x7d6, texNo != 0, "Error : null pointer.");
+        mTexNo[idx] = *texNo;
+    }
+    /* 8032201C */ virtual void setTexNo(u32 idx, u16 texNo) {
+        J3D_ASSERT(0x7dc, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        mTexNo[idx] = texNo;
+    }
+    /* 80322040 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(2019, idx >= 0 && idx < 4, "Error : range over.");
+        return mTexNo[idx];
+    }
+    /* 80322064 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) {
+        J3D_ASSERT(0x7ea, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        J3D_ASSERT(0x7eb, order != 0, "Error : null pointer.");
+        mTevOrder[idx] = *order;
+    }
+    /* 80322050 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) {
+        J3D_ASSERT(0x7f1, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        mTevOrder[idx] = order;
+    }
+    /* 80322078 */ virtual J3DTevOrder* getTevOrder(u32 idx) {
+        J3D_ASSERT(0x7f6, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        return &mTevOrder[idx];
+    }
+    /* 803220B8 */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) {
+        J3D_ASSERT(0x7fd, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        J3D_ASSERT(0x7fe, color != 0, "Error : null pointer.");
+        mTevColor[idx] = *color;
+    }
+    /* 8032208C */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) {
+        J3D_ASSERT(0x804, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        mTevColor[idx] = color;
+    }
+    /* 803220E4 */ virtual J3DGXColorS10* getTevColor(u32 idx) {
+        J3D_ASSERT(0x809, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        return &mTevColor[idx];
+    }
+    /* 80322124 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x810, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        J3D_ASSERT(0x811, color != 0, "Error : null pointer.");
+        mTevKColor[idx] = *color;
+    }
+    /* 803220F8 */ virtual void setTevKColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x817, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        mTevKColor[idx] = color;
+    }
+    /* 80322150 */ virtual J3DGXColor* getTevKColor(u32 idx) {
+        J3D_ASSERT(0x81c, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        return &mTevKColor[idx];
+    }
+    /* 80322170 */ virtual void setTevKColorSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x823, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        J3D_ASSERT(0x824, sel != 0, "Error : null pointer.");
+        mTevKColorSel[idx] = *sel;
+    }
+    /* 80322164 */ virtual void setTevKColorSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x82a, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        mTevKColorSel[idx] = sel;
+    }
+    /* 80322180 */ virtual u8 getTevKColorSel(u32 idx) {
+        J3D_ASSERT(0x82f, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        return mTevKColorSel[idx];
+    }
+    /* 80322198 */ virtual void setTevKAlphaSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x836, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        J3D_ASSERT(0x837, sel != 0, "Error : null pointer.");
+        mTevKAlphaSel[idx] = *sel;
+    }
+    /* 8032218C */ virtual void setTevKAlphaSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x83d, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        mTevKAlphaSel[idx] = sel;
+    }
+    /* 803221A8 */ virtual u8 getTevKAlphaSel(u32 idx) {
+        J3D_ASSERT(0x842, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        return mTevKAlphaSel[idx];
+    }
+    /* 803221BC */ virtual void setTevStageNum(u8 const* num) {
+        J3D_ASSERT(0x848, num != 0, "Error : null pointer.");
+        mTevStageNum = *num;
+    }
+    /* 803221B4 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
+    /* 803221C8 */ virtual u8 getTevStageNum() const { return mTevStageNum; }
+    /* 8032220C */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) {
+        J3D_ASSERT(0x857, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x858, stage != 0, "Error : null pointer.");
+        mTevStage[idx] = *stage;
+    }
+    /* 803221D0 */ virtual void setTevStage(u32 idx, J3DTevStage stage) {
+        J3D_ASSERT(0x85e, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx] = stage;
+    }
+    /* 80322248 */ virtual J3DTevStage* getTevStage(u32 idx) {
+        J3D_ASSERT(0x863, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        return &mTevStage[idx];
+    }
+    /* 80322294 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo const* info) {
+        J3D_ASSERT(0x86a, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x86b, info != 0, "Error : null pointer.");
+        mTevStage[idx].setTevSwapModeInfo(*info);
+    }
+    /* 8032225C */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo info) {
+        J3D_ASSERT(0x871, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx].setTevSwapModeInfo(info);
+    }
+    /* 803222DC */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable const* table) {
+        J3D_ASSERT(0x878, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        J3D_ASSERT(0x879, table != 0, "Error : null pointer.");
+        mTevSwapModeTable[idx] = *table;
+    }
+    /* 803222CC */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable table) {
+        J3D_ASSERT(0x87f, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        mTevSwapModeTable[idx] = table;
+    }
+    /* 803222EC */ virtual J3DTevSwapModeTable* getTevSwapModeTable(u32 idx) {
+        J3D_ASSERT(0x884, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        return &mTevSwapModeTable[idx];
+    }
+    /* 80322310 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) {
+        J3D_ASSERT(0x88b, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        J3D_ASSERT(0x88c, stage != 0, "Error : null pointer.");
+        mIndTevStage[idx] = *stage;
+    }
+    /* 803222FC */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) {
+        J3D_ASSERT(0x892, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        mIndTevStage[idx] = stage;
+    }
+    /* 80322324 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) {
+        J3D_ASSERT(0x897, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        return &mIndTevStage[idx];
+    }
+    /* 80322338 */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
+    /* 80322340 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
+    /* 80322348 */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
+    /* 80322350 */ virtual ~J3DTevBlock4() {}
+
+    /* 0x08 */ u16 mTexNo[4];
+    /* 0x10 */ J3DTevOrder mTevOrder[4];
+    /* 0x20 */ u8 mTevStageNum;
+    /* 0x21 */ J3DTevStage mTevStage[4];
+    /* 0x42 */ J3DGXColorS10 mTevColor[4];
+    /* 0x62 */ J3DGXColor mTevKColor[4];
+    /* 0x72 */ u8 mTevKColorSel[4];
+    /* 0x76 */ u8 mTevKAlphaSel[4];
+    /* 0x7A */ J3DTevSwapModeTable mTevSwapModeTable[4];
+    /* 0x80 */ J3DIndTevStage mIndTevStage[4];
+    /* 0x90 */ u32 mTevRegOffset;
+};  // Size: 0x94
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DTevBlock16 : public J3DTevBlock {
+public:
+    J3DTevBlock16() {
+        initialize();
+    }
+    /* 80317A00 */ void initialize();
+
+    /* 80320E24 */ virtual void reset(J3DTevBlock*);
+    /* 8031BA04 */ virtual void load();
+    /* 8031DB14 */ virtual void diffTexNo();
+    /* 8031DB78 */ virtual void diffTevReg();
+    /* 8031DDD8 */ virtual void diffTexCoordScale();
+    /* 8031DC14 */ virtual void diffTevStage();
+    /* 8031DD28 */ virtual void diffTevStageIndirect();
+    /* 8031CCF8 */ virtual void patch();
+    /* 8031CA1C */ virtual void patchTexNo();
+    /* 8031CAB0 */ virtual void patchTevReg();
+    /* 8031CB7C */ virtual void patchTexNoAndTexCoordScale();
+    /* 8031DED0 */ virtual void ptrToIndex();
+    /* 80321C20 */ virtual void indexToPtr() { indexToPtr_private(mTexNoOffset); }
+    /* 80321C44 */ virtual u32 getType() { return 'TV16'; }
+    /* 80317BD4 */ virtual s32 countDLSize();
+    /* 80321C60 */ virtual void setTexNo(u32 idx, u16 const* texNo) {
+        J3D_ASSERT(0x8f6, idx >= 0 && idx < ARRAY_SIZE(mTexNo), "Error : range over.");
+        J3D_ASSERT(0x8f7, texNo != 0, "Error : null pointer.");
+        mTexNo[idx] = *texNo;
+    }
+    /* 80321C50 */ virtual void setTexNo(u32 idx, u16 texNo) {
+        J3D_ASSERT(0x8fd, idx >= 0 && idx < 8, "Error : range over.");
+        mTexNo[idx] = texNo;
+    }
+    /* 80321C74 */ virtual u16 getTexNo(u32 idx) const {
+        J3D_ASSERT(2308, idx >= 0 && idx < 8, "Error : range over.");
+        return mTexNo[idx];
+    }
+    /* 80321C98 */ virtual void setTevOrder(u32 idx, J3DTevOrder const* order) {
+        J3D_ASSERT(0x90b, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        J3D_ASSERT(0x90c, order != 0, "Error : null pointer.");
+        mTevOrder[idx] = *order;
+    }
+    /* 80321C84 */ virtual void setTevOrder(u32 idx, J3DTevOrder order) {
+        J3D_ASSERT(0x912, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        mTevOrder[idx] = order;
+    }
+    /* 80321CAC */ virtual J3DTevOrder* getTevOrder(u32 idx) {
+        J3D_ASSERT(0x917, idx >= 0 && idx < ARRAY_SIZE(mTevOrder), "Error : range over.");
+        return &mTevOrder[idx];
+    }
+    /* 80321CEC */ virtual void setTevColor(u32 idx, J3DGXColorS10 const* color) {
+        J3D_ASSERT(0x91e, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        J3D_ASSERT(0x91f, color != 0, "Error : null pointer.");
+        mTevColor[idx] = *color;
+    }
+    /* 80321CC0 */ virtual void setTevColor(u32 idx, J3DGXColorS10 color) {
+        J3D_ASSERT(0x925, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        mTevColor[idx] = color;
+    }
+    /* 80321D18 */ virtual J3DGXColorS10* getTevColor(u32 idx) {
+        J3D_ASSERT(0x92a, idx >= 0 && idx < ARRAY_SIZE(mTevColor), "Error : range over.");
+        return &mTevColor[idx];
+    }
+    /* 80321D58 */ virtual void setTevKColor(u32 idx, J3DGXColor const* color) {
+        J3D_ASSERT(0x931, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        J3D_ASSERT(0x932, color != 0, "Error : null pointer.");
+        mTevKColor[idx] = *color;
+    }
+    /* 80321D2C */ virtual void setTevKColor(u32 idx, J3DGXColor color) {
+        J3D_ASSERT(0x938, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        mTevKColor[idx] = color;
+    }
+    /* 80321D84 */ virtual J3DGXColor* getTevKColor(u32 idx) {
+        J3D_ASSERT(0x93d, idx >= 0 && idx < ARRAY_SIZE(mTevKColor), "Error : range over.");
+        return &mTevKColor[idx];
+    }
+    /* 80321DA4 */ virtual void setTevKColorSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x944, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        J3D_ASSERT(0x945, sel != 0, "Error : null pointer.");
+        mTevKColorSel[idx] = *sel;
+    }
+    /* 80321D98 */ virtual void setTevKColorSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x94b, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        mTevKColorSel[idx] = sel;
+    }
+    /* 80321DB4 */ virtual u8 getTevKColorSel(u32 idx) {
+        J3D_ASSERT(0x950, idx >= 0 && idx < ARRAY_SIZE(mTevKColorSel), "Error : range over.");
+        return mTevKColorSel[idx];
+    }
+    /* 80321DCC */ virtual void setTevKAlphaSel(u32 idx, u8 const* sel) {
+        J3D_ASSERT(0x957, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        J3D_ASSERT(0x958, sel != 0, "Error : null pointer.");
+        mTevKAlphaSel[idx] = *sel;
+    }
+    /* 80321DC0 */ virtual void setTevKAlphaSel(u32 idx, u8 sel) {
+        J3D_ASSERT(0x95e, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        mTevKAlphaSel[idx] = sel;
+    }
+    /* 80321DDC */ virtual u8 getTevKAlphaSel(u32 idx) {
+        J3D_ASSERT(0x963, idx >= 0 && idx < ARRAY_SIZE(mTevKAlphaSel), "Error : range over.");
+        return mTevKAlphaSel[idx];
+    }
+    /* 80321DF0 */ virtual void setTevStageNum(u8 const* num) {
+        J3D_ASSERT(0x969, num != 0, "Error : null pointer.");
+        mTevStageNum = *num;
+    }
+    /* 80321DE8 */ virtual void setTevStageNum(u8 num) { mTevStageNum = num; }
+    /* 80321DFC */ virtual u8 getTevStageNum() const { return mTevStageNum; }
+    /* 80321E40 */ virtual void setTevStage(u32 idx, J3DTevStage const* stage) {
+        J3D_ASSERT(0x978, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x979, stage != 0, "Error : null pointer.");
+        mTevStage[idx] = *stage;
+    }
+    /* 80321E04 */ virtual void setTevStage(u32 idx, J3DTevStage stage) {
+        J3D_ASSERT(0x97f, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx] = stage;
+    }
+    /* 80321E7C */ virtual J3DTevStage* getTevStage(u32 idx) {
+        J3D_ASSERT(0x984, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        return &mTevStage[idx];
+    }
+    /* 80321EC8 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo const* info) {
+        J3D_ASSERT(0x98b, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        J3D_ASSERT(0x98c, info != 0, "Error : null pointer.");
+        mTevStage[idx].setTevSwapModeInfo(*info);
+    }
+    /* 80321E90 */ virtual void setTevSwapModeInfo(u32 idx, J3DTevSwapModeInfo info) {
+        J3D_ASSERT(0x992, idx >= 0 && idx < ARRAY_SIZE(mTevStage), "Error : range over.");
+        mTevStage[idx].setTevSwapModeInfo(info);
+    }
+    /* 80321F10 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable const* table) {
+        J3D_ASSERT(0x999, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        J3D_ASSERT(0x99a, table != 0, "Error : null pointer.");
+        mTevSwapModeTable[idx] = *table;
+    }
+    /* 80321F00 */ virtual void setTevSwapModeTable(u32 idx, J3DTevSwapModeTable table) {
+        J3D_ASSERT(0x9a0, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        mTevSwapModeTable[idx] = table;
+    }
+    /* 80321F20 */ virtual J3DTevSwapModeTable* getTevSwapModeTable(u32 idx) {
+        J3D_ASSERT(0x9a5, idx >= 0 && idx < ARRAY_SIZE(mTevSwapModeTable), "Error : range over.");
+        return &mTevSwapModeTable[idx];
+    }
+    /* 80321F44 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage const* stage) {
+        J3D_ASSERT(0x9ac, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        J3D_ASSERT(0x9ad, stage != 0, "Error : null pointer.");
+        mIndTevStage[idx] = *stage;
+    }
+    /* 80321F30 */ virtual void setIndTevStage(u32 idx, J3DIndTevStage stage) {
+        J3D_ASSERT(0x9b3, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        mIndTevStage[idx] = stage;
+    }
+    /* 80321F58 */ virtual J3DIndTevStage* getIndTevStage(u32 idx) {
+        J3D_ASSERT(0x9b8, idx >= 0 && idx < ARRAY_SIZE(mIndTevStage), "Error : range over.");
+        return &mIndTevStage[idx];
+    }
+    /* 80321F6C */ virtual u32 getTexNoOffset() const { return mTexNoOffset; }
+    /* 80321F74 */ virtual u32 getTevRegOffset() const { return mTevRegOffset; }
+    /* 80321F7C */ virtual void setTevRegOffset(u32 offset) { mTevRegOffset = offset; }
+    /* 80321F84 */ virtual ~J3DTevBlock16() {}
+
+    /* 0x008 */ u16 mTexNo[8];
+    /* 0x018 */ J3DTevOrder mTevOrder[16];
+    /* 0x058 */ u8 mTevStageNum;
+    /* 0x059 */ J3DTevStage mTevStage[16];
+    /* 0x0DA */ J3DGXColorS10 mTevColor[4];
+    /* 0x0FA */ J3DGXColor mTevKColor[4];
+    /* 0x10A */ u8 mTevKColorSel[16];
+    /* 0x11A */ u8 mTevKAlphaSel[16];
+    /* 0x12A */ J3DTevSwapModeTable mTevSwapModeTable[4];
+    /* 0x130 */ J3DIndTevStage mIndTevStage[16];
+    /* 0x170 */ u32 mTevRegOffset;
+};  // Size: 0x174
+
 extern const u16 j3dDefaultZModeID;
 
 inline u16 calcZModeID(u8 param_0, u8 param_1, u8 param_2) {
@@ -644,7 +1404,7 @@ inline u16 calcZModeID(u8 param_0, u8 param_1, u8 param_2) {
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DZModeInfo {
     /* 0x0 */ u8 field_0x0;
@@ -657,11 +1417,16 @@ extern u8 j3dZModeTable[96];
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DZMode {
     J3DZMode() : mZModeID(j3dDefaultZModeID) {}
     J3DZMode(J3DZModeInfo const& info) : mZModeID(calcZModeID(info.field_0x0, info.field_0x1, info.field_0x2)) {}
+
+    J3DZMode& operator=(u16 zModeID) {
+        mZModeID = zModeID;
+        return *this;
+    }
 
     void setZModeInfo(const J3DZModeInfo& info) {
         mZModeID = calcZModeID(info.field_0x0, info.field_0x1, info.field_0x2);
@@ -683,16 +1448,16 @@ struct J3DZMode {
         J3DGDSetZMode(getCompareEnable(), GXCompare(getFunc()), getUpdateEnable());
     }
 
-    u8 getCompareEnable() const { return j3dZModeTable[mZModeID * 3 + 0]; }
-    u8 getFunc() const { return j3dZModeTable[mZModeID * 3 + 1]; }
-    u8 getUpdateEnable() const { return j3dZModeTable[mZModeID * 3 + 2]; }
+    u8 getCompareEnable() const { return *(&j3dZModeTable[mZModeID * 3] + 0); }
+    u8 getFunc() const { return *(&j3dZModeTable[mZModeID * 3] + 1); }
+    u8 getUpdateEnable() const { return *(&j3dZModeTable[mZModeID * 3] + 2); }
 
     /* 0x0 */ u16 mZModeID;
 };
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DBlendInfo {
     void operator=(J3DBlendInfo const& other) {
@@ -708,7 +1473,7 @@ extern const J3DBlendInfo j3dDefaultBlendInfo;
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DBlend : public J3DBlendInfo {
     J3DBlend() : J3DBlendInfo(j3dDefaultBlendInfo) {}
@@ -723,8 +1488,8 @@ struct J3DBlend : public J3DBlendInfo {
     GXBlendFactor getDstFactor() const { return (GXBlendFactor)mDstFactor; }
     GXLogicOp getLogicOp() const { return (GXLogicOp)mOp; }
 
-    void load(u8 ditherEnable) {
-        J3DGDSetBlendMode(getBlendMode(), getSrcFactor(), getDstFactor(), getLogicOp(), ditherEnable);
+    void load(u8 ditherEnable) const {
+        J3DGDSetBlendMode((GXBlendMode)mType, (GXBlendFactor)mSrcFactor, (GXBlendFactor)mDstFactor, (GXLogicOp)mOp, ditherEnable);
     }
 
     void setBlendInfo(const J3DBlendInfo& i_blendInfo) { *static_cast<J3DBlendInfo*>(this) = i_blendInfo; }
@@ -734,14 +1499,14 @@ extern const J3DFogInfo j3dDefaultFogInfo;
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DFog : public J3DFogInfo {
     J3DFog() { *(J3DFogInfo*)this = j3dDefaultFogInfo; }
     ~J3DFog() {}
     J3DFogInfo* getFogInfo() { return this; }
     void setFogInfo(J3DFogInfo info) { *(J3DFogInfo*)this = info; }
-    void setFogInfo(J3DFogInfo* info) { *(J3DFogInfo*)this = *info; }
+    void setFogInfo(const J3DFogInfo* info) { *(J3DFogInfo*)this = *info; }
 
     void load() const {
         J3DGDSetFog(GXFogType(mType), mStartZ, mEndZ, mNearZ, mFarZ, mColor);
@@ -751,7 +1516,7 @@ struct J3DFog : public J3DFogInfo {
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DAlphaCompInfo {
     /* 0x0 */ u8 mComp0;
@@ -772,7 +1537,7 @@ inline u16 calcAlphaCmpID(u8 comp0, u8 op, u8 comp1) {
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DAlphaComp {
     J3DAlphaComp() : mID(j3dDefaultAlphaCmpID), mRef0(0), mRef1(0) {}
@@ -784,20 +1549,28 @@ struct J3DAlphaComp {
         mRef1 = info.mRef1;
     }
 
+    J3DAlphaComp& operator=(u16 id) { mID = id; }
+
+    J3DAlphaComp& operator=(const J3DAlphaComp& rhs) {
+        mID = rhs.mID;
+        mRef0 = rhs.mRef0;
+        mRef1 = rhs.mRef1;
+    }
+
     void setAlphaCompInfo(const J3DAlphaCompInfo& info) {
         mRef0 = info.mRef0;
         mRef1 = info.mRef1;
         mID = calcAlphaCmpID(info.mComp0, info.mOp, info.mComp1);
     }
 
-    GXCompare getComp0() const { return GXCompare(j3dAlphaCmpTable[mID * 3]); }
-    GXAlphaOp getOp() const { return GXAlphaOp(j3dAlphaCmpTable[mID * 3 + 1]); }
-    GXCompare getComp1() const { return GXCompare(j3dAlphaCmpTable[mID * 3 + 2]); }
+    GXCompare getComp0() const { return GXCompare(*(&j3dAlphaCmpTable[mID * 3] + 0)); }
+    GXAlphaOp getOp() const { return GXAlphaOp(*(&j3dAlphaCmpTable[mID * 3] + 1)); }
+    GXCompare getComp1() const { return GXCompare(*(&j3dAlphaCmpTable[mID * 3] + 2)); }
     u8 getRef0() const { return mRef0; }
     u8 getRef1() const { return mRef1; }
 
-    void load() {
-        J3DGDSetAlphaCompare(getComp0(), getRef0(), getOp(), getComp1(), getRef1());
+    void load() const {
+        J3DGDSetAlphaCompare(getComp0(), mRef0, getOp(), getComp1(), mRef1);
     }
 
     /* 0x00 */ u16 mID;
@@ -807,7 +1580,183 @@ struct J3DAlphaComp {
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
+ */
+struct J3DIndTexOrderInfo {
+    /* 0x0 */ u8 mCoord;
+    /* 0x1 */ u8 mMap;
+    /* 0x2 */ u8 field_0x2;
+    /* 0x3 */ u8 field_0x3;
+};  // Size: 0x04
+
+extern const J3DIndTexOrderInfo j3dDefaultIndTexOrderNull;
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+struct J3DIndTexOrder : public J3DIndTexOrderInfo {
+    /* 8000E128 */ J3DIndTexOrder() : J3DIndTexOrderInfo(j3dDefaultIndTexOrderNull) {}
+    J3DIndTexOrder& operator=(J3DIndTexOrder const& other) {
+        *(u32*)this = *(u32*)&other;
+    }
+    J3DIndTexOrder(J3DIndTexOrderInfo const& info) : J3DIndTexOrderInfo(info) {}
+    u8 getMap() const { return (GXTexMapID)mMap; }
+    u8 getCoord() const { return (GXTexCoordID)mCoord; }
+};  // Size: 0x04
+
+extern J3DIndTexMtxInfo const j3dDefaultIndTexMtxInfo;
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+struct J3DIndTexMtx : public J3DIndTexMtxInfo {
+    /* 8000E0F0 */ J3DIndTexMtx() { *(J3DIndTexMtxInfo*)this = j3dDefaultIndTexMtxInfo; }
+    J3DIndTexMtx(J3DIndTexMtxInfo const& info) { *(J3DIndTexMtxInfo*)this = info; }
+    /* 8000E064 */ ~J3DIndTexMtx() {}
+    void load(u32 param_1) const {
+        J3DGDSetIndTexMtx((GXIndTexMtxID)(param_1 + 1), (Mtx3P)field_0x0, field_0x18);
+    }
+};  // Size: 0x1C
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+struct J3DIndTexCoordScaleInfo {
+    /* 0x0 */ u8 mScaleS;
+    /* 0x1 */ u8 mScaleT;
+    /* 0x2 */ u8 field_0x2;
+    /* 0x3 */ u8 field_0x3;
+};  // Size: 0x4
+
+extern const J3DIndTexCoordScaleInfo j3dDefaultIndTexCoordScaleInfo;
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+struct J3DIndTexCoordScale : public J3DIndTexCoordScaleInfo {
+    /* 8000E0E4 */ J3DIndTexCoordScale() : J3DIndTexCoordScaleInfo(j3dDefaultIndTexCoordScaleInfo) {}
+    J3DIndTexCoordScale(J3DIndTexCoordScaleInfo const& info) : J3DIndTexCoordScaleInfo(info) {}
+    /* 8000E024 */ ~J3DIndTexCoordScale() {}
+    u8 getScaleS() { return mScaleS; }
+    u8 getScaleT() { return mScaleT; }
+
+    J3DIndTexCoordScale& operator=(const J3DIndTexCoordScale& other) {
+        //__memcpy(this, &other, sizeof(J3DIndTexCoordScaleInfo));
+        *(u32*)this = *(u32*)&other;
+        return *this;
+    }
+};  // Size: 0x4
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DIndBlock {
+public:
+    /* 8031734C */ virtual void reset(J3DIndBlock*) {}
+    virtual void diff(u32) = 0;
+    virtual void load() = 0;
+    /* 80317314 */ virtual s32 countDLSize() { return 0; }
+    virtual u32 getType() = 0;
+    /* 8000E0A0 */ virtual void setIndTexStageNum(u8) {}
+    /* 8000DF7C */ virtual u8 getIndTexStageNum() const { return 0; }
+    /* 80317410 */ virtual void setIndTexOrder(u32, J3DIndTexOrder) {}
+    /* 8031740C */ virtual void setIndTexOrder(u32, J3DIndTexOrder const*) {}
+    /* 8000DF74 */ virtual J3DIndTexOrder* getIndTexOrder(u32) { return NULL; }
+    /* 80317414 */ virtual void setIndTexMtx(u32, J3DIndTexMtx const*) {}
+    /* 8000E060 */ virtual void setIndTexMtx(u32, J3DIndTexMtx) {}
+    /* 8000DF6C */ virtual J3DIndTexMtx* getIndTexMtx(u32) { return NULL; }
+    /* 80317418 */ virtual void setIndTexCoordScale(u32, J3DIndTexCoordScale const*) {}
+    /* 8000E020 */ virtual void setIndTexCoordScale(u32, J3DIndTexCoordScale) {}
+    /* 8000DF64 */ virtual J3DIndTexCoordScale* getIndTexCoordScale(u32) { return NULL; }
+    /* 8031726C */ virtual ~J3DIndBlock() {}
+};
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DIndBlockNull : public J3DIndBlock {
+public:
+    /* 80317398 */ virtual void diff(u32) {}
+    /* 8031739C */ virtual void load() {}
+    /* 803173A0 */ virtual void reset(J3DIndBlock*) {}
+    /* 803173A4 */ virtual u32 getType() { return 'IBLN'; }
+    /* 803173B0 */ virtual ~J3DIndBlockNull() {}
+};
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DIndBlockFull : public J3DIndBlock {
+public:
+    J3DIndBlockFull() {
+        initialize();
+    }
+    /* 80317B28 */ void initialize();
+
+    /* 80317BDC */ virtual s32 countDLSize();
+    /* 803210B0 */ virtual void reset(J3DIndBlock*);
+    /* 8031E328 */ virtual void diff(u32);
+    /* 8031E12C */ virtual void load();
+    /* 80323390 */ virtual u32 getType() { return 'IBLF'; }
+    /* 8032339C */ virtual void setIndTexStageNum(u8 num) { mIndTexStageNum = num; }
+    /* 803233A4 */ virtual u8 getIndTexStageNum() const { return mIndTexStageNum; }
+    /* 803233C0 */ virtual void setIndTexOrder(u32 idx, J3DIndTexOrder const* order) {
+        J3D_ASSERT(0xa94, order != 0, "Error : null pointer.");
+        J3D_ASSERT(0xa95, idx >= 0 && idx < ARRAY_SIZE(mIndTexOrder), "Error : range over.");
+        mIndTexOrder[idx] = *order;
+    }
+    /* 803233AC */ virtual void setIndTexOrder(u32 idx, J3DIndTexOrder order) {
+        J3D_ASSERT(0xa9b, idx >= 0 && idx < ARRAY_SIZE(mIndTexOrder), "Error : range over.");
+        mIndTexOrder[idx] = order;
+    }
+    /* 803233D4 */ virtual J3DIndTexOrder* getIndTexOrder(u32 idx) {
+        J3D_ASSERT(0xaa0, idx >= 0 && idx < ARRAY_SIZE(mIndTexOrder), "Error : range over.");
+        return &mIndTexOrder[idx];
+    }
+    /* 8032341C */ virtual void setIndTexMtx(u32 idx, J3DIndTexMtx const* mtx) {
+        J3D_ASSERT(0xaa7, mtx != 0, "Error : null pointer.");
+        J3D_ASSERT(0xaa8, idx >= 0 && idx < ARRAY_SIZE(mIndTexMtx), "Error : range over.");
+        mIndTexMtx[idx] = *mtx;
+    }
+    /* 803233E8 */ virtual void setIndTexMtx(u32 idx, J3DIndTexMtx mtx) {
+        J3D_ASSERT(0xaae, idx >= 0 && idx < ARRAY_SIZE(mIndTexMtx), "Error : range over.");
+        mIndTexMtx[idx] = mtx;
+    }
+    /* 80323450 */ virtual J3DIndTexMtx* getIndTexMtx(u32 idx) {
+        J3D_ASSERT(0xab3, idx >= 0 && idx < ARRAY_SIZE(mIndTexMtx), "Error : range over.");
+        return &mIndTexMtx[idx];
+    }
+    /* 80323478 */ virtual void setIndTexCoordScale(u32 idx, J3DIndTexCoordScale const* scale) {
+        J3D_ASSERT(0xaba, scale != 0, "Error : null pointer.");
+        J3D_ASSERT(0xabb, idx >= 0 && idx < ARRAY_SIZE(mIndTexCoordScale), "Error : range over.");
+        mIndTexCoordScale[idx] = *scale;
+    }
+    /* 80323464 */ virtual void setIndTexCoordScale(u32 idx, J3DIndTexCoordScale scale) {
+        J3D_ASSERT(0xac1, idx >= 0 && idx < ARRAY_SIZE(mIndTexCoordScale), "Error : range over.");
+        mIndTexCoordScale[idx] = scale;
+    }
+    /* 8032348C */ virtual J3DIndTexCoordScale* getIndTexCoordScale(u32 idx) {
+        J3D_ASSERT(0xac6, idx >= 0 && idx < ARRAY_SIZE(mIndTexCoordScale), "Error : range over.");
+        return &mIndTexCoordScale[idx];
+    }
+    /* 803234A0 */ virtual ~J3DIndBlockFull() {}
+
+    /* 0x04 */ u8 mIndTexStageNum;
+    /* 0x05 */ J3DIndTexOrder mIndTexOrder[4];
+    /* 0x18 */ J3DIndTexMtx mIndTexMtx[3];
+    /* 0x6C */ J3DIndTexCoordScale mIndTexCoordScale[4];
+};  // Size: 0x7C
+
+/**
+ * @ingroup jsystem-j3d
+ *
  */
 class J3DPEBlock {
 public:
@@ -844,7 +1793,7 @@ public:
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DPEBlockNull : public J3DPEBlock {
     /* 803329A0 */ virtual void load() {}
@@ -854,43 +1803,99 @@ struct J3DPEBlockNull : public J3DPEBlock {
 
 /**
  * @ingroup jsystem-j3d
- * 
- */
-class J3DPEBlockXlu : public J3DPEBlock {
-public:
-    /* 8031E98C */ virtual void load();
-    /* 80317BF4 */ virtual s32 countDLSize();
-    /* 80323258 */ virtual u32 getType() { return 'PEXL'; }
-    /* 80323264 */ virtual ~J3DPEBlockXlu() {}
-};
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DPEBlockTexEdge : public J3DPEBlock {
-public:
-    /* 8031E6C8 */ virtual void load();
-    /* 80317BEC */ virtual s32 countDLSize();
-    /* 803232C0 */ virtual u32 getType() { return 'PEED'; }
-    /* 803232CC */ virtual ~J3DPEBlockTexEdge() {}
-};
-
-/**
- * @ingroup jsystem-j3d
- * 
+ *
  */
 class J3DPEBlockOpa : public J3DPEBlock {
 public:
-    /* 8031E408 */ virtual void load();
     /* 80317BE4 */ virtual s32 countDLSize();
+    /* 8031E408 */ virtual void load();
     /* 80323328 */ virtual u32 getType() { return 'PEOP'; }
     /* 80323334 */ virtual ~J3DPEBlockOpa() {}
 };
 
 /**
  * @ingroup jsystem-j3d
- * 
+ *
+ */
+class J3DPEBlockTexEdge : public J3DPEBlock {
+public:
+    /* 80317BEC */ virtual s32 countDLSize();
+    /* 8031E6C8 */ virtual void load();
+    /* 803232C0 */ virtual u32 getType() { return 'PEED'; }
+    /* 803232CC */ virtual ~J3DPEBlockTexEdge() {}
+};
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DPEBlockXlu : public J3DPEBlock {
+public:
+    /* 80317BF4 */ virtual s32 countDLSize();
+    /* 8031E98C */ virtual void load();
+    /* 80323258 */ virtual u32 getType() { return 'PEXL'; }
+    /* 80323264 */ virtual ~J3DPEBlockXlu() {}
+};
+
+/**
+ * @ingroup jsystem-j3d
+ *
+ */
+class J3DPEBlockFogOff : public J3DPEBlock {
+public:
+    J3DPEBlockFogOff() {
+        initialize();
+    }
+    /* 80317B34 */ void initialize();
+
+    /* 803211B4 */ virtual void reset(J3DPEBlock*);
+    /* 8031EC50 */ virtual void load();
+    /* 80321ACC */ virtual void diff(u32 param_0) { if (param_0 & 0x20000000) diffBlend(); };
+    /* 8031F0D8 */ virtual void diffBlend();
+    /* 80317BFC */ virtual s32 countDLSize();
+    /* 80321B00 */ virtual u32 getType() { return 'PEFG'; }
+    /* 80321B28 */ virtual void setAlphaComp(J3DAlphaComp const* alphaComp) {
+        J3D_ASSERT(0xbf9, alphaComp != 0, "Error : null pointer.");
+        mAlphaComp = *alphaComp;
+    }
+    /* 80321B0C */ virtual void setAlphaComp(J3DAlphaComp const& alphaComp) { mAlphaComp = alphaComp; }
+    /* 80321B44 */ virtual J3DAlphaComp* getAlphaComp() { return &mAlphaComp; }
+    /* 80321B58 */ virtual void setBlend(J3DBlend const* blend) {
+        J3D_ASSERT(0xc07, blend != 0, "Error : null pointer.");
+        mBlend = *blend;
+    }
+    /* 80321B4C */ virtual void setBlend(J3DBlend const& blend) { mBlend = blend; }
+    /* 80321B64 */ virtual J3DBlend* getBlend() { return &mBlend; }
+    /* 80321B78 */ virtual void setZMode(J3DZMode const* zMode) {
+        J3D_ASSERT(0xc15, zMode != 0, "Error : null pointer.");
+        mZMode = *zMode;
+    }
+    /* 80321B6C */ virtual void setZMode(J3DZMode zMode) { mZMode = zMode; }
+    /* 80321B84 */ virtual J3DZMode* getZMode() { return &mZMode; }
+    /* 80321B94 */ virtual void setZCompLoc(u8 const* zCompLoc) {
+        J3D_ASSERT(0xc23, zCompLoc != 0, "Error : null pointer.");
+        mZCompLoc = *zCompLoc;
+    }
+    /* 80321B8C */ virtual void setZCompLoc(u8 zCompLoc) { mZCompLoc = zCompLoc; }
+    /* 80321BA0 */ virtual u8 getZCompLoc() const { return mZCompLoc; }
+    /* 80321BB0 */ virtual void setDither(u8 const* dither) {
+        J3D_ASSERT(0xc31, dither != 0, "Error : null pointer.");
+        mDither = *dither;
+    }
+    /* 80321BA8 */ virtual void setDither(u8 dither) { mDither = dither; }
+    /* 80321BBC */ virtual u8 getDither() const { return mDither; }
+    /* 80321BC4 */ virtual ~J3DPEBlockFogOff() {}
+
+    /* 0x04 */ J3DAlphaComp mAlphaComp;
+    /* 0x08 */ J3DBlend mBlend;
+    /* 0x0C */ J3DZMode mZMode;
+    /* 0x0E */ u8 mZCompLoc;
+    /* 0x0F */ u8 mDither;
+};  // Size: 0x10
+
+/**
+ * @ingroup jsystem-j3d
+ *
  */
 class J3DPEBlockFull : public J3DPEBlock {
 public:
@@ -910,19 +1915,34 @@ public:
     /* 8032197C */ virtual void setFog(J3DFog fog) { mFog.setFogInfo(fog.getFogInfo()); }
     /* 80321958 */ virtual void setFog(J3DFog* pFog) { mFog.setFogInfo(pFog->getFogInfo()); }
     /* 803219A0 */ virtual J3DFog* getFog() { return &mFog; }
-    /* 803219C4 */ virtual void setAlphaComp(J3DAlphaComp const* alphaComp) { mAlphaComp = *alphaComp; }
+    /* 803219C4 */ virtual void setAlphaComp(J3DAlphaComp const* alphaComp) {
+        J3D_ASSERT(0xc7d, alphaComp != 0, "Error : null pointer.");
+        mAlphaComp = *alphaComp;
+    }
     /* 803219A8 */ virtual void setAlphaComp(J3DAlphaComp const& alphaComp) { mAlphaComp = alphaComp; }
     /* 803219E0 */ virtual J3DAlphaComp* getAlphaComp() { return &mAlphaComp; }
-    /* 803219F4 */ virtual void setBlend(J3DBlend const* blend) { mBlend = *blend; }
+    /* 803219F4 */ virtual void setBlend(J3DBlend const* blend) {
+        J3D_ASSERT(0xc8b, blend != 0, "Error : null pointer.");
+        mBlend = *blend;
+    }
     /* 803219E8 */ virtual void setBlend(J3DBlend const& blend) { mBlend = blend; }
     /* 80321A00 */ virtual J3DBlend* getBlend() { return &mBlend; }
-    /* 80321A14 */ virtual void setZMode(J3DZMode const* zMode) { mZMode = *zMode; }
+    /* 80321A14 */ virtual void setZMode(J3DZMode const* zMode) {
+        J3D_ASSERT(0xc99, zMode != 0, "Error : null pointer.");
+        mZMode = *zMode;
+    }
     /* 80321A08 */ virtual void setZMode(J3DZMode zMode) { mZMode = zMode; }
     /* 80321A20 */ virtual J3DZMode* getZMode() { return &mZMode; }
-    /* 80321A30 */ virtual void setZCompLoc(u8 const* zCompLoc) { mZCompLoc = *zCompLoc; }
+    /* 80321A30 */ virtual void setZCompLoc(u8 const* zCompLoc) {
+        J3D_ASSERT(0xca7, zCompLoc != 0, "Error : null pointer.");
+        mZCompLoc = *zCompLoc;
+    }
     /* 80321A28 */ virtual void setZCompLoc(u8 zCompLoc) { mZCompLoc = zCompLoc; }
     /* 80321A3C */ virtual u8 getZCompLoc() const { return mZCompLoc; }
-    /* 80321A4C */ virtual void setDither(u8 const* dither) { mDither = *dither; }
+    /* 80321A4C */ virtual void setDither(u8 const* dither) {
+        J3D_ASSERT(0xcb5, dither != 0, "Error : null pointer.");
+        mDither = *dither;
+    }
     /* 80321A44 */ virtual void setDither(u8 dither) { mDither = dither; }
     /* 80321A58 */ virtual u8 getDither() const { return mDither; }
     /* 80321A60 */ virtual u32 getFogOffset() const { return mFogOffset; }
@@ -940,457 +1960,11 @@ public:
 
 /**
  * @ingroup jsystem-j3d
- * 
- */
-class J3DPEBlockFogOff : public J3DPEBlock {
-public:
-    J3DPEBlockFogOff() {
-        initialize();
-    }
-    /* 80317B34 */ void initialize();
-
-    /* 803211B4 */ virtual void reset(J3DPEBlock*);
-    /* 8031EC50 */ virtual void load();
-    /* 80321ACC */ virtual void diff(u32 param_0) { if (param_0 & 0x20000000) diffBlend(); };
-    /* 8031F0D8 */ virtual void diffBlend();
-    /* 80317BFC */ virtual s32 countDLSize();
-    /* 80321B00 */ virtual u32 getType() { return 'PEFG'; }
-    /* 80321B28 */ virtual void setAlphaComp(J3DAlphaComp const* alphaComp) { mAlphaComp = *alphaComp; }
-    /* 80321B0C */ virtual void setAlphaComp(J3DAlphaComp const& alphaComp) { mAlphaComp = alphaComp; }
-    /* 80321B44 */ virtual J3DAlphaComp* getAlphaComp() { return &mAlphaComp; }
-    /* 80321B58 */ virtual void setBlend(J3DBlend const* blend) { mBlend = *blend; }
-    /* 80321B4C */ virtual void setBlend(J3DBlend const& blend) { mBlend = blend; }
-    /* 80321B64 */ virtual J3DBlend* getBlend() { return &mBlend; }
-    /* 80321B78 */ virtual void setZMode(J3DZMode const* zMode) { mZMode = *zMode; }
-    /* 80321B6C */ virtual void setZMode(J3DZMode zMode) { mZMode = zMode; }
-    /* 80321B84 */ virtual J3DZMode* getZMode() { return &mZMode; }
-    /* 80321B94 */ virtual void setZCompLoc(u8 const* zCompLoc) { mZCompLoc = *zCompLoc; }
-    /* 80321B8C */ virtual void setZCompLoc(u8 zCompLoc) { mZCompLoc = zCompLoc; }
-    /* 80321BA0 */ virtual u8 getZCompLoc() const { return mZCompLoc; }
-    /* 80321BB0 */ virtual void setDither(u8 const* dither) { mDither = *dither; }
-    /* 80321BA8 */ virtual void setDither(u8 dither) { mDither = dither; }
-    /* 80321BBC */ virtual u8 getDither() const { return mDither; }
-    /* 80321BC4 */ virtual ~J3DPEBlockFogOff() {}
-
-    /* 0x04 */ J3DAlphaComp mAlphaComp;
-    /* 0x08 */ J3DBlend mBlend;
-    /* 0x0C */ J3DZMode mZMode;
-    /* 0x0E */ u8 mZCompLoc;
-    /* 0x0F */ u8 mDither;
-};  // Size: 0x10
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DIndTexCoordScaleInfo {
-    /* 0x0 */ u8 mScaleS;
-    /* 0x1 */ u8 mScaleT;
-    /* 0x2 */ u8 field_0x2;
-    /* 0x3 */ u8 field_0x3;
-};  // Size: 0x4
-
-extern const J3DIndTexCoordScaleInfo j3dDefaultIndTexCoordScaleInfo;
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DIndTexCoordScale : public J3DIndTexCoordScaleInfo {
-    /* 8000E0E4 */ J3DIndTexCoordScale() : J3DIndTexCoordScaleInfo(j3dDefaultIndTexCoordScaleInfo) {}
-    J3DIndTexCoordScale(J3DIndTexCoordScaleInfo const& info) : J3DIndTexCoordScaleInfo(info) {}
-    /* 8000E024 */ ~J3DIndTexCoordScale() {}
-    u8 getScaleS() { return mScaleS; }
-    u8 getScaleT() { return mScaleT; }
-
-    J3DIndTexCoordScale& operator=(const J3DIndTexCoordScale& other) {
-        //__memcpy(this, &other, sizeof(J3DIndTexCoordScaleInfo));
-        *(u32*)this = *(u32*)&other;
-        return *this;
-    }
-};  // Size: 0x4
-
-extern J3DIndTexMtxInfo const j3dDefaultIndTexMtxInfo;
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DIndTexMtx : public J3DIndTexMtxInfo {
-    /* 8000E0F0 */ J3DIndTexMtx() { *(J3DIndTexMtxInfo*)this = j3dDefaultIndTexMtxInfo; }
-    J3DIndTexMtx(J3DIndTexMtxInfo const& info) { *(J3DIndTexMtxInfo*)this = info; }
-    /* 8000E064 */ ~J3DIndTexMtx() {}
-    void load(u32 param_1) const {
-        J3DGDSetIndTexMtx((GXIndTexMtxID)(param_1 + 1), (Mtx3P)field_0x0, field_0x18);
-    }
-};  // Size: 0x1C
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DIndTexOrderInfo {
-    /* 0x0 */ u8 mCoord;
-    /* 0x1 */ u8 mMap;
-    /* 0x2 */ u8 field_0x2;
-    /* 0x3 */ u8 field_0x3;
-};  // Size: 0x04
-
-extern const J3DIndTexOrderInfo j3dDefaultIndTexOrderNull;
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DIndTexOrder : public J3DIndTexOrderInfo {
-    /* 8000E128 */ J3DIndTexOrder() : J3DIndTexOrderInfo(j3dDefaultIndTexOrderNull) {}
-    J3DIndTexOrder(J3DIndTexOrderInfo const& info) : J3DIndTexOrderInfo(info) {}
-    u8 getMap() const { return (GXTexMapID)mMap; }
-    u8 getCoord() const { return (GXTexCoordID)mCoord; }
-
-    J3DIndTexOrder& operator=(const J3DIndTexOrder& other) {
-        //__memcpy(this, &other, sizeof(J3DIndTexOrderInfo));
-        *(u32*)this = *(u32*)&other;
-        return *this;
-    }
-};  // Size: 0x04
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DIndBlock {
-public:
-    /* 8031734C */ virtual void reset(J3DIndBlock*) {}
-    virtual void diff(u32) = 0;
-    virtual void load() = 0;
-    /* 80317314 */ virtual s32 countDLSize() { return 0; }
-    virtual u32 getType() = 0;
-    /* 8000E0A0 */ virtual void setIndTexStageNum(u8) {}
-    /* 8000DF7C */ virtual u8 getIndTexStageNum() const { return 0; }
-    /* 80317410 */ virtual void setIndTexOrder(u32, J3DIndTexOrder) {}
-    /* 8031740C */ virtual void setIndTexOrder(u32, J3DIndTexOrder const*) {}
-    /* 8000DF74 */ virtual J3DIndTexOrder* getIndTexOrder(u32) { return NULL; }
-    /* 80317414 */ virtual void setIndTexMtx(u32, J3DIndTexMtx const*) {}
-    /* 8000E060 */ virtual void setIndTexMtx(u32, J3DIndTexMtx) {}
-    /* 8000DF6C */ virtual J3DIndTexMtx* getIndTexMtx(u32) { return NULL; }
-    /* 80317418 */ virtual void setIndTexCoordScale(u32, J3DIndTexCoordScale const*) {}
-    /* 8000E020 */ virtual void setIndTexCoordScale(u32, J3DIndTexCoordScale) {}
-    /* 8000DF64 */ virtual J3DIndTexCoordScale* getIndTexCoordScale(u32) { return NULL; }
-    /* 8031726C */ virtual ~J3DIndBlock() {}
-};
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DIndBlockNull : public J3DIndBlock {
-public:
-    /* 80317398 */ virtual void diff(u32) {}
-    /* 8031739C */ virtual void load() {}
-    /* 803173A0 */ virtual void reset(J3DIndBlock*) {}
-    /* 803173A4 */ virtual u32 getType() { return 'IBLN'; }
-    /* 803173B0 */ virtual ~J3DIndBlockNull() {}
-};
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DIndBlockFull : public J3DIndBlock {
-public:
-    J3DIndBlockFull() {
-        initialize();
-    }
-    /* 80317B28 */ void initialize();
-
-    /* 803210B0 */ virtual void reset(J3DIndBlock*);
-    /* 8031E328 */ virtual void diff(u32);
-    /* 8031E12C */ virtual void load();
-    /* 80317BDC */ virtual s32 countDLSize();
-    /* 80323390 */ virtual u32 getType() { return 'IBLF'; }
-    /* 8032339C */ virtual void setIndTexStageNum(u8 num) { mIndTexStageNum = num; }
-    /* 803233A4 */ virtual u8 getIndTexStageNum() const { return mIndTexStageNum; }
-    /* 803233AC */ virtual void setIndTexOrder(u32 idx, J3DIndTexOrder order) { mIndTexOrder[idx] = order; }
-    /* 803233C0 */ virtual void setIndTexOrder(u32 idx, J3DIndTexOrder const* order) { mIndTexOrder[idx] = *order; }
-    /* 803233D4 */ virtual J3DIndTexOrder* getIndTexOrder(u32 idx) { return &mIndTexOrder[idx]; }
-    /* 8032341C */ virtual void setIndTexMtx(u32 idx, J3DIndTexMtx const* mtx) { mIndTexMtx[idx] = *mtx; }
-    /* 803233E8 */ virtual void setIndTexMtx(u32 idx, J3DIndTexMtx mtx) { mIndTexMtx[idx] = mtx; }
-    /* 80323450 */ virtual J3DIndTexMtx* getIndTexMtx(u32 idx) { return &mIndTexMtx[idx]; }
-    /* 80323478 */ virtual void setIndTexCoordScale(u32 idx, J3DIndTexCoordScale const* scale) { mIndTexCoordScale[idx] = *scale; }
-    /* 80323464 */ virtual void setIndTexCoordScale(u32 idx, J3DIndTexCoordScale scale) { mIndTexCoordScale[idx] = scale; }
-    /* 8032348C */ virtual J3DIndTexCoordScale* getIndTexCoordScale(u32 idx) { return &mIndTexCoordScale[idx]; }
-    /* 803234A0 */ virtual ~J3DIndBlockFull() {}
-
-    /* 0x04 */ u8 mIndTexStageNum;
-    /* 0x05 */ J3DIndTexOrder mIndTexOrder[4];
-    /* 0x18 */ J3DIndTexMtx mIndTexMtx[3];
-    /* 0x6C */ J3DIndTexCoordScale mIndTexCoordScale[4];
-};  // Size: 0x7C
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DColorChanInfo {
-    /* 0x0 */ u8 mEnable;
-    /* 0x1 */ u8 mMatSrc;
-    /* 0x2 */ u8 mLightMask;
-    /* 0x3 */ u8 mDiffuseFn;
-    /* 0x4 */ u8 mAttnFn;
-    /* 0x5 */ u8 mAmbSrc;
-    /* 0x6 */ u8 pad[2];
-};
-
-extern const J3DColorChanInfo j3dDefaultColorChanInfo;
-
-static inline u32 setChanCtrlMacro(u8 enable, GXColorSrc ambSrc, GXColorSrc matSrc, u32 lightMask,
-                                   GXDiffuseFn diffuseFn, GXAttnFn attnFn) {
-    u32 tmp = matSrc << 0;
-    return tmp | enable << 1 | (lightMask & 0x0F) << 2 | ambSrc << 6 |
-           ((attnFn == GX_AF_SPEC) ? GX_DF_NONE : diffuseFn) << 7 | (attnFn != GX_AF_NONE) << 9 |
-           (attnFn != GX_AF_SPEC) << 10 | (lightMask >> 4 & 0x0F) << 11;
-}
-
-inline u16 calcColorChanID(u16 enable, u8 matSrc, u8 lightMask, u8 diffuseFn, u8 attnFn, u8 ambSrc) {
-    u32 reg = 0;
-    reg = (reg & ~0x0002) | enable << 1;
-    reg = (reg & ~0x0001) | matSrc;
-    reg = (reg & ~0x0040) | ambSrc << 6;
-    reg = (reg & ~0x0004) | bool(lightMask & 0x01) << 2;
-    reg = (reg & ~0x0008) | bool(lightMask & 0x02) << 3;
-    reg = (reg & ~0x0010) | bool(lightMask & 0x04) << 4;
-    reg = (reg & ~0x0020) | bool(lightMask & 0x08) << 5;
-    reg = (reg & ~0x0800) | bool(lightMask & 0x10) << 11;
-    reg = (reg & ~0x1000) | bool(lightMask & 0x20) << 12;
-    reg = (reg & ~0x2000) | bool(lightMask & 0x40) << 13;
-    reg = (reg & ~0x4000) | bool(lightMask & 0x80) << 14;
-    reg = (reg & ~0x0180) | (attnFn == GX_AF_SPEC ? 0 : diffuseFn) << 7;
-    reg = (reg & ~0x0200) | (attnFn != GX_AF_NONE) << 9;
-    reg = (reg & ~0x0400) | (attnFn != GX_AF_SPEC) << 10;
-    return reg;
-}
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-struct J3DColorChan {
-    /* 8000E47C */ J3DColorChan() {
-        setColorChanInfo(j3dDefaultColorChanInfo);
-    }
-    J3DColorChan(J3DColorChanInfo const& info) {
-        u32 ambSrc = info.mAmbSrc == 0xFF ? 0 : info.mAmbSrc;
-        mColorChanID = calcColorChanID(info.mEnable, info.mMatSrc, info.mLightMask,
-            info.mDiffuseFn, info.mAttnFn, ambSrc);
-    }
-    void setColorChanInfo(J3DColorChanInfo const& info) {
-        // Bug: It compares info.mAmbSrc (an 8 bit integer) with 0xFFFF instead of 0xFF.
-        // This inline is only called by the default constructor J3DColorChan().
-        // The J3DColorChan(const J3DColorChanInfo&) constructor does not call this inline, and instead duplicates the
-        // same logic but without the bug.
-        // See J3DMaterialFactory::newColorChan - both the bugged and correct behavior are present there, as it calls
-        // both constructors.
-        u32 ambSrc = info.mAmbSrc == 0xFFFF ? 0 : info.mAmbSrc;
-        mColorChanID = calcColorChanID(info.mEnable, info.mMatSrc, info.mLightMask,
-            info.mDiffuseFn, info.mAttnFn, ambSrc);
-    }
-    u8 getLightMask() const { return ((mColorChanID >> 2) & 0xf) | ((mColorChanID >> 11) & 0xf) << 4; }
-    void setLightMask(u8 param_1) {
-        mColorChanID = (mColorChanID & ~0x3c) | ((param_1 & 0xf) << 2);
-        mColorChanID = (mColorChanID & ~0x7800) | ((param_1 & 0xf0) << 7);
-    }
-
-    u8 getEnable() const { return (mColorChanID >> 1) & 1; }
-    u8 getAmbSrc() const { return (GXColorSrc)((mColorChanID >> 6) & 1); }
-    u8 getMatSrc() const { return (GXColorSrc)(mColorChanID & 1); }
-    u8 getDiffuseFn() const { return ((mColorChanID >> 7) & 3); }
-    // This function has to appear in J3DMatBlock.cpp because it generates extra data in .sdata2
-    inline u8 getAttnFn() const;
-
-    void load() const {
-        J3DGDWrite_u32(setChanCtrlMacro(getEnable(), (GXColorSrc)getAmbSrc(), (GXColorSrc)getMatSrc(), getLightMask(),
-                                        (GXDiffuseFn)getDiffuseFn(), (GXAttnFn)getAttnFn()));
-    }
-
-    /* 0x0 */ u16 mColorChanID;
-};
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DColorBlock {
-public:
-    /* 80317324 */ virtual void load() {}
-    /* 80317358 */ virtual void reset(J3DColorBlock*) {}
-    /* 8031733C */ virtual void patch() {}
-    /* 80317434 */ virtual void patchMatColor() {}
-    /* 8000DBD0 */ virtual void patchLight() {}
-    /* 80317340 */ virtual void diff(u32) {}
-    /* 80317438 */ virtual void diffAmbColor() {}
-    /* 8031743C */ virtual void diffMatColor() {}
-    /* 80317440 */ virtual void diffColorChan() {}
-    /* 80317444 */ virtual void diffLightObj(u32) {}
-    /* 80317304 */ virtual s32 countDLSize() { return 0; }
-    virtual u32 getType() = 0;
-    /* 80317448 */ virtual void setMatColor(u32, J3DGXColor const*) {}
-    /* 8000E0DC */ virtual void setMatColor(u32, J3DGXColor) {}
-    /* 8000E000 */ virtual J3DGXColor* getMatColor(u32) { return NULL; }
-    /* 801A4C0C */ virtual void setAmbColor(u32, J3DGXColor const*) {}
-    /* 8000E0D4 */ virtual void setAmbColor(u32, J3DGXColor) {}
-    /* 8000DFF0 */ virtual J3DGXColor* getAmbColor(u32) { return NULL; }
-    /* 8000E0E0 */ virtual void setColorChanNum(u8) {}
-    /* 8031744C */ virtual void setColorChanNum(u8 const*) {}
-    /* 8000E008 */ virtual u8 getColorChanNum() const { return 0; }
-    /* 8000E0D8 */ virtual void setColorChan(u32, J3DColorChan const&) {}
-    /* 80317450 */ virtual void setColorChan(u32, J3DColorChan const*) {}
-    /* 8000DFF8 */ virtual J3DColorChan* getColorChan(u32) { return NULL; }
-    /* 801A4C08 */ virtual void setLight(u32, J3DLightObj*) {}
-    /* 80317454 */ virtual J3DLightObj* getLight(u32) { return NULL; }
-    /* 80317460 */ virtual void setCullMode(u8 const*) {}
-    /* 8031745C */ virtual void setCullMode(u8) {}
-    /* 80317328 */ virtual s32 getCullMode() const { return 2; }
-    /* 80317464 */ virtual u32 getMatColorOffset() const { return 0; }
-    /* 8031746C */ virtual u32 getColorChanOffset() const { return 0; }
-    /* 80317474 */ virtual void setMatColorOffset(u32) {}
-    /* 80317478 */ virtual void setColorChanOffset(u32) {}
-    /* 80317138 */ virtual ~J3DColorBlock() {}
-};
-
-/**
- * @ingroup jsystem-j3d
- * 
+ *
  */
 struct J3DColorBlockNull : public J3DColorBlock {
     /* 80332B2C */ virtual u32 getType() { return 'CLNL'; }
     /* 80332B38 */ virtual ~J3DColorBlockNull() {}
 };
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DColorBlockLightOn : public J3DColorBlock {
-public:
-    J3DColorBlockLightOn() {
-        initialize();
-    }
-    /* 80317580 */ void initialize();
-
-    /* 803187F4 */ virtual void load();
-    /* 8031FF34 */ virtual void reset(J3DColorBlock*);
-    /* 803194E8 */ virtual void patch();
-    /* 80319534 */ virtual void patchMatColor();
-    /* 803196E0 */ virtual void patchLight();
-    /* 8031A13C */ virtual void diff(u32);
-    /* 8031A1DC */ virtual void diffAmbColor();
-    /* 8031A358 */ virtual void diffMatColor();
-    /* 8031A4D4 */ virtual void diffColorChan();
-    /* 8031A8E0 */ virtual void diffLightObj(u32);
-    /* 80317B94 */ virtual s32 countDLSize();
-    /* 80322E80 */ virtual u32 getType() { return 'CLON'; }
-    /* 80322EB8 */ virtual void setMatColor(u32 idx, J3DGXColor const* color) { mMatColor[idx] = *color; }
-    /* 80322E8C */ virtual void setMatColor(u32 idx, J3DGXColor color) { mMatColor[idx] = color; }
-    /* 80322EE4 */ virtual J3DGXColor* getMatColor(u32 idx) { return &mMatColor[idx]; }
-    /* 80322F24 */ virtual void setAmbColor(u32 idx, J3DGXColor const* color) { mAmbColor[idx] = *color; }
-    /* 80322EF8 */ virtual void setAmbColor(u32 idx, J3DGXColor color) { mAmbColor[idx] = color; }
-    /* 80322F50 */ virtual J3DGXColor* getAmbColor(u32 idx) { return &mAmbColor[idx]; }
-    /* 80322F70 */ virtual void setColorChanNum(u8 num) { mColorChanNum = num; }
-    /* 80322F64 */ virtual void setColorChanNum(u8 const* num) { mColorChanNum = *num; }
-    /* 80322F78 */ virtual u8 getColorChanNum() const { return mColorChanNum; }
-    /* 80322F94 */ virtual void setColorChan(u32 idx, J3DColorChan const& chan) { mColorChan[idx] = chan; }
-    /* 80322F80 */ virtual void setColorChan(u32 idx, J3DColorChan const* chan) { mColorChan[idx] = *chan; }
-    /* 80322FA8 */ virtual J3DColorChan* getColorChan(u32 idx) { return &mColorChan[idx]; }
-    /* 80322FBC */ virtual void setLight(u32 idx, J3DLightObj* light) { mLight[idx] = light; }
-    /* 80322FCC */ virtual J3DLightObj* getLight(u32 idx) { return mLight[idx]; }
-    /* 80322FE4 */ virtual void setCullMode(u8 const* mode) { mCullMode = *mode; }
-    /* 80322FDC */ virtual void setCullMode(u8 mode) { mCullMode = mode; }
-    /* 80322FF0 */ virtual s32 getCullMode() const { return mCullMode; }
-    /* 80322FF8 */ virtual u32 getMatColorOffset() const { return mMatColorOffset; }
-    /* 80323000 */ virtual u32 getColorChanOffset() const { return mColorChanOffset; }
-    /* 80323008 */ virtual void setMatColorOffset(u32 offset) { mMatColorOffset = offset; }
-    /* 80323010 */ virtual void setColorChanOffset(u32 offset) { mColorChanOffset = offset; }
-    /* 80323018 */ virtual ~J3DColorBlockLightOn() {}
-
-    /* 0x04 */ J3DGXColor mMatColor[2];
-    /* 0x0C */ J3DGXColor mAmbColor[2];
-    /* 0x14 */ u8 mColorChanNum;
-    /* 0x16 */ J3DColorChan mColorChan[4];
-    /* 0x20 */ J3DLightObj* mLight[8];
-    /* 0x40 */ u8 mCullMode;
-    /* 0x44 */ u32 mMatColorOffset;
-    /* 0x48 */ u32 mColorChanOffset;
-};  // Size: 0x4C
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DColorBlockLightOff : public J3DColorBlock {
-public:
-    J3DColorBlockLightOff() {
-        initialize();
-    }
-    /* 8031747C */ void initialize();
-
-    /* 80317C0C */ virtual void load();
-    /* 8031FD08 */ virtual void reset(J3DColorBlock*);
-    /* 80318EB4 */ virtual void patch();
-    /* 80318F00 */ virtual void patchMatColor();
-    /* 803190AC */ virtual void patchLight();
-    /* 80319B4C */ virtual void diff(u32);
-    /* 80319BB4 */ virtual void diffMatColor();
-    /* 80319D30 */ virtual void diffColorChan();
-    /* 80317B84 */ virtual s32 countDLSize();
-    /* 80323560 */ virtual u32 getType() { return 'CLOF'; }
-    /* 80323184 */ virtual void setMatColor(u32 idx, J3DGXColor const* color) { mMatColor[idx] = *color; }
-    /* 80323158 */ virtual void setMatColor(u32 idx, J3DGXColor color) { mMatColor[idx] = color; }
-    /* 803231B0 */ virtual J3DGXColor* getMatColor(u32 idx) { return &mMatColor[idx]; }
-    /* 803231D0 */ virtual void setColorChanNum(u8 num) { mColorChanNum = num; }
-    /* 803231C4 */ virtual void setColorChanNum(u8 const* num) { mColorChanNum = *num; }
-    /* 803231D8 */ virtual u8 getColorChanNum() const { return mColorChanNum; }
-    /* 803231F4 */ virtual void setColorChan(u32 idx, J3DColorChan const& chan) { mColorChan[idx] = chan; }
-    /* 803231E0 */ virtual void setColorChan(u32 idx, J3DColorChan const* chan) { mColorChan[idx] = *chan; }
-    /* 80323208 */ virtual J3DColorChan* getColorChan(u32 idx) { return &mColorChan[idx]; }
-    /* 80323224 */ virtual void setCullMode(u8 const* mode) { mCullMode = *mode; }
-    /* 8032321C */ virtual void setCullMode(u8 mode) { mCullMode = mode; }
-    /* 80323230 */ virtual s32 getCullMode() const { return mCullMode; }
-    /* 80323238 */ virtual u32 getMatColorOffset() const { return mMatColorOffset; }
-    /* 80323240 */ virtual u32 getColorChanOffset() const { return mColorChanOffset; }
-    /* 80323248 */ virtual void setMatColorOffset(u32 offset) { mMatColorOffset = offset; }
-    /* 80323250 */ virtual void setColorChanOffset(u32 offset) { mColorChanOffset = offset; }
-    /* 803170DC */ virtual ~J3DColorBlockLightOff() {}
-
-    /* 0x04 */ J3DGXColor mMatColor[2];
-    /* 0x0C */ u8 mColorChanNum;
-    /* 0x0E */ J3DColorChan mColorChan[4];
-    /* 0x16 */ u8 mCullMode;
-    /* 0x18 */ u32 mMatColorOffset;
-    /* 0x1C */ u32 mColorChanOffset;
-};  // Size: 0x20
-
-/**
- * @ingroup jsystem-j3d
- * 
- */
-class J3DColorBlockAmbientOn : public J3DColorBlockLightOff {
-public:
-    J3DColorBlockAmbientOn() {
-        initialize();
-    }
-    /* 803174DC */ void initialize();
-
-    /* 8031816C */ virtual void load();
-    /* 8031FDE4 */ virtual void reset(J3DColorBlock*);
-    /* 80317B8C */ virtual s32 countDLSize();
-    /* 80323074 */ virtual u32 getType() { return 'CLAB'; }
-    /* 803230AC */ virtual void setAmbColor(u32 idx, J3DGXColor const* color) { mAmbColor[idx] = *color; }
-    /* 80323080 */ virtual void setAmbColor(u32 idx, J3DGXColor color) { mAmbColor[idx] = color; }
-    /* 803230D8 */ virtual J3DGXColor* getAmbColor(u32 idx) { return &mAmbColor[idx]; }
-    /* 803230EC */ virtual ~J3DColorBlockAmbientOn() {}
-
-    /* 0x20 */ J3DGXColor mAmbColor[2];
-};  // Size: 0x28
 
 #endif /* J3DMATBLOCK_H */

--- a/include/JSystem/J3DGraphBase/J3DShape.h
+++ b/include/JSystem/J3DGraphBase/J3DShape.h
@@ -96,7 +96,7 @@ public:
     /* 80314BB8 */ void addTexMtxIndexInDL(_GXAttr, u32);
     /* 80314CBC */ void addTexMtxIndexInVcd(_GXAttr);
     /* 80314DA8 */ void calcNBTScale(Vec const&, f32 (*)[3][3], f32 (*)[3][3]);
-    /* 80314E28 */ u32 countBumpMtxNum() const;
+    /* 80314E28 */ u16 countBumpMtxNum() const;
     /* 80314EEC */ void loadVtxArray() const;
     /* 80314F5C */ bool isSameVcdVatCmd(J3DShape*);
     /* 80314F98 */ void makeVtxArrayCmd();
@@ -188,8 +188,8 @@ public:
 
     /* 80314798 */ virtual ~J3DShapeMtx() {}
     /* 803147E0 */ virtual u32 getType() const { return 'SMTX'; }
-    /* 80273E08 */ virtual u32 getUseMtxNum() const { return 1; }
-    /* 8031459C */ virtual u32 getUseMtxIndex(u16) const { return mUseMtxIndex; }
+    /* 80273E08 */ virtual u16 getUseMtxNum() const { return 1; }
+    /* 8031459C */ virtual u16 getUseMtxIndex(u16) const { return mUseMtxIndex; }
     /* 80313B94 */ virtual void load() const;
     /* 80313BF0 */ virtual void calcNBTScale(Vec const&, f32 (*)[3][3], f32 (*)[3][3]);
 

--- a/include/JSystem/J3DGraphBase/J3DShapeMtx.h
+++ b/include/JSystem/J3DGraphBase/J3DShapeMtx.h
@@ -13,9 +13,15 @@ class J3DTexGenBlock;
  */
 class J3DTexMtxObj {
 public:
-    Mtx& getMtx(u16 idx) { return mpTexMtx[idx]; }
-    Mtx44& getEffectMtx(u16 idx) { return mpEffectMtx[idx]; }
-    u16 getNumTexMtx() { return mTexMtxNum; }
+    Mtx& getMtx(u16 idx) {
+        J3D_ASSERT(0x113, idx <= mTexMtxNum, "Error : range over");
+        return mpTexMtx[idx];
+    }
+    Mtx44& getEffectMtx(u16 idx) {
+        J3D_ASSERT(0x125, idx <= mTexMtxNum, "Error : range over");
+        return mpEffectMtx[idx];
+    }
+    u16 getNumTexMtx() const { return mTexMtxNum; }
     void setMtx(u16 idx, Mtx const* mtx) { MTXCopy(*mtx, mpTexMtx[idx]); }
 
     /* 0x00 */ Mtx* mpTexMtx;
@@ -114,8 +120,8 @@ public:
 
     /* 803146B0 */ virtual ~J3DShapeMtxMulti() {}
     /* 803147E0 */ virtual u32 getType() const { return 'SMML'; }
-    /* 80273E08 */ virtual u32 getUseMtxNum() const { return mUseMtxNum; }
-    /* 8031459C */ virtual u32 getUseMtxIndex(u16 no) const { return mUseMtxIndexTable[no]; }
+    /* 80273E08 */ virtual u16 getUseMtxNum() const { return mUseMtxNum; }
+    /* 8031459C */ virtual u16 getUseMtxIndex(u16 no) const { return mUseMtxIndexTable[no]; }
     /* 80313E4C */ virtual void load() const;
     /* 80313EEC */ virtual void calcNBTScale(Vec const&, f32 (*)[3][3], f32 (*)[3][3]);
 
@@ -138,8 +144,8 @@ public:
 
     /* 8031461C */ virtual ~J3DShapeMtxMultiConcatView() {}
     /* 803147E0 */ virtual u32 getType() const { return 'SMMC'; }
-    /* 80273E08 */ virtual u32 getUseMtxNum() const { return mUseMtxNum; }
-    /* 8031459C */ virtual u32 getUseMtxIndex(u16 no) const { return mUseMtxIndexTable[no]; }
+    /* 80273E08 */ virtual u16 getUseMtxNum() const { return mUseMtxNum; }
+    /* 8031459C */ virtual u16 getUseMtxIndex(u16 no) const { return mUseMtxIndexTable[no]; }
     /* 80313FA4 */ virtual void load() const;
     /* 803146AC */ virtual void loadNrmMtx(int, u16) const {}
     /* 8031419C */ virtual void loadNrmMtx(int, u16, f32 (*)[4]) const;

--- a/include/JSystem/J3DGraphBase/J3DTevs.h
+++ b/include/JSystem/J3DGraphBase/J3DTevs.h
@@ -69,6 +69,7 @@ struct J3DTevStage {
         setTevStageInfo(j3dDefaultTevStageInfo);
         setTevSwapModeInfo(j3dDefaultTevSwapMode);
     }
+
     void setTevColorOp(u8 param_1, u8 param_2, u8 param_3, u8 param_4, u8 param_5) {
         mTevColorOp = mTevColorOp & ~(0x01 << 2) | param_1 << 2;
         if (param_1 <= 1) {
@@ -128,10 +129,16 @@ struct J3DTevStage {
         setTexSel(param_0.mTexSel);
         setRasSel(param_0.mRasSel);
     }
+
+    void setStageNo(u32 param_0) {
+        field_0x0 = 0xC0 + param_0 * 2;
+        field_0x4 = 0xC1 + param_0 * 2;
+    }
+
     void setRasSel(u8 ras_sel) { mTevSwapModeInfo = (mTevSwapModeInfo & ~3) | ras_sel; }
     void setTexSel(u8 tex_sel) { mTevSwapModeInfo = (mTevSwapModeInfo & ~0xc) | (tex_sel << 2); }
 
-    void load(u32 param_1) {
+    void load(u32 param_1) const {
         J3DGDWriteBPCmd(*(u32*)&field_0x0);
         J3DGDWriteBPCmd(*(u32*)&field_0x4);
     }
@@ -203,7 +210,7 @@ struct J3DIndTevStage {
     void setLod(u8 lod) { mInfo = (mInfo & ~0x80000) | (lod << 19); }
     void setAlphaSel(u8 alphaSel) { mInfo = (mInfo & ~0x180) | (alphaSel << 7); }
 
-    void load(u32 param_1) {
+    void load(u32 param_1) const {
         J3DGDWriteBPCmd(mInfo | (param_1 + 0x10) * 0x1000000);
     }
 
@@ -251,14 +258,20 @@ struct J3DTevSwapModeTable {
     J3DTevSwapModeTable(J3DTevSwapModeTableInfo const& info) {
         mIdx = calcTevSwapTableID(info.field_0x0, info.field_0x1, info.field_0x2, info.field_0x3);
     }
+
+    J3DTevSwapModeTable& operator=(const J3DTevSwapModeTable& rhs) {
+        mIdx = rhs.mIdx;
+        return *this;
+    }
+
     u8 calcTevSwapTableID(u8 param_0, u8 param_1, u8 param_2, u8 param_3) {
         return 0x40 * param_0 + 0x10 * param_1 + 4 * param_2 + param_3;
     }
 
-    u8 getR() { return j3dTevSwapTableTable[mIdx * 4]; }
-    u8 getG() { return j3dTevSwapTableTable[mIdx * 4 + 1]; }
-    u8 getB() { return j3dTevSwapTableTable[mIdx * 4 + 2]; }
-    u8 getA() { return j3dTevSwapTableTable[mIdx * 4 + 3]; }
+    u8 getR() const { return *(&j3dTevSwapTableTable[mIdx * 4] + 0); }
+    u8 getG() const { return *(&j3dTevSwapTableTable[mIdx * 4] + 1); }
+    u8 getB() const { return *(&j3dTevSwapTableTable[mIdx * 4] + 2); }
+    u8 getA() const { return *(&j3dTevSwapTableTable[mIdx * 4] + 3); }
 
     /* 0x0 */ u8 mIdx;
 };  // Size: 0x1

--- a/src/JSystem/J3DGraphAnimator/J3DMtxBuffer.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DMtxBuffer.cpp
@@ -21,6 +21,15 @@ Mtx* J3DMtxBuffer::sNoUseDrawMtxPtr = &J3DMtxBuffer::sNoUseDrawMtx;
 /* 80450974-80450978 -00001 0004+00 1/1 0/0 0/0 .sdata           sNoUseNrmMtxPtr__12J3DMtxBuffer */
 Mtx33* J3DMtxBuffer::sNoUseNrmMtxPtr = &J3DMtxBuffer::sNoUseNrmMtx;
 
+// force .sdata2 order
+f32 dummy1() {
+    return 1.0f;
+}
+
+f32 dummy0() {
+    return 0.0f;
+}
+
 /* 80326214-80326258 320B54 0044+00 0/0 1/1 0/0 .text            initialize__12J3DMtxBufferFv */
 void J3DMtxBuffer::initialize() {
     mJointTree = NULL;

--- a/src/JSystem/J3DGraphBase/J3DMatBlock.cpp
+++ b/src/JSystem/J3DGraphBase/J3DMatBlock.cpp
@@ -4,12 +4,12 @@
 //
 
 #include "JSystem/J3DGraphBase/J3DMatBlock.h"
-#include "JSystem/J3DGraphBase/J3DGD.h"
+#include "JSystem/J3DGraphBase/J3DPacket.h"
 #include "JSystem/J3DGraphBase/J3DSys.h"
 #include "JSystem/J3DGraphBase/J3DTransform.h"
 #include "dolphin/os.h"
-#include "string.h"
 #include "global.h"
+#include "string.h"
 
 inline void loadMatColors(const J3DGXColor* color) {
     J3DGDWriteXFCmdHdr(0x100C, 2);
@@ -38,7 +38,7 @@ inline void loadTevKColor(u32 reg, const J3DGXColor& color) {
 /* 8031747C-803174DC 311DBC 0060+00 0/0 1/1 0/0 .text initialize__21J3DColorBlockLightOffFv */
 void J3DColorBlockLightOff::initialize() {
     mColorChanNum = 0;
-    for (u32 i = 0; i < ARRAY_SIZE(mMatColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mMatColor); i++) {
         mMatColor[i] = j3dDefaultColInfo;
     }
     mMatColorOffset = 0;
@@ -48,10 +48,10 @@ void J3DColorBlockLightOff::initialize() {
 /* 803174DC-80317580 311E1C 00A4+00 0/0 1/1 0/0 .text initialize__22J3DColorBlockAmbientOnFv */
 void J3DColorBlockAmbientOn::initialize() {
     mColorChanNum = 0;
-    for (u32 i = 0; i < ARRAY_SIZE(mMatColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mMatColor); i++) {
         mMatColor[i] = j3dDefaultColInfo;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mAmbColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mAmbColor); i++) {
         mAmbColor[i] = j3dDefaultAmbInfo;
     }
     mMatColorOffset = 0;
@@ -61,13 +61,13 @@ void J3DColorBlockAmbientOn::initialize() {
 /* 80317580-80317644 311EC0 00C4+00 0/0 1/1 0/0 .text initialize__20J3DColorBlockLightOnFv */
 void J3DColorBlockLightOn::initialize() {
     mColorChanNum = 0;
-    for (u32 i = 0; i < ARRAY_SIZE(mMatColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mMatColor); i++) {
         mMatColor[i] = j3dDefaultColInfo;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mAmbColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mAmbColor); i++) {
         mAmbColor[i] = j3dDefaultAmbInfo;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mLight); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mLight); i++) {
         mLight[i] = NULL;
     }
     mMatColorOffset = 0;
@@ -77,7 +77,7 @@ void J3DColorBlockLightOn::initialize() {
 /* 80317644-80317674 311F84 0030+00 0/0 2/2 0/0 .text initialize__21J3DTexGenBlockPatchedFv */
 void J3DTexGenBlockPatched::initialize() {
     mTexGenNum = 0;
-    for (u32 i = 0; i < 8; i++)
+    for (s32 i = 0; i < 8; i++)
         mTexMtx[i] = NULL;
     mTexMtxOffset = 0;
 }
@@ -85,7 +85,7 @@ void J3DTexGenBlockPatched::initialize() {
 /* 80317674-803176A4 311FB4 0030+00 0/0 1/1 0/0 .text            initialize__15J3DTexGenBlock4Fv */
 void J3DTexGenBlock4::initialize() {
     mTexGenNum = 0;
-    for (u32 i = 0; i < 4; i++)
+    for (s32 i = 0; i < 4; i++)
         mTexMtx[i] = NULL;
     mTexMtxOffset = 0;
 }
@@ -94,7 +94,7 @@ void J3DTexGenBlock4::initialize() {
  */
 void J3DTexGenBlockBasic::initialize() {
     mTexGenNum = 0;
-    for (u32 i = 0; i < 8; i++)
+    for (s32 i = 0; i < 8; i++)
         mTexMtx[i] = NULL;
     mTexMtxOffset = 0;
 }
@@ -107,20 +107,19 @@ void J3DTevBlockNull::initialize() {
 /* 803176E0-803177E8 312020 0108+00 0/0 1/1 0/0 .text            initialize__18J3DTevBlockPatchedFv
  */
 void J3DTevBlockPatched::initialize() {
-    for (u32 i = 0; i < ARRAY_SIZE(mTexNo); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTexNo); i++) {
         mTexNo[i] = 0xFFFF;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevStage); i++) {
-        mTevStage[i].field_0x0 = 0xC0 + i * 2;
-        mTevStage[i].field_0x4 = 0xC1 + i * 2;
+    for (s32 i = 0; i < ARRAY_SIZE(mTevStage); i++) {
+        mTevStage[i].setStageNo(i);
     }
-    for (u32 i = 0; i < 3; i++) {
+    for (s32 i = 0; i < 3; i++) {
         mTevColor[i] = j3dDefaultTevColor;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColor); i++) {
         mTevKColor[i] = j3dDefaultTevKColor;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColorSel); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColorSel); i++) {
         mTevKColorSel[i] = GX_TEV_KCSEL_K0;
     }
     mTevStageNum = 1;
@@ -131,8 +130,7 @@ void J3DTevBlockPatched::initialize() {
 /* 803177E8-80317810 312128 0028+00 0/0 1/1 0/0 .text            initialize__12J3DTevBlock1Fv */
 void J3DTevBlock1::initialize() {
     mTexNo[0] = 0xFFFF;
-    mTevStage[0].field_0x0 = 0xC0;
-    mTevStage[0].field_0x4 = 0xC1;
+    mTevStage[0].setStageNo(0);
     mTexNoOffset = 0;
 }
 
@@ -142,19 +140,17 @@ void J3DTevBlock2::initialize() {
     mTexNo[1] = 0xFFFF;
     mTevStageNum = 1;
 
-    mTevStage[0].field_0x0 = 0xC0;
-    mTevStage[0].field_0x4 = 0xC1;
-    mTevStage[1].field_0x0 = 0xC2;
-    mTevStage[1].field_0x4 = 0xC3;
+    mTevStage[0].setStageNo(0);
+    mTevStage[1].setStageNo(1);
     mTevKColorSel[0] = GX_TEV_KCSEL_K0;
     mTevKColorSel[1] = GX_TEV_KCSEL_K0;
     mTevKAlphaSel[0] = GX_TEV_KASEL_K0_A;
     mTevKAlphaSel[1] = GX_TEV_KASEL_K0_A;
 
-    for (u32 i = 0; i < 3; i++) {
+    for (s32 i = 0; i < 3; i++) {
         mTevColor[i] = j3dDefaultTevColor;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColor); i++) {
         mTevKColor[i] = j3dDefaultTevKColor;
     }
     mTexNoOffset = 0;
@@ -169,14 +165,10 @@ void J3DTevBlock4::initialize() {
     mTexNo[3] = 0xFFFF;
     mTevStageNum = 1;
 
-    mTevStage[0].field_0x0 = 0xC0;
-    mTevStage[0].field_0x4 = 0xC1;
-    mTevStage[1].field_0x0 = 0xC2;
-    mTevStage[1].field_0x4 = 0xC3;
-    mTevStage[2].field_0x0 = 0xC4;
-    mTevStage[2].field_0x4 = 0xC5;
-    mTevStage[3].field_0x0 = 0xC6;
-    mTevStage[3].field_0x4 = 0xC7;
+    mTevStage[0].setStageNo(0);
+    mTevStage[1].setStageNo(1);
+    mTevStage[2].setStageNo(2);
+    mTevStage[3].setStageNo(3);
     mTevKColorSel[0] = GX_TEV_KCSEL_K0;
     mTevKColorSel[1] = GX_TEV_KCSEL_K0;
     mTevKColorSel[2] = GX_TEV_KCSEL_K0;
@@ -186,10 +178,10 @@ void J3DTevBlock4::initialize() {
     mTevKAlphaSel[2] = GX_TEV_KASEL_K0_A;
     mTevKAlphaSel[3] = GX_TEV_KASEL_K0_A;
 
-    for (u32 i = 0; i < 3; i++) {
+    for (s32 i = 0; i < 3; i++) {
         mTevColor[i] = j3dDefaultTevColor;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColor); i++) {
         mTevKColor[i] = j3dDefaultTevKColor;
     }
     mTexNoOffset = 0;
@@ -198,25 +190,24 @@ void J3DTevBlock4::initialize() {
 
 /* 80317A00-80317B28 312340 0128+00 0/0 1/1 0/0 .text            initialize__13J3DTevBlock16Fv */
 void J3DTevBlock16::initialize() {
-    for (u32 i = 0; i < ARRAY_SIZE(mTexNo); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTexNo); i++) {
         mTexNo[i] = 0xFFFF;
     }
     mTevStageNum = 1;
-    for (u32 i = 0; i < 3; i++) {
+    for (s32 i = 0; i < 3; i++) {
         mTevColor[i] = j3dDefaultTevColor;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColor); i++) {
         mTevKColor[i] = j3dDefaultTevKColor;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColorSel); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColorSel); i++) {
         mTevKColorSel[i] = GX_TEV_KCSEL_K0;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevKColorSel); i++) {
+    for (s32 i = 0; i < (s32)ARRAY_SIZE(mTevKColorSel); i++) {
         mTevKAlphaSel[i] = GX_TEV_KASEL_K0_A;
     }
-    for (u32 i = 0; i < ARRAY_SIZE(mTevStage); i++) {
-        mTevStage[i].field_0x0 = 0xC0 + i * 2;
-        mTevStage[i].field_0x4 = 0xC1 + i * 2;
+    for (s32 i = 0; i < ARRAY_SIZE(mTevStage); i++) {
+        mTevStage[i].setStageNo(i);
     }
     mTexNoOffset = 0;
     mTevRegOffset = 0;
@@ -229,16 +220,16 @@ void J3DIndBlockFull::initialize() {
 
 /* 80317B34-80317B58 312474 0024+00 0/0 1/1 0/0 .text            initialize__16J3DPEBlockFogOffFv */
 void J3DPEBlockFogOff::initialize() {
-    mAlphaComp.mID = 0xFFFF;
-    mZMode.mZModeID = 0xFFFF;
+    mAlphaComp = 0xFFFF;
+    mZMode = 0xFFFF;
     mZCompLoc = 0xFF;
     mDither = 1;
 }
 
 /* 80317B58-80317B84 312498 002C+00 0/0 1/1 0/0 .text            initialize__14J3DPEBlockFullFv */
 void J3DPEBlockFull::initialize() {
-    mAlphaComp.mID = 0xFFFF;
-    mZMode.mZModeID = 0xFFFF;
+    mAlphaComp = 0xFFFF;
+    mZMode = 0xFFFF;
     mZCompLoc = 0xFF;
     mDither = 1;
     mFogOffset = 0;
@@ -341,12 +332,14 @@ static u32 SizeOfLoadAmbColors = 0x0000000D;
 /* 80450968-80450970 0003E8 0004+04 5/5 0/0 0/0 .sdata           SizeOfLoadColorChans */
 static u32 SizeOfLoadColorChans = 21;
 
+static u8 sdata_padding[4] = {};
+
 /* 804515D8-804515DC 000AD8 0004+00 2/2 0/0 0/0 .sbss            SizeOfJ3DColorBlockLightOffLoad */
 static u32 SizeOfJ3DColorBlockLightOffLoad = SizeOfLoadMatColors + SizeOfLoadColorChans;
 
-u8 J3DColorChan::getAttnFn() const { 
+u8 J3DColorChan::getAttnFn() const {
     u8 AttnArr[] = {2,0,2,1};
-    return AttnArr[(mColorChanID >> 9) & 3]; 
+    return AttnArr[(u32)(mColorChanID & (3 << 9)) >> 9];
 }
 
 /* 80317C0C-8031816C 31254C 0560+00 1/0 0/0 0/0 .text            load__21J3DColorBlockLightOffFv */
@@ -498,8 +491,9 @@ void J3DColorBlockLightOn::diff(u32 flag) {
     if (flag & 2)
         diffColorChan();
 
-    if ((flag >> 4) & 0x0f)
-        diffLightObj((flag >> 4) & 0x0f);
+    s32 lightObjNumFlag = getDiffFlag_LightObjNum(flag);
+    if (lightObjNumFlag)
+        diffLightObj(lightObjNumFlag);
 }
 
 /* 8031A1DC-8031A358 314B1C 017C+00 1/0 0/0 0/0 .text diffAmbColor__20J3DColorBlockLightOnFv */
@@ -600,7 +594,7 @@ void J3DTexGenBlockBasic::patch() {
 
 /* 8031AC68-8031ACD0 3155A8 0068+00 3/0 0/0 0/0 .text            diff__21J3DTexGenBlockPatchedFUl */
 void J3DTexGenBlockPatched::diff(u32 flag) {
-    if ((flag >> 8) & 0x0f) {
+    if (getDiffFlag_TexGenNum(flag)) {
         diffTexMtx();
         if (flag & 0x1000) {
             diffTexGen();
@@ -650,7 +644,7 @@ void J3DTevBlock1::load() {
 
 /* 8031AFA4-8031B4C0 3158E4 051C+00 1/0 0/0 0/0 .text            load__12J3DTevBlock2Fv */
 void J3DTevBlock2::load() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     mTexNoOffset = GDGetCurrOffset();
     for (u32 i = 0; i < 2; i++) {
         if (mTexNo[i] != 0xffff) {
@@ -709,7 +703,7 @@ void J3DTevBlock2::load() {
 
 /* 8031B4C0-8031BA04 315E00 0544+00 1/0 0/0 0/0 .text            load__12J3DTevBlock4Fv */
 void J3DTevBlock4::load() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     mTexNoOffset = GDGetCurrOffset();
     for (u32 i = 0; i < 4; i++) {
         if (mTexNo[i] != 0xffff) {
@@ -770,7 +764,7 @@ void J3DTevBlock4::load() {
 
 /* 8031BA04-8031BF4C 316344 0548+00 1/0 0/0 0/0 .text            load__13J3DTevBlock16Fv */
 void J3DTevBlock16::load() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     mTexNoOffset = GDGetCurrOffset();
     for (u32 i = 0; i < 8; i++) {
         if (mTexNo[i] != 0xffff) {
@@ -853,10 +847,10 @@ void J3DTevBlockPatched::patchTevReg() {
     void* start = GDGetCurrPointer();
 
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 
     void* end = GDGetCurrPointer();
@@ -869,7 +863,7 @@ void J3DTevBlockPatched::patchTexNoAndTexCoordScale() {
     GDSetCurrOffset(mTexNoOffset);
     void* start = GDGetCurrPointer();
 
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < 8; i++) {
         if (mTexNo[i] != 0xffff) {
             loadTexNo(i, mTexNo[i]);
@@ -977,10 +971,10 @@ void J3DTevBlock2::patchTevReg() {
     void* start = GDGetCurrPointer();
 
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 
     void* end = GDGetCurrPointer();
@@ -1048,10 +1042,10 @@ void J3DTevBlock4::patchTevReg() {
     void* start = GDGetCurrPointer();
 
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 
     void* end = GDGetCurrPointer();
@@ -1064,7 +1058,7 @@ void J3DTevBlock4::patchTexNoAndTexCoordScale() {
     GDSetCurrOffset(mTexNoOffset);
     void* start = GDGetCurrPointer();
 
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < 4; i++) {
         if (mTexNo[i] != 0xffff) {
             loadTexNo(i, mTexNo[i]);
@@ -1121,10 +1115,10 @@ void J3DTevBlock16::patchTevReg() {
     void* start = GDGetCurrPointer();
 
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 
     void* end = GDGetCurrPointer();
@@ -1137,7 +1131,7 @@ void J3DTevBlock16::patchTexNoAndTexCoordScale() {
     GDSetCurrOffset(mTexNoOffset);
     void* start = GDGetCurrPointer();
 
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < 8; i++) {
         if (mTexNo[i] != 0xffff) {
             loadTexNo(i, mTexNo[i]);
@@ -1168,7 +1162,6 @@ void J3DTevBlock16::patchTexNoAndTexCoordScale() {
     DCStoreRange(start, (u32)end - (u32)start);
 }
 
-
 /* 8031CCF8-8031CD44 317638 004C+00 1/0 0/0 0/0 .text            patch__13J3DTevBlock16Fv */
 void J3DTevBlock16::patch() {
     patchTexNo();
@@ -1177,13 +1170,13 @@ void J3DTevBlock16::patch() {
 
 /* 8031CD44-8031CE00 317684 00BC+00 6/0 1/0 0/0 .text            diff__11J3DTevBlockFUl */
 void J3DTevBlock::diff(u32 flag) {
-    if ((flag >> 16) & 0x0f) {
+    if (getDiffFlag_TexNoNum(flag)) {
         diffTexNo();
     }
     if (flag & 0x4000000) {
         diffTexCoordScale();
     }
-    if ((flag >> 20) & 0x0f) {
+    if (getDiffFlag_TevStageNum(flag)) {
         diffTevStage();
         if (flag & 0x8000000) {
             diffTevStageIndirect();
@@ -1206,7 +1199,7 @@ void J3DTevBlockPatched::diffTexNo() {
 
 /* 8031CE64-8031CF78 3177A4 0114+00 1/0 0/0 0/0 .text diffTevStage__18J3DTevBlockPatchedFv */
 void J3DTevBlockPatched::diffTevStage() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mTevStage[i].load(i);
     }
@@ -1215,7 +1208,7 @@ void J3DTevBlockPatched::diffTevStage() {
 /* 8031CF78-8031D028 3178B8 00B0+00 1/0 0/0 0/0 .text diffTevStageIndirect__18J3DTevBlockPatchedFv
  */
 void J3DTevBlockPatched::diffTevStageIndirect() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mIndTevStage[i].load(i);
     }
@@ -1225,16 +1218,16 @@ void J3DTevBlockPatched::diffTevStageIndirect() {
  */
 void J3DTevBlockPatched::diffTevReg() {
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 }
 
 /* 8031D0C4-8031D1BC 317A04 00F8+00 1/0 0/0 0/0 .text diffTexCoordScale__18J3DTevBlockPatchedFv */
 void J3DTevBlockPatched::diffTexCoordScale() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i += 2) {
         loadTexCoordScale(
             GXTexCoordID(mTevOrder[i].getTevOrderInfo().mTexCoord & 7),
@@ -1289,16 +1282,16 @@ void J3DTevBlock2::diffTexNo() {
 /* 8031D434-8031D4D0 317D74 009C+00 1/0 0/0 0/0 .text            diffTevReg__12J3DTevBlock2Fv */
 void J3DTevBlock2::diffTevReg() {
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 }
 
 /* 8031D4D0-8031D5E4 317E10 0114+00 1/0 0/0 0/0 .text            diffTevStage__12J3DTevBlock2Fv */
 void J3DTevBlock2::diffTevStage() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mTevStage[i].load(i);
     }
@@ -1306,7 +1299,7 @@ void J3DTevBlock2::diffTevStage() {
 
 /* 8031D5E4-8031D694 317F24 00B0+00 1/0 0/0 0/0 .text diffTevStageIndirect__12J3DTevBlock2Fv */
 void J3DTevBlock2::diffTevStageIndirect() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mIndTevStage[i].load(i);
     }
@@ -1337,23 +1330,23 @@ void J3DTevBlock4::diffTexNo() {
 /* 8031D7BC-8031D858 3180FC 009C+00 1/0 0/0 0/0 .text            diffTevReg__12J3DTevBlock4Fv */
 void J3DTevBlock4::diffTevReg() {
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 }
 
 /* 8031D858-8031D96C 318198 0114+00 1/0 0/0 0/0 .text            diffTevStage__12J3DTevBlock4Fv */
 void J3DTevBlock4::diffTevStage() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mTevStage[i].load(i);
     }
 }
 /* 8031D96C-8031DA1C 3182AC 00B0+00 1/0 0/0 0/0 .text diffTevStageIndirect__12J3DTevBlock4Fv */
 void J3DTevBlock4::diffTevStageIndirect() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mIndTevStage[i].load(i);
     }
@@ -1362,7 +1355,7 @@ void J3DTevBlock4::diffTevStageIndirect() {
 /* 8031DA1C-8031DB14 31835C 00F8+00 1/0 0/0 0/0 .text            diffTexCoordScale__12J3DTevBlock4Fv
  */
 void J3DTevBlock4::diffTexCoordScale() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i += 2) {
         loadTexCoordScale(
             GXTexCoordID(mTevOrder[i].getTevOrderInfo().mTexCoord & 7),
@@ -1386,16 +1379,16 @@ void J3DTevBlock16::diffTexNo() {
 /* 8031DB78-8031DC14 3184B8 009C+00 1/0 0/0 0/0 .text            diffTevReg__13J3DTevBlock16Fv */
 void J3DTevBlock16::diffTevReg() {
     for (u32 i = 0; i < ARRAY_SIZE(mTevColor) - 1; i++) {
-        J3DGDSetTevColorS10((GXTevRegID)(i + 1), mTevColor[i]);
+        loadTevColor(i, mTevColor[i]);
     }
     for (u32 i = 0; i < ARRAY_SIZE(mTevKColor); i++) {
-        J3DGDSetTevKColor((GXTevKColorID)i, mTevKColor[i]);
+        loadTevKColor(i, mTevKColor[i]);
     }
 }
 
 /* 8031DC14-8031DD28 318554 0114+00 1/0 0/0 0/0 .text            diffTevStage__13J3DTevBlock16Fv */
 void J3DTevBlock16::diffTevStage() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mTevStage[i].load(i);
     }
@@ -1403,7 +1396,7 @@ void J3DTevBlock16::diffTevStage() {
 
 /* 8031DD28-8031DDD8 318668 00B0+00 1/0 0/0 0/0 .text diffTevStageIndirect__13J3DTevBlock16Fv */
 void J3DTevBlock16::diffTevStageIndirect() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i++) {
         mIndTevStage[i].load(i);
     }
@@ -1411,7 +1404,7 @@ void J3DTevBlock16::diffTevStageIndirect() {
 
 /* 8031DDD8-8031DED0 318718 00F8+00 1/0 0/0 0/0 .text diffTexCoordScale__13J3DTevBlock16Fv */
 void J3DTevBlock16::diffTexCoordScale() {
-    u8 tevStageNum = mTevStageNum;
+    u32 tevStageNum = mTevStageNum;
     for (u32 i = 0; i < tevStageNum; i += 2) {
         loadTexCoordScale(
             GXTexCoordID(mTevOrder[i].getTevOrderInfo().mTexCoord & 7),
@@ -1434,8 +1427,10 @@ void J3DTevBlock16::ptrToIndex() {
         if (mTexNo[i] != 0xFFFF) {
             GDSetCurrOffset(mTexNoOffset + offs);
             patchTexNo_PtrToIdx(i, mTexNo[i]);
+            ResTIMG* img = j3dSys.getTexture()->getResTIMG(mTexNo[i]);
+            J3D_ASSERT(0x828, img != 0, "Error : null pointer.");
             offs += 0x14;
-            if (j3dSys.getTexture()->getResTIMG(mTexNo[i])->indexTexture == 1) {
+            if (img->indexTexture == 1) {
                 offs += 0x23;
             }
         }
@@ -1456,8 +1451,10 @@ void J3DTevBlockPatched::ptrToIndex() {
         if (mTexNo[i] != 0xFFFF) {
             GDSetCurrOffset(mTexNoOffset + offs);
             patchTexNo_PtrToIdx(i, mTexNo[i]);
+            ResTIMG* img = j3dSys.getTexture()->getResTIMG(mTexNo[i]);
+            J3D_ASSERT(0x851, img != 0, "Error : null pointer.");
             offs += 0x14;
-            if (j3dSys.getTexture()->getResTIMG(mTexNo[i])->indexTexture == 1) {
+            if (img->indexTexture == 1) {
                 offs += 0x23;
             }
         }
@@ -1523,7 +1520,7 @@ void J3DIndBlockFull::diff(u32 flag) {
     if ((flag & 0x08000000) == 0) {
         return;
     }
-    u8 indTexStageNum = mIndTexStageNum;
+    u32 indTexStageNum = mIndTexStageNum;
     mIndTexMtx[0].load(0);
     J3DGDSetIndTexCoordScale(
         GX_INDTEXSTAGE0,
@@ -1641,6 +1638,8 @@ void J3DPEBlockFull::diff(u32 flag) {
 /* 8031FD08-8031FDE4 31A648 00DC+00 1/0 0/0 0/0 .text
  * reset__21J3DColorBlockLightOffFP13J3DColorBlock              */
 void J3DColorBlockLightOff::reset(J3DColorBlock* pBlock) {
+    J3D_ASSERT(0x982, pBlock != 0, "Error : null pointer.");
+
     mColorChanNum = pBlock->getColorChanNum();
 
     for (u32 i = 0; i < ARRAY_SIZE(mMatColor); i++) {
@@ -1654,6 +1653,8 @@ void J3DColorBlockLightOff::reset(J3DColorBlock* pBlock) {
 /* 8031FDE4-8031FF34 31A724 0150+00 1/0 0/0 0/0 .text
  * reset__22J3DColorBlockAmbientOnFP13J3DColorBlock             */
 void J3DColorBlockAmbientOn::reset(J3DColorBlock* pBlock) {
+    J3D_ASSERT(0x993, pBlock != 0, "Error : null pointer.");
+
     mColorChanNum = pBlock->getColorChanNum();
 
     for (u32 i = 0; i < ARRAY_SIZE(mMatColor); i++) {
@@ -1672,6 +1673,8 @@ void J3DColorBlockAmbientOn::reset(J3DColorBlock* pBlock) {
 /* 8031FF34-80320084 31A874 0150+00 1/0 0/0 0/0 .text
  * reset__20J3DColorBlockLightOnFP13J3DColorBlock               */
 void J3DColorBlockLightOn::reset(J3DColorBlock* pBlock) {
+    J3D_ASSERT(0x9ac, pBlock != 0, "Error : null pointer.");
+
     mColorChanNum = pBlock->getColorChanNum();
 
     for (u32 i = 0; i < ARRAY_SIZE(mMatColor); i++) {
@@ -1690,6 +1693,8 @@ void J3DColorBlockLightOn::reset(J3DColorBlock* pBlock) {
 /* 80320084-803201A0 31A9C4 011C+00 1/0 0/0 0/0 .text
  * reset__21J3DTexGenBlockPatchedFP14J3DTexGenBlock             */
 void J3DTexGenBlockPatched::reset(J3DTexGenBlock* pBlock) {
+    J3D_ASSERT(0x9c8, pBlock != 0, "Error : null pointer.");
+
     mTexGenNum = pBlock->getTexGenNum();
     for (u32 i = 0; i < 8; i++) {
         mTexCoord[i] = *pBlock->getTexCoord(i);
@@ -1709,6 +1714,8 @@ void J3DTexGenBlockPatched::reset(J3DTexGenBlock* pBlock) {
 /* 803201A0-803202DC 31AAE0 013C+00 1/0 0/0 0/0 .text reset__15J3DTexGenBlock4FP14J3DTexGenBlock
  */
 void J3DTexGenBlock4::reset(J3DTexGenBlock* pBlock) {
+    J3D_ASSERT(0x9e9, pBlock != 0, "Error : null pointer.");
+
     mTexGenNum = pBlock->getTexGenNum();
     for (u32 i = 0; i < 4; i++) {
         mTexCoord[i] = *pBlock->getTexCoord(i);
@@ -1730,6 +1737,8 @@ void J3DTexGenBlock4::reset(J3DTexGenBlock* pBlock) {
 /* 803202DC-80320418 31AC1C 013C+00 1/0 0/0 0/0 .text
  * reset__19J3DTexGenBlockBasicFP14J3DTexGenBlock               */
 void J3DTexGenBlockBasic::reset(J3DTexGenBlock* pBlock) {
+    J3D_ASSERT(0xa0c, pBlock != 0, "Error : null pointer.");
+
     mTexGenNum = pBlock->getTexGenNum();
     for (u32 i = 0; i < 8; i++) {
         mTexCoord[i] = *pBlock->getTexCoord(i);
@@ -1751,6 +1760,8 @@ void J3DTexGenBlockBasic::reset(J3DTexGenBlock* pBlock) {
 /* 80320418-803205D4 31AD58 01BC+00 1/0 0/0 0/0 .text reset__18J3DTevBlockPatchedFP11J3DTevBlock
  */
 void J3DTevBlockPatched::reset(J3DTevBlock* pBlock) {
+    J3D_ASSERT(0xa30, pBlock != 0, "Error : null pointer.");
+
     mTevStageNum = pBlock->getTevStageNum();
     for (u32 i = 0; i < 8; i++) {
         mTexNo[i] = pBlock->getTexNo(i);
@@ -1769,6 +1780,8 @@ void J3DTevBlockPatched::reset(J3DTevBlock* pBlock) {
 
 /* 803205D4-803206AC 31AF14 00D8+00 1/0 0/0 0/0 .text reset__12J3DTevBlock1FP11J3DTevBlock */
 void J3DTevBlock1::reset(J3DTevBlock* pBlock) {
+    J3D_ASSERT(0xa49, pBlock != 0, "Error : null pointer.");
+
     mTexNo[0] = pBlock->getTexNo(0);
     mTevOrder[0] = *pBlock->getTevOrder(0);
     mTevStage[0] = *pBlock->getTevStage(0);
@@ -1777,6 +1790,8 @@ void J3DTevBlock1::reset(J3DTevBlock* pBlock) {
 
 /* 803206AC-8032098C 31AFEC 02E0+00 1/0 0/0 0/0 .text reset__12J3DTevBlock2FP11J3DTevBlock */
 void J3DTevBlock2::reset(J3DTevBlock* pBlock) {
+    J3D_ASSERT(0xa59, pBlock != 0, "Error : null pointer.");
+
     mTevStageNum = pBlock->getTevStageNum();
     mTexNo[0] = pBlock->getTexNo(0);
     mTexNo[1] = pBlock->getTexNo(1);
@@ -1803,6 +1818,8 @@ void J3DTevBlock2::reset(J3DTevBlock* pBlock) {
 
 /* 8032098C-80320E24 31B2CC 0498+00 1/0 0/0 0/0 .text reset__12J3DTevBlock4FP11J3DTevBlock */
 void J3DTevBlock4::reset(J3DTevBlock* pBlock) {
+    J3D_ASSERT(0xa7a, pBlock != 0, "Error : null pointer.");
+
     mTevStageNum = pBlock->getTevStageNum();
     mTexNo[0] = pBlock->getTexNo(0);
     mTexNo[1] = pBlock->getTexNo(1);
@@ -1838,6 +1855,8 @@ void J3DTevBlock4::reset(J3DTevBlock* pBlock) {
 
 /* 80320E24-803210B0 31B764 028C+00 1/0 0/0 0/0 .text reset__13J3DTevBlock16FP11J3DTevBlock */
 void J3DTevBlock16::reset(J3DTevBlock* pBlock) {
+    J3D_ASSERT(0xaa8, pBlock != 0, "Error : null pointer.");
+
     mTevStageNum = pBlock->getTevStageNum();
     for (u32 i = 0; i < 8; i++) {
         mTexNo[i] = pBlock->getTexNo(i);
@@ -1868,6 +1887,8 @@ void J3DTevBlock16::reset(J3DTevBlock* pBlock) {
 
 /* 803210B0-803211B4 31B9F0 0104+00 1/0 0/0 0/0 .text reset__15J3DIndBlockFullFP11J3DIndBlock */
 void J3DIndBlockFull::reset(J3DIndBlock* pBlock) {
+    J3D_ASSERT(0xaca, pBlock != 0, "Error : null pointer.");
+
     mIndTexStageNum = pBlock->getIndTexStageNum();
     for (u32 i = 0; i < 4; i++) {
         mIndTexOrder[i] = *pBlock->getIndTexOrder(i);
@@ -1882,6 +1903,8 @@ void J3DIndBlockFull::reset(J3DIndBlock* pBlock) {
 
 /* 803211B4-8032129C 31BAF4 00E8+00 1/0 0/0 0/0 .text reset__16J3DPEBlockFogOffFP10J3DPEBlock */
 void J3DPEBlockFogOff::reset(J3DPEBlock* pBlock) {
+    J3D_ASSERT(0xadf, pBlock != 0, "Error : null pointer.");
+
     switch (pBlock->getType()) {
     case 'PEFL':
     case 'PEFG':
@@ -1895,8 +1918,10 @@ void J3DPEBlockFogOff::reset(J3DPEBlock* pBlock) {
 
 /* 8032129C-803213C0 31BBDC 0124+00 1/0 0/0 0/0 .text reset__14J3DPEBlockFullFP10J3DPEBlock */
 void J3DPEBlockFull::reset(J3DPEBlock* pBlock) {
+    J3D_ASSERT(0xaf7, pBlock != 0, "Error : null pointer.");
+
     if (pBlock->getFog() != NULL) {
-        mFog = *pBlock->getFog();
+        this->mFog.setFogInfo(pBlock->getFog()->getFogInfo());
     }
 
     switch (pBlock->getType()) {
@@ -1915,7 +1940,7 @@ void J3DTexGenBlockPatched::calc(const Mtx modelMtx) {
     Mtx viewMtx;
     for (int i = 0; i < 8; i++) {
         if (mTexMtx[i] != NULL) {
-            u8 texMtxMode = mTexMtx[i]->getTexMtxInfo().mInfo & 0x3f;
+            u32 texMtxMode = mTexMtx[i]->getTexMtxInfo().mInfo & 0x3f;
             mTexCoord[i].resetTexMtxReg();
             switch (texMtxMode) {
             case J3DTexMtxMode_EnvmapBasic:
@@ -1976,7 +2001,7 @@ void J3DTexGenBlockPatched::calcWithoutViewMtx(const Mtx modelMtx) {
     Mtx mtx;
     for (int i = 0; i < 8; i++) {
         if (mTexMtx[i] != NULL) {
-            u8 texMtxMode = mTexMtx[i]->getTexMtxInfo().mInfo & 0x3f;
+            u32 texMtxMode = mTexMtx[i]->getTexMtxInfo().mInfo & 0x3f;
             mTexCoord[i].resetTexMtxReg();
             switch (texMtxMode) {
             case J3DTexMtxMode_EnvmapBasic:
@@ -2023,7 +2048,7 @@ void J3DTexGenBlockPatched::calcPostTexMtx(const Mtx modelMtx) {
     Mtx mtx1, mtx2;
     for (int i = 0; i < 8; i++) {
         if (mTexMtx[i] != NULL) {
-            u8 texMtxMode = mTexMtx[i]->getTexMtxInfo().mInfo & 0x3f;
+            u32 texMtxMode = mTexMtx[i]->getTexMtxInfo().mInfo & 0x3f;
             mTexCoord[i].resetTexMtxReg();
             switch (texMtxMode) {
             case J3DTexMtxMode_EnvmapBasic:
@@ -2034,7 +2059,7 @@ void J3DTexGenBlockPatched::calcPostTexMtx(const Mtx modelMtx) {
                 break;
             case J3DTexMtxMode_ProjmapBasic:
             case J3DTexMtxMode_Projmap:
-                MTXInverse(j3dSys.getViewMtx(), mtx1);
+                PSMTXInverse(j3dSys.getViewMtx(), mtx1);
                 mTexCoord[i].setTexMtxReg(0);
                 mTexMtx[i]->calcPostTexMtx(mtx1);
                 break;
@@ -2046,7 +2071,7 @@ void J3DTexGenBlockPatched::calcPostTexMtx(const Mtx modelMtx) {
             case J3DTexMtxMode_Unknown5:
             case J3DTexMtxMode_EnvmapOldEffectMtx:
             case J3DTexMtxMode_EnvmapEffectMtx:
-                MTXInverse(j3dSys.getViewMtx(), mtx2);
+                PSMTXInverse(j3dSys.getViewMtx(), mtx2);
                 mtx2[0][3] = 0.0f;
                 mtx2[1][3] = 0.0f;
                 mtx2[2][3] = 0.0f;
@@ -2056,7 +2081,7 @@ void J3DTexGenBlockPatched::calcPostTexMtx(const Mtx modelMtx) {
             default:
                 mTexCoord[i].setTexMtxReg(60);
                 mTexMtx[i]->calcPostTexMtx(j3dDefaultMtx);
-                break;
+                continue;
             }
         }
     }
@@ -2099,4 +2124,23 @@ void J3DTexGenBlockPatched::calcPostTexMtxWithoutViewMtx(f32 const (*param_0)[4]
             }
         }
     }
+}
+
+void J3DTevBlock::diffTevReg() {
+    // empty function
+}
+
+void J3DTevBlock::diffTevStageIndirect() {
+    // empty function
+}
+
+void J3DTevBlock::diffTevStage() {
+    // empty function
+}
+
+void J3DTevBlock::diffTexCoordScale() {
+    // empty function
+}
+
+void J3DTevBlock::diffTexNo() {
 }

--- a/src/JSystem/J3DGraphBase/J3DShape.cpp
+++ b/src/JSystem/J3DGraphBase/J3DShape.cpp
@@ -110,8 +110,8 @@ void J3DShape::calcNBTScale(Vec const& param_0, f32 (*param_1)[3][3], f32 (*para
 }
 
 /* 80314E28-80314E98 30F768 0070+00 0/0 1/1 0/0 .text            countBumpMtxNum__8J3DShapeCFv */
-u32 J3DShape::countBumpMtxNum() const {
-    u32 num = 0;
+u16 J3DShape::countBumpMtxNum() const {
+    u16 num = 0;
     for (u16 i = 0; i < mMtxGroupNum; i++)
         num += mShapeMtx[i]->getUseMtxNum();
     return num;

--- a/src/JSystem/J3DGraphBase/J3DShapeMtx.cpp
+++ b/src/JSystem/J3DGraphBase/J3DShapeMtx.cpp
@@ -109,7 +109,6 @@ J3DTexGenBlock* J3DDifferedTexMtx::sTexGenBlock;
 J3DTexMtxObj* J3DDifferedTexMtx::sTexMtxObj;
 
 /* 8031322C-80313828 30DB6C 05FC+00 7/5 0/0 0/0 .text loadExecute__17J3DDifferedTexMtxFPA4_Cf */
-// NONMATCHING regalloc
 void J3DDifferedTexMtx::loadExecute(f32 const (*param_0)[4]) {
     static Mtx qMtx = {
         {0.5f, 0.0f, 0.5f, 0.0f},
@@ -121,194 +120,193 @@ void J3DDifferedTexMtx::loadExecute(f32 const (*param_0)[4]) {
         {0.0f, -0.5f, 0.0f, 0.5f},
         {0.0f, 0.0f, 1.0f, 0.0f}
     };
-    J3DTexCoord* tex_coord;
-    J3DTexMtx* tex_mtx;
-    Mtx* mtx;
-    Mtx44* eff_mtx;
-    Mtx tmp2;
-    Mtx44 tmp1, tmp0;
-    J3DTexMtxInfo* tex_mtx_info;
-    J3DTexGenBlock* tex_gen_block = sTexGenBlock;
-    J3DTexMtxObj* tex_mtx_obj = sTexMtxObj;
+
+    Mtx* mtx; // sp_64
+    Mtx sp_e8;
+    Mtx44 sp_a8, sp_68;
+
+    J3DTexGenBlock* tex_gen_block = sTexGenBlock; // sp_60
+    JUT_ASSERT_MSG(0xc3, tex_gen_block != NULL, "Error : null pointer");
+
+    J3DTexMtxObj* tex_mtx_obj = sTexMtxObj; // sp_5c
+    JUT_ASSERT_MSG(0xc6, tex_mtx_obj != NULL, "Error : null pointer");
+
+    J3DTexMtxInfo* tex_mtx_info_1; // sp_58
+    int tex_gen_type; // sp_54
+    J3DTexMtx* tex_mtx_2; // sp_50
+
     u16 tex_mtx_num = tex_mtx_obj->getNumTexMtx();
-    if ((j3dSys.checkFlag(J3DSysFlag_PostTexMtx))) {
-        for (u16 i = 0; i < (u16)tex_mtx_num; i++) {
-            tex_coord = tex_gen_block->getTexCoord(i);
-            int tex_gen_type = tex_coord->getTexGenType();
+
+    if (j3dSys.checkFlag(J3DSysFlag_PostTexMtx)) {
+        for (u16 i = 0; i < tex_mtx_num; i++) {
+            tex_gen_type = tex_gen_block->getTexCoord(i)->getTexGenType();
             if (tex_gen_type == 1 || tex_gen_type == 0) {
-                tex_mtx = tex_gen_block->getTexMtx(i);
-                u8 tex_gen_src = tex_mtx->getTexMtxInfo().mInfo;
-                u32 unk;
-                switch (tex_gen_src & 0x3f) {
+                tex_mtx_2 = tex_gen_block->getTexMtx(i);
+                JUT_ASSERT_MSG(0xd7, tex_mtx_2 != NULL, "Error : null pointer");
+                tex_mtx_info_1 = &tex_mtx_2->getTexMtxInfo();
+                u32 sp_4c = tex_mtx_info_1->mInfo & 0x3f;
+                switch (sp_4c) {
                 case 3:
                 case 9: {
-                    Mtx& tmp5 = tex_mtx_obj->getMtx(i);
-                    mtx = &tmp5;
+                    mtx = &tex_mtx_obj->getMtx(i);
                     break;
                 }
                 case 1:
                 case 6:
                 case 7: {
-                    Mtx& tmp6 = tex_mtx_obj->getMtx(i);
-                    mtx = &tmp6;
+                    mtx = &tex_mtx_obj->getMtx(i);
                     break;
                 }
                 case 2:
-                case 8:
-                    PSMTXInverse(j3dSys.mViewMtx, tmp2);
-                    PSMTXConcat(tex_mtx_obj->getMtx(i), tmp2, tmp2);
-                    mtx = &tmp2;
+                case 8: {
+                    MTXInverse(j3dSys.getViewMtx(), sp_e8);
+                    MTXConcat(tex_mtx_obj->getMtx(i), sp_e8, sp_e8);
+                    mtx = &sp_e8;
                     break;
-                case 5:
-                    tex_mtx_info = &tex_mtx->getTexMtxInfo();
-                    unk = (tex_gen_src & 0x80) >> 7;
-                    if (unk == 0) {
-                        J3DGetTextureMtxOld(tex_mtx_info->mSRT, tex_mtx_info->mCenter, tmp0);
-                    } else if (unk == 1) {
-                        J3DGetTextureMtxMayaOld(tex_mtx_info->mSRT, tmp0);
+                }
+                case 5: {
+                    J3DTexMtxInfo* tex_mtx_info_2 = &tex_mtx_2->getTexMtxInfo(); // sp_48
+                    u32 sp_44 = (u32)(tex_mtx_info_2->mInfo & 0x80) >> 7;
+                    if (sp_44 == 0) {
+                        J3DGetTextureMtxOld(tex_mtx_info_2->mSRT, tex_mtx_info_2->mCenter, sp_68);
+                    } else if (sp_44 == 1) {
+                        J3DGetTextureMtxMayaOld(tex_mtx_info_2->mSRT, sp_68);
                     }
-                    eff_mtx = &tex_mtx_obj->getEffectMtx(i);
-                    J3DMtxProjConcat(tmp0, *eff_mtx, tmp2);
-                    PSMTXInverse(j3dSys.mViewMtx, tmp1);
-                    PSMTXConcat(tmp2, tmp1, tmp2);
-                    tmp2[2][3] = 0.0f;
-                    tmp2[1][3] = 0.0f;
-                    tmp2[0][3] = 0.0f;
-                    mtx = &tmp2;
+                    J3DMtxProjConcat(sp_68, tex_mtx_obj->getEffectMtx(i), sp_e8);
+                    MTXInverse(j3dSys.getViewMtx(), sp_a8);
+                    MTXConcat(sp_e8, sp_a8, sp_e8);
+                    sp_e8[0][3] = sp_e8[1][3] = sp_e8[2][3] = 0.0f;
+                    mtx = &sp_e8;
                     break;
-                case 10:
-                    tex_mtx_info = &tex_mtx->getTexMtxInfo();
-                    unk = (tex_gen_src & 0x80) >> 7;
-                    if (unk == 0) {
-                        J3DGetTextureMtx(tex_mtx_info->mSRT, tex_mtx_info->mCenter, tmp0);
-                    } else if (unk == 1) {
-                        J3DGetTextureMtxMaya(tex_mtx_info->mSRT, tmp0);
+                }
+                case 11: {
+                    J3DTexMtxInfo* tex_mtx_info_2 = &tex_mtx_2->getTexMtxInfo(); // sp_40
+                    u32 sp_3c = (u32)(tex_mtx_info_2->mInfo & 0x80) >> 7;
+                    if (sp_3c == 0) {
+                        J3DGetTextureMtx(tex_mtx_info_2->mSRT, tex_mtx_info_2->mCenter, sp_68);
+                    } else if (sp_3c == 1) {
+                        J3DGetTextureMtxMaya(tex_mtx_info_2->mSRT, sp_68);
                     }
-                    PSMTXConcat(tmp0, qMtx, tmp0);
-                    eff_mtx = &tex_mtx_obj->getEffectMtx(i);
-                    J3DMtxProjConcat(tmp0, *eff_mtx, tmp2);
-                    PSMTXInverse(j3dSys.mViewMtx, tmp1);
-                    PSMTXConcat(tmp2, tmp1, tmp2);
-                    tmp2[2][3] = 0.0f;
-                    tmp2[1][3] = 0.0f;
-                    tmp2[0][3] = 0.0f;
-                    mtx = &tmp2;
+                    MTXConcat(sp_68, qMtx, sp_68);
+                    J3DMtxProjConcat(sp_68, tex_mtx_obj->getEffectMtx(i), sp_e8);
+                    MTXInverse(j3dSys.getViewMtx(), sp_a8);
+                    MTXConcat(sp_e8, sp_a8, sp_e8);
+                    sp_e8[0][3] = sp_e8[1][3] = sp_e8[2][3] = 0.0f;
+                    mtx = &sp_e8;
                     break;
-                case 11:
-                    tex_mtx_info = &tex_mtx->getTexMtxInfo();
-                    unk = (tex_gen_src & 0x80) >> 7;
-                    if (unk == 0) {
-                        J3DGetTextureMtx(tex_mtx_info->mSRT, tex_mtx_info->mCenter, tmp0);
-                    } else if (unk == 1) {
-                        J3DGetTextureMtxMaya(tex_mtx_info->mSRT, tmp0);
+                }
+                case 10: {
+                    J3DTexMtxInfo* tex_mtx_info_2 = &tex_mtx_2->getTexMtxInfo(); // sp_38
+                    u32 sp_34 = (u32)(tex_mtx_info_2->mInfo & 0x80) >> 7;
+                    if (sp_34 == 0) {
+                        J3DGetTextureMtx(tex_mtx_info_2->mSRT, tex_mtx_info_2->mCenter, sp_68);
+                    } else if (sp_34 == 1) {
+                        J3DGetTextureMtxMaya(tex_mtx_info_2->mSRT, sp_68);
                     }
-                    PSMTXConcat(tmp0, qMtx2, tmp0);
-                    eff_mtx = &tex_mtx_obj->getEffectMtx(i);
-                    J3DMtxProjConcat(tmp0, *eff_mtx, tmp2);
-                    PSMTXInverse(j3dSys.mViewMtx, tmp1);
-                    PSMTXConcat(tmp2, tmp1, tmp2);
-                    tmp2[2][3] = 0.0f;
-                    tmp2[1][3] = 0.0f;
-                    tmp2[0][3] = 0.0f;
-                    mtx = &tmp2;
+                    MTXConcat(sp_68, qMtx2, sp_68);
+                    J3DMtxProjConcat(sp_68, tex_mtx_obj->getEffectMtx(i), sp_e8);
+                    MTXInverse(j3dSys.getViewMtx(), sp_a8);
+                    MTXConcat(sp_e8, sp_a8, sp_e8);
+                    sp_e8[0][3] = sp_e8[1][3] = sp_e8[2][3] = 0.0f;
+                    mtx = &sp_e8;
                     break;
-                default:
-                    Mtx& tmp7 = tex_mtx_obj->getMtx(i);
-                    mtx = &tmp7;
-                    break;
+                }
+                case 0:
+                case 4:
+                default: {
+                    mtx = &tex_mtx_obj->getMtx(i);
+                }
                 }
                 GXLoadTexMtxImm(*mtx, i * 3 + 0x40, GX_MTX3x4);
             }
         }
     } else {
-        for (u16 i = 0; i < (u16)tex_mtx_num; i++) {
+        for (u16 i = 0; i < tex_mtx_num; i++) {
             int tex_gen_type = tex_gen_block->getTexCoord(i)->getTexGenType();
             if (tex_gen_type == 1 || tex_gen_type == 0) {
-                tex_mtx = tex_gen_block->getTexMtx(i);
-                u8 tex_gen_src = tex_mtx->getTexMtxInfo().mInfo;
-                u32 unk;
-                switch (tex_gen_src & 0x3f) {
+                J3DTexMtx* tex_mtx = tex_gen_block->getTexMtx(i); // sp_2c
+                JUT_ASSERT_MSG(0x145, tex_mtx != NULL, "Error : null pointer");
+                tex_mtx_info_1 = &tex_mtx->getTexMtxInfo();
+                u32 tex_gen_src = tex_mtx_info_1->mInfo & 0x3f; // sp_28
+                switch (tex_gen_src) {
                 case 3:
                 case 9:
-                    PSMTXConcat(tex_mtx_obj->getMtx(i), param_0, tmp2);
-                    mtx = &tmp2;
+                    MTXConcat(tex_mtx_obj->getMtx(i), param_0, sp_e8);
+                    mtx = &sp_e8;
                     break;
                 case 1:
                 case 6:
                 case 7:
-                    PSMTXCopy(param_0, tmp1);
-                    tmp1[2][3] = 0.0f;
-                    tmp1[1][3] = 0.0f;
-                    tmp1[0][3] = 0.0f;
-                    PSMTXConcat(tex_mtx_obj->getMtx(i), tmp1, tmp2);
-                    mtx = &tmp2;
+                    MTXCopy(param_0, sp_a8);
+                    sp_a8[0][3] = sp_a8[1][3] = sp_a8[2][3] = 0.0f;
+                    MTXConcat(tex_mtx_obj->getMtx(i), sp_a8, sp_e8);
+                    mtx = &sp_e8;
                     break;
                 case 2:
                 case 8:
                     mtx = &tex_mtx_obj->getMtx(i);
                     break;
-                case 5:
-                    tex_mtx_info = &tex_mtx->getTexMtxInfo();
-                    unk = (tex_gen_src & 0x80) >> 7;
-                    if (unk == 0) {
-                        J3DGetTextureMtxOld(tex_mtx_info->mSRT, tex_mtx_info->mCenter, tmp0);
-                    } else if (unk == 1) {
-                        J3DGetTextureMtxMayaOld(tex_mtx_info->mSRT, tmp0);
+                case 5: {
+                    J3DTexMtxInfo* tex_mtx_info_2 = &tex_mtx->getTexMtxInfo(); // sp_24
+                    u32 sp_24 = (u32)(tex_mtx_info_2->mInfo & 0x80) >> 7;
+                    if (sp_24 == 0) {
+                        J3DGetTextureMtxOld(tex_mtx_info_2->mSRT, tex_mtx_info_2->mCenter, sp_68);
+                    } else if (sp_24 == 1) {
+                        J3DGetTextureMtxMayaOld(tex_mtx_info_2->mSRT, sp_68);
                     }
-                    eff_mtx = &tex_mtx_obj->getEffectMtx(i);
-                    J3DMtxProjConcat(tmp0, *eff_mtx, tmp2);
-                    PSMTXInverse(j3dSys.mViewMtx, tmp1);
-                    PSMTXConcat(tmp2, tmp1, tmp2);
-                    PSMTXConcat(tmp2, param_0, tmp2);
-                    tmp2[2][3] = 0.0f;
-                    tmp2[1][3] = 0.0f;
-                    tmp2[0][3] = 0.0f;
-                    mtx = &tmp2;
+                    J3DMtxProjConcat(sp_68, tex_mtx_obj->getEffectMtx(i), sp_e8);
+                    MTXInverse(j3dSys.getViewMtx(), sp_a8);
+                    MTXConcat(sp_e8, sp_a8, sp_e8);
+                    MTXConcat(sp_e8, param_0, sp_e8);
+                    sp_e8[0][3] = sp_e8[1][3] = sp_e8[2][3] = 0.0f;
+                    mtx = &sp_e8;
                     break;
-                case 10:
-                    tex_mtx_info = &tex_mtx->getTexMtxInfo();
-                    unk = (tex_gen_src & 0x80) >> 7;
-                    if (unk == 0) {
-                        J3DGetTextureMtx(tex_mtx_info->mSRT, tex_mtx_info->mCenter, tmp0);
-                    } else if (unk == 1) {
-                        J3DGetTextureMtxMaya(tex_mtx_info->mSRT, tmp0);
+                }
+                case 11: {
+                    J3DTexMtxInfo* tex_mtx_info_2 = &tex_mtx->getTexMtxInfo(); // sp_1c
+                    u32 sp_18 = (u32)(tex_mtx_info_2->mInfo & 0x80) >> 7;
+                    if (sp_18 == 0) {
+                        J3DGetTextureMtx(tex_mtx_info_2->mSRT, tex_mtx_info_2->mCenter, sp_68);
+                    } else if (sp_18 == 1) {
+                        J3DGetTextureMtxMaya(tex_mtx_info_2->mSRT, sp_68);
                     }
-                    PSMTXConcat(tmp0, qMtx, tmp0);
-                    eff_mtx = &tex_mtx_obj->getEffectMtx(i);
-                    J3DMtxProjConcat(tmp0, *eff_mtx, tmp2);
-                    PSMTXInverse(j3dSys.mViewMtx, tmp1);
-                    PSMTXConcat(tmp2, tmp1, tmp2);
-                    PSMTXConcat(tmp2, param_0, tmp2);
-                    tmp2[2][3] = 0.0f;
-                    tmp2[1][3] = 0.0f;
-                    tmp2[0][3] = 0.0f;
-                    mtx = &tmp2;
+                    MTXConcat(sp_68, qMtx, sp_68);
+                    J3DMtxProjConcat(sp_68, tex_mtx_obj->getEffectMtx(i), sp_e8);
+                    MTXInverse(j3dSys.getViewMtx(), sp_a8);
+                    MTXConcat(sp_e8, sp_a8, sp_e8);
+                    MTXConcat(sp_e8, param_0, sp_e8);
+                    sp_e8[0][3] = sp_e8[1][3] = sp_e8[2][3] = 0.0f;
+                    mtx = &sp_e8;
                     break;
-                case 11:
-                    tex_mtx_info = &tex_mtx->getTexMtxInfo();
-                    unk = (tex_gen_src & 0x80) >> 7;
-                    if (unk == 0) {
-                        J3DGetTextureMtx(tex_mtx_info->mSRT, tex_mtx_info->mCenter, tmp0);
-                    } else if (unk == 1) {
-                        J3DGetTextureMtxMaya(tex_mtx_info->mSRT, tmp0);
+                }
+                case 10: {
+                    J3DTexMtxInfo* tex_mtx_info_2 = &tex_mtx->getTexMtxInfo(); // sp_14
+                    u32 sp_10 = (u32)(tex_mtx_info_2->mInfo & 0x80) >> 7;
+                    if (sp_10 == 0) {
+                        J3DGetTextureMtx(tex_mtx_info_2->mSRT, tex_mtx_info_2->mCenter, sp_68);
+                    } else if (sp_10 == 1) {
+                        J3DGetTextureMtxMaya(tex_mtx_info_2->mSRT, sp_68);
                     }
-                    PSMTXConcat(tmp0, qMtx2, tmp0);
-                    eff_mtx = &tex_mtx_obj->getEffectMtx(i);
-                    J3DMtxProjConcat(tmp0, *eff_mtx, tmp2);
-                    PSMTXInverse(j3dSys.mViewMtx, tmp1);
-                    PSMTXConcat(tmp2, tmp1, tmp2);
-                    PSMTXConcat(tmp2, param_0, tmp2);
-                    tmp2[2][3] = 0.0f;
-                    tmp2[1][3] = 0.0f;
-                    tmp2[0][3] = 0.0f;
-                    mtx = &tmp2;
+                    MTXConcat(sp_68, qMtx2, sp_68);
+                    J3DMtxProjConcat(sp_68, tex_mtx_obj->getEffectMtx(i), sp_e8);
+                    MTXInverse(j3dSys.getViewMtx(), sp_a8);
+                    MTXConcat(sp_e8, sp_a8, sp_e8);
+                    MTXConcat(sp_e8, param_0, sp_e8);
+                    sp_e8[2][3] = 0.0f;
+                    sp_e8[1][3] = 0.0f;
+                    sp_e8[0][3] = 0.0f;
+                    mtx = &sp_e8;
                     break;
-                default:
+                }
+                case 0:
+                case 4:
+                default: {
                     mtx = &tex_mtx_obj->getMtx(i);
                     break;
                 }
-                GXLoadTexMtxImm(*mtx, i * 3 + 0x1e,
-                                (GXTexMtxType)tex_mtx->getTexMtxInfo().mProjection);
+                }
+                GXLoadTexMtxImm(*mtx, i * 3 + 30,
+                                (GXTexMtxType)tex_mtx_info_1->mProjection);
             }
         }
     }

--- a/src/JSystem/J3DGraphBase/J3DTexture.cpp
+++ b/src/JSystem/J3DGraphBase/J3DTexture.cpp
@@ -4,10 +4,14 @@
 //
 
 #include "JSystem/J3DGraphBase/J3DTexture.h"
+
 #include "dolphin/gx.h"
+#include "global.h"
 
 /* 8031204C-803121A4 30C98C 0158+00 0/0 1/1 0/0 .text loadGX__10J3DTextureCFUs11_GXTexMapID */
 void J3DTexture::loadGX(u16 idx, GXTexMapID texMapID) const {
+    J3D_ASSERT(0, idx < mNum, "Error : range over.");
+
     ResTIMG* timg = getResTIMG(idx);
     GXTexObj texObj;
 
@@ -37,8 +41,11 @@ void J3DTexture::loadGX(u16 idx, GXTexMapID texMapID) const {
 
 /* 803121A4-8031221C 30CAE4 0078+00 1/1 0/0 0/0 .text            entryNum__10J3DTextureFUs */
 void J3DTexture::entryNum(u16 num) {
+    J3D_ASSERT(79, num != 0, "Error : non-zero argument is specified 0.");
+
     mNum = num;
     mpRes = new ResTIMG[num]();
+    J3D_ASSERT(83, mpRes != 0, "Error : allocate memory.");
 
     for (s32 i = 0; i < mNum; i++) {
         mpRes[i].paletteOffset = 0;
@@ -51,20 +58,18 @@ void J3DTexture::addResTIMG(u16 newNum, ResTIMG const* newRes) {
     if (newNum == 0)
         return;
 
+    J3D_ASSERT(105, newRes != 0, "Error : null pointer.");
+
     u16 oldNum = mNum;
     ResTIMG* oldRes = mpRes;
 
     entryNum(mNum + newNum);
 
     for (u16 i = 0; i < oldNum; i++) {
-        mpRes[i] = oldRes[i];
-        mpRes[i].imageOffset = (u32)(&oldRes[i]) + mpRes[i].imageOffset - (u32)(&mpRes[i]);
-        mpRes[i].paletteOffset = (u32)(&oldRes[i]) + mpRes[i].paletteOffset - (u32)(&mpRes[i]);
+        setResTIMG(i, oldRes[i]);
     }
 
     for (u16 i = oldNum; i < mNum; i++) {
-        mpRes[i] = newRes[i];
-        mpRes[i].imageOffset = (u32)(&newRes[i]) + mpRes[i].imageOffset - (u32)(&mpRes[i]);
-        mpRes[i].paletteOffset = (u32)(&newRes[i]) + mpRes[i].paletteOffset - (u32)(&mpRes[i]);
+        setResTIMG(i, newRes[i]);
     }
 }


### PR DESCRIPTION
This PR includes some improvements for J3D* classes, including `J3DShapeMtx` which is now matching. `J3DMatBlock` is also equivalent, but has virtual function ordering issues specifically relating to `J3DTevBlock` - any input on how to resolve these would be greatly appreciated!