### PR TITLE
Fix incorrect PCH being used in some framework objects

### DIFF
--- a/include/d/dolzel_rel.h
+++ b/include/d/dolzel_rel.h
@@ -1,7 +1,6 @@
 #ifndef DOLZEL_REL_H
 #define DOLZEL_REL_H
 
-// PCH breaks debug build for RELs right now
 #if __MWERKS__
 #include "d/dolzel_rel.mch"
 #else

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -3,7 +3,7 @@
  * Player (Link) Actor
  */
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_alink.h"
 #include "JSystem/J2DGraph/J2DAnmLoader.h"

--- a/src/d/actor/d_a_itembase.cpp
+++ b/src/d/actor/d_a_itembase.cpp
@@ -3,7 +3,7 @@
  * Item Actor base
  */
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_itembase.h"
 #include "d/d_com_inf_game.h"

--- a/src/d/actor/d_a_no_chg_room.cpp
+++ b/src/d/actor/d_a_no_chg_room.cpp
@@ -3,7 +3,7 @@
  *
  */
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_no_chg_room.h"
 #include "d/d_s_room.h"

--- a/src/d/actor/d_a_npc.cpp
+++ b/src/d/actor/d_a_npc.cpp
@@ -1,4 +1,4 @@
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_npc.h"
 #include "d/actor/d_a_npc_tk.h"

--- a/src/d/actor/d_a_npc2.cpp
+++ b/src/d/actor/d_a_npc2.cpp
@@ -1,5 +1,3 @@
-#include "d/dolzel_rel.h"
-
 #include "d/actor/d_a_npc.h"
 
 static s32 daBaseNpc_chkPnt(cXyz param_0, dPnt* param_1, u16 param_2, u16 param_3, int param_4, int param_5);

--- a/src/d/actor/d_a_npc3.cpp
+++ b/src/d/actor/d_a_npc3.cpp
@@ -1,5 +1,3 @@
-#include "d/dolzel_rel.h"
-
 #include "d/actor/d_a_npc.h"
 #include "d/d_bg_w.h"
 

--- a/src/d/actor/d_a_npc4.cpp
+++ b/src/d/actor/d_a_npc4.cpp
@@ -1,5 +1,3 @@
-#include "d/dolzel_rel.h"
-
 #include "d/actor/d_a_npc.h"
 #include "d/actor/d_a_npc_tk.h"
 #include "d/d_msg_object.h"

--- a/src/d/actor/d_a_npc_cd.cpp
+++ b/src/d/actor/d_a_npc_cd.cpp
@@ -3,7 +3,7 @@
 // Translation Unit: a/npc/d_a_npc_cd
 //
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_npc_cd.h"
 #include "d/actor/d_a_player.h"

--- a/src/d/actor/d_a_npc_cd2.cpp
+++ b/src/d/actor/d_a_npc_cd2.cpp
@@ -3,7 +3,7 @@
 // Translation Unit: a/npc/d_a_npc_cd2
 //
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_npc_cd2.h"
 #include "d/actor/d_a_player.h"

--- a/src/d/actor/d_a_obj_item.cpp
+++ b/src/d/actor/d_a_obj_item.cpp
@@ -3,7 +3,7 @@
  * Item (Rupee, Arrow, Heart, etc) Object Actor
  */
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_obj_item.h"
 #include "SSystem/SComponent/c_math.h"

--- a/src/d/actor/d_a_obj_ss_base.cpp
+++ b/src/d/actor/d_a_obj_ss_base.cpp
@@ -3,7 +3,7 @@
 // Translation Unit: a/obj/d_a_obj_ss_base
 //
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_obj_ss_base.h"
 #include "f_op/f_op_actor_mng.h"

--- a/src/d/actor/d_a_player.cpp
+++ b/src/d/actor/d_a_player.cpp
@@ -3,7 +3,7 @@
  * Base Player Actor functionality
  */
 
-#include "d/dolzel_rel.h"
+#include "d/dolzel.h"
 
 #include "d/actor/d_a_player.h"
 #include "JSystem/J3DGraphLoader/J3DAnmLoader.h"


### PR DESCRIPTION
This PR fixes an issue where objects under `d/actor` which are not RELs were incorrectly including the REL version of the PCH, which broke the debug build. This also removes the PCH include from `d_a_npc2.cpp`, `d_a_npc3.cpp`, and `d_a_npc4.cpp` which are not objects and are instead included from `d_a_npc.cpp`.