### PR TITLE
Fix all REL module names for ShieldD

### DIFF
--- a/config/ShieldD/config.yml
+++ b/config/ShieldD/config.yml
@@ -23,1074 +23,1253 @@ modules:
   symbols: config/ShieldD/rels/d_a_alldieD/symbols.txt
   splits: config/ShieldD/rels/d_a_alldieD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_alldieD.map
+  name: d_a_alldie
 
 - object: files/rel/RVL/Debug/d_a_andswD.rel
   hash: 66ef18d23ee1aec103f0739ac25c4bb74dd3eaf8
   symbols: config/ShieldD/rels/d_a_andswD/symbols.txt
   splits: config/ShieldD/rels/d_a_andswD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_andswD.map
+  name: d_a_andsw
 
 - object: files/rel/RVL/Debug/d_a_arrowD.rel
   hash: 18e5e5c8ecc828009fac04acccc0fec63d40e2e1
   symbols: config/ShieldD/rels/d_a_arrowD/symbols.txt
   splits: config/ShieldD/rels/d_a_arrowD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_arrowD.map
+  name: d_a_arrow
 
 - object: files/rel/RVL/Debug/d_a_balloon_2DD.rel
   hash: 10d07f9ebe7f2677a0c824773a690e57dd8a1a09
   symbols: config/ShieldD/rels/d_a_balloon_2DD/symbols.txt
   splits: config/ShieldD/rels/d_a_balloon_2DD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_balloon_2DD.map
+  name: d_a_balloon_2D
 
 - object: files/rel/RVL/Debug/d_a_bdD.rel
   hash: 6cf5b26669e14c3a5699d09525dad72710ba92e0
   symbols: config/ShieldD/rels/d_a_bdD/symbols.txt
   splits: config/ShieldD/rels/d_a_bdD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_bdD.map
+  name: d_a_bd
 
 - object: files/rel/RVL/Debug/d_a_bgD.rel
   hash: c23e7f2dae3fb3d1b8cded01cd323d562350dc79
   symbols: config/ShieldD/rels/d_a_bgD/symbols.txt
   splits: config/ShieldD/rels/d_a_bgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_bgD.map
+  name: d_a_bg
 
 - object: files/rel/RVL/Debug/d_a_bg_objD.rel
   hash: be9fbefba8e71589f0021d326375f6716c8840e1
   symbols: config/ShieldD/rels/d_a_bg_objD/symbols.txt
   splits: config/ShieldD/rels/d_a_bg_objD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_bg_objD.map
+  name: d_a_bg_obj
 
 - object: files/rel/RVL/Debug/d_a_boomerangD.rel
   hash: d7949bfb1f515932238c69764d6202ed4dc02460
   symbols: config/ShieldD/rels/d_a_boomerangD/symbols.txt
   splits: config/ShieldD/rels/d_a_boomerangD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_boomerangD.map
+  name: d_a_boomerang
 
 - object: files/rel/RVL/Debug/d_a_bulletD.rel
   hash: 80b4eb58d9ccf2333156ffe22b042c3703681b44
   symbols: config/ShieldD/rels/d_a_bulletD/symbols.txt
   splits: config/ShieldD/rels/d_a_bulletD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_bulletD.map
+  name: d_a_bullet
 
 - object: files/rel/RVL/Debug/d_a_b_bhD.rel
   hash: 263f863144d1b1f83e8c3b47326795bf40e37e93
   symbols: config/ShieldD/rels/d_a_b_bhD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_bhD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_bhD.map
+  name: d_a_b_bh
 
 - object: files/rel/RVL/Debug/d_a_b_bqD.rel
   hash: 7c92e34ba6ef94c0538b3c411306d3bce07fbb65
   symbols: config/ShieldD/rels/d_a_b_bqD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_bqD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_bqD.map
+  name: d_a_b_bq
 
 - object: files/rel/RVL/Debug/d_a_b_drD.rel
   hash: 1ff0f7f26970053357741c14ef82e8e2526843d1
   symbols: config/ShieldD/rels/d_a_b_drD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_drD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_drD.map
+  name: d_a_b_dr
 
 - object: files/rel/RVL/Debug/d_a_b_dreD.rel
   hash: 48a60bee5d92d89fc564821dee8966302e4542ba
   symbols: config/ShieldD/rels/d_a_b_dreD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_dreD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_dreD.map
+  name: d_a_b_dre
 
 - object: files/rel/RVL/Debug/d_a_b_dsD.rel
   hash: 47b0aff8e74ab750e8fdc2a60df9d51b64199b7f
   symbols: config/ShieldD/rels/d_a_b_dsD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_dsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_dsD.map
+  name: d_a_b_ds
 
 - object: files/rel/RVL/Debug/d_a_b_ggD.rel
   hash: df59bca6dec25ebc426a3065949b6dff6cc888a3
   symbols: config/ShieldD/rels/d_a_b_ggD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_ggD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_ggD.map
+  name: d_a_b_gg
 
 - object: files/rel/RVL/Debug/d_a_b_gmD.rel
   hash: 22ff212b62c625d2fd348f4952b3d6f616b5fcd3
   symbols: config/ShieldD/rels/d_a_b_gmD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_gmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_gmD.map
+  name: d_a_b_gm
 
 - object: files/rel/RVL/Debug/d_a_b_gndD.rel
   hash: df6b1baf5184c3e826ead44257b01da6d7dec8f0
   symbols: config/ShieldD/rels/d_a_b_gndD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_gndD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_gndD.map
+  name: d_a_b_gnd
 
 - object: files/rel/RVL/Debug/d_a_b_goD.rel
   hash: 64902c3c25265e4c3ae9f1ae2527e8a65a86c287
   symbols: config/ShieldD/rels/d_a_b_goD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_goD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_goD.map
+  name: d_a_b_go
 
 - object: files/rel/RVL/Debug/d_a_b_gosD.rel
   hash: 1e4678cf04bece663172000c4e8ab4c84a078b2b
   symbols: config/ShieldD/rels/d_a_b_gosD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_gosD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_gosD.map
+  name: d_a_b_gos
 
 - object: files/rel/RVL/Debug/d_a_b_mgnD.rel
   hash: b2e79532289778f238f08b4d5401a00a81f17574
   symbols: config/ShieldD/rels/d_a_b_mgnD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_mgnD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_mgnD.map
+  name: d_a_b_mgn
 
 - object: files/rel/RVL/Debug/d_a_b_obD.rel
   hash: 4d5cb5978894bdd7f6c18f3f010e429d7fe8eb1a
   symbols: config/ShieldD/rels/d_a_b_obD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_obD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_obD.map
+  name: d_a_b_ob
 
 - object: files/rel/RVL/Debug/d_a_b_oh2D.rel
   hash: 7b26c21fc63e5f2476ac8c8d2cdd0d647f4b01dd
   symbols: config/ShieldD/rels/d_a_b_oh2D/symbols.txt
   splits: config/ShieldD/rels/d_a_b_oh2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_oh2D.map
+  name: d_a_b_oh2
 
 - object: files/rel/RVL/Debug/d_a_b_ohD.rel
   hash: 38371bd6aedd09e6ad8986f8bb28e861808c90fe
   symbols: config/ShieldD/rels/d_a_b_ohD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_ohD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_ohD.map
+  name: d_a_b_oh
 
 - object: files/rel/RVL/Debug/d_a_b_tnD.rel
   hash: 88e7fd3cbcacea798d8bbde18aa0252f5359cc34
   symbols: config/ShieldD/rels/d_a_b_tnD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_tnD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_tnD.map
+  name: d_a_b_tn
 
 - object: files/rel/RVL/Debug/d_a_b_yoD.rel
   hash: abb33063717fe2f3bd4a9a878dfdd8ef850c5c3f
   symbols: config/ShieldD/rels/d_a_b_yoD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_yoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_yoD.map
+  name: d_a_b_yo
 
 - object: files/rel/RVL/Debug/d_a_b_yo_iceD.rel
   hash: 1797c4c9f4abbde41c41fbe59faefeff65627208
   symbols: config/ShieldD/rels/d_a_b_yo_iceD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_yo_iceD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_yo_iceD.map
+  name: d_a_b_yo_ice
 
 - object: files/rel/RVL/Debug/d_a_b_zantD.rel
   hash: 54b81186dd45a9ae138a57a7be24f956caba134b
   symbols: config/ShieldD/rels/d_a_b_zantD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_zantD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_zantD.map
+  name: d_a_b_zant
 
 - object: files/rel/RVL/Debug/d_a_b_zant_magicD.rel
   hash: e209794e20b09ecbab577f77e79ee65f8850ca93
   symbols: config/ShieldD/rels/d_a_b_zant_magicD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_zant_magicD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_zant_magicD.map
+  name: d_a_b_zant_magic
 
 - object: files/rel/RVL/Debug/d_a_b_zant_mobileD.rel
   hash: 55514cdd5c493d0094143eab6aa30d80f535a902
   symbols: config/ShieldD/rels/d_a_b_zant_mobileD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_zant_mobileD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_zant_mobileD.map
+  name: d_a_b_zant_mobile
 
 - object: files/rel/RVL/Debug/d_a_b_zant_simaD.rel
   hash: 99beeed1b638557b3981741d360f3c879d3f889e
   symbols: config/ShieldD/rels/d_a_b_zant_simaD/symbols.txt
   splits: config/ShieldD/rels/d_a_b_zant_simaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_b_zant_simaD.map
+  name: d_a_b_zant_sima
 
 - object: files/rel/RVL/Debug/d_a_canoeD.rel
   hash: e2ba4ac197231aa2fba48a6b3bb9c77d7466e86b
   symbols: config/ShieldD/rels/d_a_canoeD/symbols.txt
   splits: config/ShieldD/rels/d_a_canoeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_canoeD.map
+  name: d_a_canoe
 
 - object: files/rel/RVL/Debug/d_a_coach_2DD.rel
   hash: 87d700376c6d6ae6bbcad4a3f2f2dfbd6507f6c0
   symbols: config/ShieldD/rels/d_a_coach_2DD/symbols.txt
   splits: config/ShieldD/rels/d_a_coach_2DD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_coach_2DD.map
+  name: d_a_coach_2D
 
 - object: files/rel/RVL/Debug/d_a_coach_fireD.rel
   hash: 93e843ec6fd4dcb17df3bf18746ca8004e25585f
   symbols: config/ShieldD/rels/d_a_coach_fireD/symbols.txt
   splits: config/ShieldD/rels/d_a_coach_fireD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_coach_fireD.map
+  name: d_a_coach_fire
 
 - object: files/rel/RVL/Debug/d_a_cowD.rel
   hash: f4e78cab4388f7188a89a55c24b790f071783305
   symbols: config/ShieldD/rels/d_a_cowD/symbols.txt
   splits: config/ShieldD/rels/d_a_cowD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_cowD.map
+  name: d_a_cow
 
 - object: files/rel/RVL/Debug/d_a_crodD.rel
   hash: 1f0c1dc24982a127641aafbd18016ea3f73c12cd
   symbols: config/ShieldD/rels/d_a_crodD/symbols.txt
   splits: config/ShieldD/rels/d_a_crodD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_crodD.map
+  name: d_a_crod
 
 - object: files/rel/RVL/Debug/d_a_cstaFD.rel
   hash: d419d1e7f88be8098c1a1bd20e9ef06d9debe991
   symbols: config/ShieldD/rels/d_a_cstaFD/symbols.txt
   splits: config/ShieldD/rels/d_a_cstaFD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_cstaFD.map
+  name: d_a_cstaF
 
 - object: files/rel/RVL/Debug/d_a_cstatueD.rel
   hash: 8d3e6af2df2e3854c2355b00741ffca74ca2c457
   symbols: config/ShieldD/rels/d_a_cstatueD/symbols.txt
   splits: config/ShieldD/rels/d_a_cstatueD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_cstatueD.map
+  name: d_a_cstatue
 
 - object: files/rel/RVL/Debug/d_a_demo00D.rel
   hash: 019972df2c12d138816605c21121daba66c324f2
   symbols: config/ShieldD/rels/d_a_demo00D/symbols.txt
   splits: config/ShieldD/rels/d_a_demo00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_demo00D.map
+  name: d_a_demo00
 
 - object: files/rel/RVL/Debug/d_a_demo_itemD.rel
   hash: 4bc20ce77ef0d4a02024dc96c5fe6d85d25adf0d
   symbols: config/ShieldD/rels/d_a_demo_itemD/symbols.txt
   splits: config/ShieldD/rels/d_a_demo_itemD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_demo_itemD.map
+  name: d_a_demo_item
 
 - object: files/rel/RVL/Debug/d_a_disappearD.rel
   hash: f41471ae32a1cf9f660f3ae37d9b4a09502cc9e7
   symbols: config/ShieldD/rels/d_a_disappearD/symbols.txt
   splits: config/ShieldD/rels/d_a_disappearD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_disappearD.map
+  name: d_a_disappear
 
 - object: files/rel/RVL/Debug/d_a_dmidnaD.rel
   hash: e1cbd82c57f0016ed3eb9dd42df94f0fa3e7586a
   symbols: config/ShieldD/rels/d_a_dmidnaD/symbols.txt
   splits: config/ShieldD/rels/d_a_dmidnaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_dmidnaD.map
+  name: d_a_dmidna
 
 - object: files/rel/RVL/Debug/d_a_doD.rel
   hash: 0456e77c6e247eb05617ba1aae96884e6cb404f9
   symbols: config/ShieldD/rels/d_a_doD/symbols.txt
   splits: config/ShieldD/rels/d_a_doD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_doD.map
+  name: d_a_do
 
 - object: files/rel/RVL/Debug/d_a_door_bossD.rel
   hash: 1eb48ad3e2e5b37aa755bb376564638a69d14225
   symbols: config/ShieldD/rels/d_a_door_bossD/symbols.txt
   splits: config/ShieldD/rels/d_a_door_bossD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_bossD.map
+  name: d_a_door_boss
 
 - object: files/rel/RVL/Debug/d_a_door_bossL1D.rel
   hash: 5095f7987d2a5cef1e4b07919cca51834d81ee5a
   symbols: config/ShieldD/rels/d_a_door_bossL1D/symbols.txt
   splits: config/ShieldD/rels/d_a_door_bossL1D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_bossL1D.map
+  name: d_a_door_bossL1
 
 - object: files/rel/RVL/Debug/d_a_door_bossL5D.rel
   hash: 2a9b8be014e70bd5bd4ac441959e10b918213ac7
   symbols: config/ShieldD/rels/d_a_door_bossL5D/symbols.txt
   splits: config/ShieldD/rels/d_a_door_bossL5D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_bossL5D.map
+  name: d_a_door_bossL5
 
 - object: files/rel/RVL/Debug/d_a_door_dbdoor00D.rel
   hash: 6b59bd3ac5fa275edc8a678501baf870ddf8f82a
   symbols: config/ShieldD/rels/d_a_door_dbdoor00D/symbols.txt
   splits: config/ShieldD/rels/d_a_door_dbdoor00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_dbdoor00D.map
+  name: d_a_door_dbdoor00
 
 - object: files/rel/RVL/Debug/d_a_door_knob00D.rel
   hash: f69eee6b803b9760f5c4e216cb2cfcd392ff372d
   symbols: config/ShieldD/rels/d_a_door_knob00D/symbols.txt
   splits: config/ShieldD/rels/d_a_door_knob00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_knob00D.map
+  name: d_a_door_knob00
 
 - object: files/rel/RVL/Debug/d_a_door_mbossL1D.rel
   hash: 3e910d37f81dcbcc807f3fa662ccea626b455606
   symbols: config/ShieldD/rels/d_a_door_mbossL1D/symbols.txt
   splits: config/ShieldD/rels/d_a_door_mbossL1D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_mbossL1D.map
+  name: d_a_door_mbossL1
 
 - object: files/rel/RVL/Debug/d_a_door_pushD.rel
   hash: 8093a168c4305d62eb78de581d00a669348669ba
   symbols: config/ShieldD/rels/d_a_door_pushD/symbols.txt
   splits: config/ShieldD/rels/d_a_door_pushD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_pushD.map
+  name: d_a_door_push
 
 - object: files/rel/RVL/Debug/d_a_door_shutterD.rel
   hash: 4fd2a0afd11c9dfd51f0f0d94161d206a29e0564
   symbols: config/ShieldD/rels/d_a_door_shutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_door_shutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_shutterD.map
+  name: d_a_door_shutter
 
 - object: files/rel/RVL/Debug/d_a_door_spiralD.rel
   hash: 251689a685d35226b8bced8e3c77bb6506a92ff5
   symbols: config/ShieldD/rels/d_a_door_spiralD/symbols.txt
   splits: config/ShieldD/rels/d_a_door_spiralD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_door_spiralD.map
+  name: d_a_door_spiral
 
 - object: files/rel/RVL/Debug/d_a_dshutterD.rel
   hash: bc2e40598e23464736dd05514aa66581de29ad00
   symbols: config/ShieldD/rels/d_a_dshutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_dshutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_dshutterD.map
+  name: d_a_dshutter
 
 - object: files/rel/RVL/Debug/d_a_econtD.rel
   hash: 4d7c45a687759064cda02c166367b99f944141d5
   symbols: config/ShieldD/rels/d_a_econtD/symbols.txt
   splits: config/ShieldD/rels/d_a_econtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_econtD.map
+  name: d_a_econt
 
 - object: files/rel/RVL/Debug/d_a_epD.rel
   hash: c8d9f993c2a00c31838729bd810373647dec074b
   symbols: config/ShieldD/rels/d_a_epD/symbols.txt
   splits: config/ShieldD/rels/d_a_epD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_epD.map
+  name: d_a_ep
 
 - object: files/rel/RVL/Debug/d_a_e_aiD.rel
   hash: d497376bb54e35ffbc236b2521a04331a6c35861
   symbols: config/ShieldD/rels/d_a_e_aiD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_aiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_aiD.map
+  name: d_a_e_ai
 
 - object: files/rel/RVL/Debug/d_a_e_arrowD.rel
   hash: 74ad3301fce912877e01f38c33bb9ea0d8af4d9f
   symbols: config/ShieldD/rels/d_a_e_arrowD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_arrowD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_arrowD.map
+  name: d_a_e_arrow
 
 - object: files/rel/RVL/Debug/d_a_e_baD.rel
   hash: 7d17727470adade2031f3d957f7051c66ddf660c
   symbols: config/ShieldD/rels/d_a_e_baD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_baD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_baD.map
+  name: d_a_e_ba
 
 - object: files/rel/RVL/Debug/d_a_e_beeD.rel
   hash: 18fd6767cb14db4245a44b4b796fdddd0a875aa4
   symbols: config/ShieldD/rels/d_a_e_beeD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_beeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_beeD.map
+  name: d_a_e_bee
 
 - object: files/rel/RVL/Debug/d_a_e_bgD.rel
   hash: 69d2324661d9730e21062fe88f19f60fa2ccb84c
   symbols: config/ShieldD/rels/d_a_e_bgD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_bgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_bgD.map
+  name: d_a_e_bg
 
 - object: files/rel/RVL/Debug/d_a_e_biD.rel
   hash: 05e045b18dd47069d65aef5d5dc5418ce63edd4c
   symbols: config/ShieldD/rels/d_a_e_biD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_biD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_biD.map
+  name: d_a_e_bi
 
 - object: files/rel/RVL/Debug/d_a_e_bi_leafD.rel
   hash: 731bd8057f51d253582245db540116e5ca86f4c5
   symbols: config/ShieldD/rels/d_a_e_bi_leafD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_bi_leafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_bi_leafD.map
+  name: d_a_e_bi_leaf
 
 - object: files/rel/RVL/Debug/d_a_e_bsD.rel
   hash: 287423588d8b2b6db5e064b139a052c82d62fb07
   symbols: config/ShieldD/rels/d_a_e_bsD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_bsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_bsD.map
+  name: d_a_e_bs
 
 - object: files/rel/RVL/Debug/d_a_e_buD.rel
   hash: c128345956eafced36c0c198ef848639d6f74c07
   symbols: config/ShieldD/rels/d_a_e_buD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_buD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_buD.map
+  name: d_a_e_bu
 
 - object: files/rel/RVL/Debug/d_a_e_bugD.rel
   hash: 5b1dba152292f26c723fbe5f70b557b703422a7f
   symbols: config/ShieldD/rels/d_a_e_bugD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_bugD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_bugD.map
+  name: d_a_e_bug
 
 - object: files/rel/RVL/Debug/d_a_e_crD.rel
   hash: 336447ce09aff9ff572d94c696983dc7afb74dc3
   symbols: config/ShieldD/rels/d_a_e_crD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_crD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_crD.map
+  name: d_a_e_cr
 
 - object: files/rel/RVL/Debug/d_a_e_cr_eggD.rel
   hash: 281347038033b53b854c7f73111b69f512d96b6d
   symbols: config/ShieldD/rels/d_a_e_cr_eggD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_cr_eggD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_cr_eggD.map
+  name: d_a_e_cr_egg
 
 - object: files/rel/RVL/Debug/d_a_e_dbD.rel
   hash: 1a662e2e6a02d6402f6670f51ffeadd952747e59
   symbols: config/ShieldD/rels/d_a_e_dbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_dbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_dbD.map
+  name: d_a_e_db
 
 - object: files/rel/RVL/Debug/d_a_e_db_leafD.rel
   hash: e9e02724730f266e9b7bae21b9b6f9aa3dc87b43
   symbols: config/ShieldD/rels/d_a_e_db_leafD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_db_leafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_db_leafD.map
+  name: d_a_e_db_leaf
 
 - object: files/rel/RVL/Debug/d_a_e_ddD.rel
   hash: 495a63b65e9386fbc428a0b62f1676602a1c11f1
   symbols: config/ShieldD/rels/d_a_e_ddD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ddD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ddD.map
+  name: d_a_e_dd
 
 - object: files/rel/RVL/Debug/d_a_e_dfD.rel
   hash: acae7c1640a522bfa5c1a11267dd3630a803a0f9
   symbols: config/ShieldD/rels/d_a_e_dfD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_dfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_dfD.map
+  name: d_a_e_df
 
 - object: files/rel/RVL/Debug/d_a_e_dkD.rel
   hash: 68fd57a2455b6119f84ee50d2cf123a68501052f
   symbols: config/ShieldD/rels/d_a_e_dkD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_dkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_dkD.map
+  name: d_a_e_dk
 
 - object: files/rel/RVL/Debug/d_a_e_dnD.rel
   hash: 58a2373ce0ea528164f470df75afe13749e53bfb
   symbols: config/ShieldD/rels/d_a_e_dnD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_dnD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_dnD.map
+  name: d_a_e_dn
 
 - object: files/rel/RVL/Debug/d_a_e_dtD.rel
   hash: c0a2339c6c7b217377566742416eaa9b25b0f0c4
   symbols: config/ShieldD/rels/d_a_e_dtD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_dtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_dtD.map
+  name: d_a_e_dt
 
 - object: files/rel/RVL/Debug/d_a_e_fbD.rel
   hash: 1eabd9f0bbb4725f8fc05185bd385551db7614e6
   symbols: config/ShieldD/rels/d_a_e_fbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_fbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_fbD.map
+  name: d_a_e_fb
 
 - object: files/rel/RVL/Debug/d_a_e_fkD.rel
   hash: 2b8757b1da5f80e5f2e1f6ca94037e1414230b85
   symbols: config/ShieldD/rels/d_a_e_fkD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_fkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_fkD.map
+  name: d_a_e_fk
 
 - object: files/rel/RVL/Debug/d_a_e_fmD.rel
   hash: 9374bc8f67a83a5e61d8bc8bba567c37418b41cb
   symbols: config/ShieldD/rels/d_a_e_fmD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_fmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_fmD.map
+  name: d_a_e_fm
 
 - object: files/rel/RVL/Debug/d_a_e_fsD.rel
   hash: 32da5b01518b40c4a0c043a506df21b2cabc9907
   symbols: config/ShieldD/rels/d_a_e_fsD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_fsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_fsD.map
+  name: d_a_e_fs
 
 - object: files/rel/RVL/Debug/d_a_e_fzD.rel
   hash: 3bef8fa37b6c942f20104c3d436c23312d860a0f
   symbols: config/ShieldD/rels/d_a_e_fzD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_fzD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_fzD.map
+  name: d_a_e_fz
 
 - object: files/rel/RVL/Debug/d_a_e_gaD.rel
   hash: 49a2f9e3bcfd4fe79a8dae59cb1aea5e818ddfeb
   symbols: config/ShieldD/rels/d_a_e_gaD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_gaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_gaD.map
+  name: d_a_e_ga
 
 - object: files/rel/RVL/Debug/d_a_e_gbD.rel
   hash: a0c390e4d871531172a53f06c917189dabc602ff
   symbols: config/ShieldD/rels/d_a_e_gbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_gbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_gbD.map
+  name: d_a_e_gb
 
 - object: files/rel/RVL/Debug/d_a_e_geD.rel
   hash: e7532a81d2ed0a7dc57b01661b2e6bd427341441
   symbols: config/ShieldD/rels/d_a_e_geD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_geD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_geD.map
+  name: d_a_e_ge
 
 - object: files/rel/RVL/Debug/d_a_e_giD.rel
   hash: b86196fe6559697a6899806f3e59976e5d7ecbc5
   symbols: config/ShieldD/rels/d_a_e_giD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_giD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_giD.map
+  name: d_a_e_gi
 
 - object: files/rel/RVL/Debug/d_a_e_gmD.rel
   hash: d4a07ad05833febed2fa27e0565a7bfdb4ea2859
   symbols: config/ShieldD/rels/d_a_e_gmD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_gmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_gmD.map
+  name: d_a_e_gm
 
 - object: files/rel/RVL/Debug/d_a_e_gobD.rel
   hash: d9137a7d8b1cf3c1b34bdb0915d04b7d0c61c7c7
   symbols: config/ShieldD/rels/d_a_e_gobD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_gobD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_gobD.map
+  name: d_a_e_gob
 
 - object: files/rel/RVL/Debug/d_a_e_gsD.rel
   hash: a45c2b9e3c28304d92f0d457337b086a30a6d130
   symbols: config/ShieldD/rels/d_a_e_gsD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_gsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_gsD.map
+  name: d_a_e_gs
 
 - object: files/rel/RVL/Debug/d_a_e_hbD.rel
   hash: 08ba795b6719b960d6e9376d94987a8a9e32f3ca
   symbols: config/ShieldD/rels/d_a_e_hbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_hbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_hbD.map
+  name: d_a_e_hb
 
 - object: files/rel/RVL/Debug/d_a_e_hb_leafD.rel
   hash: c174cc8873c51f8c01cbf59282fd582f4e99bc55
   symbols: config/ShieldD/rels/d_a_e_hb_leafD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_hb_leafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_hb_leafD.map
+  name: d_a_e_hb_leaf
 
 - object: files/rel/RVL/Debug/d_a_e_hmD.rel
   hash: faf6d51d080cc7a7245ae83e8a0be1c33bd29247
   symbols: config/ShieldD/rels/d_a_e_hmD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_hmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_hmD.map
+  name: d_a_e_hm
 
 - object: files/rel/RVL/Debug/d_a_e_hpD.rel
   hash: ab96ebfdab58ebd14094dff1d9c6b04b1de1f077
   symbols: config/ShieldD/rels/d_a_e_hpD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_hpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_hpD.map
+  name: d_a_e_hp
 
 - object: files/rel/RVL/Debug/d_a_e_hzD.rel
   hash: 73ebe0830cd1220a21ad532791e4ff1e3d3433ce
   symbols: config/ShieldD/rels/d_a_e_hzD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_hzD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_hzD.map
+  name: d_a_e_hz
 
 - object: files/rel/RVL/Debug/d_a_e_hzeldaD.rel
   hash: 4f4d0867daee885d04b44d1f98cb2583d2a62601
   symbols: config/ShieldD/rels/d_a_e_hzeldaD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_hzeldaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_hzeldaD.map
+  name: d_a_e_hzelda
 
 - object: files/rel/RVL/Debug/d_a_e_isD.rel
   hash: e76b2b091bb654d9ae6850e8ae7ab2fac3435ebc
   symbols: config/ShieldD/rels/d_a_e_isD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_isD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_isD.map
+  name: d_a_e_is
 
 - object: files/rel/RVL/Debug/d_a_e_kgD.rel
   hash: 2f5d5646edf52f718d9d8dc2e29ddfa36827ab53
   symbols: config/ShieldD/rels/d_a_e_kgD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_kgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_kgD.map
+  name: d_a_e_kg
 
 - object: files/rel/RVL/Debug/d_a_e_kkD.rel
   hash: 8015efb82d15fa5412cd4c4e17e4feff7fa81775
   symbols: config/ShieldD/rels/d_a_e_kkD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_kkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_kkD.map
+  name: d_a_e_kk
 
 - object: files/rel/RVL/Debug/d_a_e_krD.rel
   hash: d7a81740a0099c3b16bebf8424aa105b45cb0a6d
   symbols: config/ShieldD/rels/d_a_e_krD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_krD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_krD.map
+  name: d_a_e_kr
 
 - object: files/rel/RVL/Debug/d_a_e_mbD.rel
   hash: cac48cf843b00026b585e08f877976a1340bf6e2
   symbols: config/ShieldD/rels/d_a_e_mbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mbD.map
+  name: d_a_e_mb
 
 - object: files/rel/RVL/Debug/d_a_e_mdD.rel
   hash: bb7ea7be5d369417b94ea73b597f1ee130b865b7
   symbols: config/ShieldD/rels/d_a_e_mdD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mdD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mdD.map
+  name: d_a_e_md
 
 - object: files/rel/RVL/Debug/d_a_e_mfD.rel
   hash: 6fe8a96199925d37096dbfc7b3fc068c60ebe52e
   symbols: config/ShieldD/rels/d_a_e_mfD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mfD.map
+  name: d_a_e_mf
 
 - object: files/rel/RVL/Debug/d_a_e_mkD.rel
   hash: f9b841def5eee0e3a4dc294ffc7707bfd36cf7de
   symbols: config/ShieldD/rels/d_a_e_mkD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mkD.map
+  name: d_a_e_mk
 
 - object: files/rel/RVL/Debug/d_a_e_mk_boD.rel
   hash: 7fe31f98e2322ba95dd43c851a1c32ad2848acb3
   symbols: config/ShieldD/rels/d_a_e_mk_boD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mk_boD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mk_boD.map
+  name: d_a_e_mk_bo
 
 - object: files/rel/RVL/Debug/d_a_e_mmD.rel
   hash: 558abe5dec13567bb97245f6b88ea9c614717f31
   symbols: config/ShieldD/rels/d_a_e_mmD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mmD.map
+  name: d_a_e_mm
 
 - object: files/rel/RVL/Debug/d_a_e_mm_mtD.rel
   hash: 2f60f043b4f610b9b0d8a968b9701e3c1e17c5a9
   symbols: config/ShieldD/rels/d_a_e_mm_mtD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_mm_mtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_mm_mtD.map
+  name: d_a_e_mm_mt
 
 - object: files/rel/RVL/Debug/d_a_e_msD.rel
   hash: d09ca5ee3aeac19fa5fc0401bd33af664543d3d1
   symbols: config/ShieldD/rels/d_a_e_msD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_msD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_msD.map
+  name: d_a_e_ms
 
 - object: files/rel/RVL/Debug/d_a_e_nestD.rel
   hash: 50c72014be4188844eeb8296fa8c1aa622098625
   symbols: config/ShieldD/rels/d_a_e_nestD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_nestD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_nestD.map
+  name: d_a_e_nest
 
 - object: files/rel/RVL/Debug/d_a_e_nzD.rel
   hash: 8c6428fddb502e68069c075d27274421e7c313b8
   symbols: config/ShieldD/rels/d_a_e_nzD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_nzD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_nzD.map
+  name: d_a_e_nz
 
 - object: files/rel/RVL/Debug/d_a_e_ocD.rel
   hash: 83596d59efc9e452d3f7aea51dbf5ed69976ad79
   symbols: config/ShieldD/rels/d_a_e_ocD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ocD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ocD.map
+  name: d_a_e_oc
 
 - object: files/rel/RVL/Debug/d_a_e_oct_bgD.rel
   hash: b3923e833d106328987b5279e012111d2d2a7286
   symbols: config/ShieldD/rels/d_a_e_oct_bgD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_oct_bgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_oct_bgD.map
+  name: d_a_e_oct_bg
 
 - object: files/rel/RVL/Debug/d_a_e_otD.rel
   hash: faf12b840632939ed719b2d118099dde41ba735e
   symbols: config/ShieldD/rels/d_a_e_otD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_otD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_otD.map
+  name: d_a_e_ot
 
 - object: files/rel/RVL/Debug/d_a_e_phD.rel
   hash: ec59c0c450b07065cc51d5022b0cc41c6f91bfe3
   symbols: config/ShieldD/rels/d_a_e_phD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_phD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_phD.map
+  name: d_a_e_ph
 
 - object: files/rel/RVL/Debug/d_a_e_pmD.rel
   hash: 7c23c024968847f4e8cd1142975cfedfce316104
   symbols: config/ShieldD/rels/d_a_e_pmD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_pmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_pmD.map
+  name: d_a_e_pm
 
 - object: files/rel/RVL/Debug/d_a_e_poD.rel
   hash: 6be6e3a8bb6c7948c48de91f8ff94cefdd3bdd38
   symbols: config/ShieldD/rels/d_a_e_poD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_poD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_poD.map
+  name: d_a_e_po
 
 - object: files/rel/RVL/Debug/d_a_e_pzD.rel
   hash: 8365428a0454dc01019d2e9378bebc988da94c14
   symbols: config/ShieldD/rels/d_a_e_pzD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_pzD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_pzD.map
+  name: d_a_e_pz
 
 - object: files/rel/RVL/Debug/d_a_e_rbD.rel
   hash: 749fea2c4581a9d90771bf7ed66b38dfc079ff05
   symbols: config/ShieldD/rels/d_a_e_rbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_rbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_rbD.map
+  name: d_a_e_rb
 
 - object: files/rel/RVL/Debug/d_a_e_rdbD.rel
   hash: 62eefd664f700fc121c77c1988e11af418a4a071
   symbols: config/ShieldD/rels/d_a_e_rdbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_rdbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_rdbD.map
+  name: d_a_e_rdb
 
 - object: files/rel/RVL/Debug/d_a_e_rdD.rel
   hash: 3c57586411c50008020b70e0bef9909d344e1911
   symbols: config/ShieldD/rels/d_a_e_rdD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_rdD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_rdD.map
+  name: d_a_e_rd
 
 - object: files/rel/RVL/Debug/d_a_e_rdyD.rel
   hash: 2e0a6b4c95711d9307a017576f08dc74ecef86b3
   symbols: config/ShieldD/rels/d_a_e_rdyD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_rdyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_rdyD.map
+  name: d_a_e_rdy
 
 - object: files/rel/RVL/Debug/d_a_e_s1D.rel
   hash: b9ebddeff56b9da9331e5528f793d15dfbe54e4f
   symbols: config/ShieldD/rels/d_a_e_s1D/symbols.txt
   splits: config/ShieldD/rels/d_a_e_s1D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_s1D.map
+  name: d_a_e_s1
 
 - object: files/rel/RVL/Debug/d_a_e_sbD.rel
   hash: 0d2a7c0377425eb40fbc702014202c06bdeb1241
   symbols: config/ShieldD/rels/d_a_e_sbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_sbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_sbD.map
+  name: d_a_e_sb
 
 - object: files/rel/RVL/Debug/d_a_e_sfD.rel
   hash: 492fb5bdb53e9f427747c0f399fd6b12b1169b3a
   symbols: config/ShieldD/rels/d_a_e_sfD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_sfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_sfD.map
+  name: d_a_e_sf
 
 - object: files/rel/RVL/Debug/d_a_e_sgD.rel
   hash: 9a8389b679e5f6a2f0d573578d35d7e972a32214
   symbols: config/ShieldD/rels/d_a_e_sgD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_sgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_sgD.map
+  name: d_a_e_sg
 
 - object: files/rel/RVL/Debug/d_a_e_shD.rel
   hash: 01dc29fe4eb454199c3c7a639d11f864cd50e6c1
   symbols: config/ShieldD/rels/d_a_e_shD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_shD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_shD.map
+  name: d_a_e_sh
 
 - object: files/rel/RVL/Debug/d_a_e_sm2D.rel
   hash: 0f311479ced606b5c5272d671f602595325dbdfa
   symbols: config/ShieldD/rels/d_a_e_sm2D/symbols.txt
   splits: config/ShieldD/rels/d_a_e_sm2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_sm2D.map
+  name: d_a_e_sm2
 
 - object: files/rel/RVL/Debug/d_a_e_smD.rel
   hash: b237dba1a22acb71031dbd76782cd2f056c94c79
   symbols: config/ShieldD/rels/d_a_e_smD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_smD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_smD.map
+  name: d_a_e_sm
 
 - object: files/rel/RVL/Debug/d_a_e_stD.rel
   hash: 7a0dbd11e07843ffbed355b06685f7cc5743b4a7
   symbols: config/ShieldD/rels/d_a_e_stD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_stD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_stD.map
+  name: d_a_e_st
 
 - object: files/rel/RVL/Debug/d_a_e_st_lineD.rel
   hash: 7aff4c686e2e233f08cc87c7c468fb9380c50f06
   symbols: config/ShieldD/rels/d_a_e_st_lineD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_st_lineD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_st_lineD.map
+  name: d_a_e_st_line
 
 - object: files/rel/RVL/Debug/d_a_e_swD.rel
   hash: e68e37f333f61053f5175adcbadbea80acabc018
   symbols: config/ShieldD/rels/d_a_e_swD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_swD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_swD.map
+  name: d_a_e_sw
 
 - object: files/rel/RVL/Debug/d_a_e_thD.rel
   hash: 9732b181133e826b021e05aeef910a354e6b47e0
   symbols: config/ShieldD/rels/d_a_e_thD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_thD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_thD.map
+  name: d_a_e_th
 
 - object: files/rel/RVL/Debug/d_a_e_th_ballD.rel
   hash: cacef1add3dc3e8c40cc5b47ddce6750282d4e31
   symbols: config/ShieldD/rels/d_a_e_th_ballD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_th_ballD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_th_ballD.map
+  name: d_a_e_th_ball
 
 - object: files/rel/RVL/Debug/d_a_e_tk2D.rel
   hash: 4ce8c88bfc05b9eadd72221c14e2a670964efe90
   symbols: config/ShieldD/rels/d_a_e_tk2D/symbols.txt
   splits: config/ShieldD/rels/d_a_e_tk2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_tk2D.map
+  name: d_a_e_tk2
 
 - object: files/rel/RVL/Debug/d_a_e_tkD.rel
   hash: 139fb187bdb9cc186dc28eeb2f476be9757f59e4
   symbols: config/ShieldD/rels/d_a_e_tkD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_tkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_tkD.map
+  name: d_a_e_tk
 
 - object: files/rel/RVL/Debug/d_a_e_tk_ballD.rel
   hash: 53a7bb04899abb1d8a4469dd9b01e7a7279d5ccc
   symbols: config/ShieldD/rels/d_a_e_tk_ballD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_tk_ballD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_tk_ballD.map
+  name: d_a_e_tk_ball
 
 - object: files/rel/RVL/Debug/d_a_e_ttD.rel
   hash: f0b77ab832596c0274e07042a289dd671b45f5c8
   symbols: config/ShieldD/rels/d_a_e_ttD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ttD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ttD.map
+  name: d_a_e_tt
 
 - object: files/rel/RVL/Debug/d_a_e_vtD.rel
   hash: ca4f7c7ab374d93e2ee7a872be859896bdf291aa
   symbols: config/ShieldD/rels/d_a_e_vtD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_vtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_vtD.map
+  name: d_a_e_vt
 
 - object: files/rel/RVL/Debug/d_a_e_warpappearD.rel
   hash: ce92ac80d178c0d09d1efc71f6a75aef7d6b57a3
   symbols: config/ShieldD/rels/d_a_e_warpappearD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_warpappearD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_warpappearD.map
+  name: d_a_e_warpappear
 
 - object: files/rel/RVL/Debug/d_a_e_wbD.rel
   hash: 85bdcb1f9af96e734fa10e8c831d78cd89c912e2
   symbols: config/ShieldD/rels/d_a_e_wbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_wbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_wbD.map
+  name: d_a_e_wb
 
 - object: files/rel/RVL/Debug/d_a_e_wsD.rel
   hash: bcbbd69c104118aecd137de4897721ef0a4be369
   symbols: config/ShieldD/rels/d_a_e_wsD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_wsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_wsD.map
+  name: d_a_e_ws
 
 - object: files/rel/RVL/Debug/d_a_e_wwD.rel
   hash: 4643da44e9e1dcc57ee277a4808bdc5816761ee7
   symbols: config/ShieldD/rels/d_a_e_wwD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_wwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_wwD.map
+  name: d_a_e_ww
 
 - object: files/rel/RVL/Debug/d_a_e_ycD.rel
   hash: 92aa91951dd7b8726fc3153a8a292a5b5b7ce813
   symbols: config/ShieldD/rels/d_a_e_ycD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ycD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ycD.map
+  name: d_a_e_yc
 
 - object: files/rel/RVL/Debug/d_a_e_ydD.rel
   hash: 02fbd8b2ff09b0b19067eedc6cbd0faaaee890f7
   symbols: config/ShieldD/rels/d_a_e_ydD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ydD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ydD.map
+  name: d_a_e_yd
 
 - object: files/rel/RVL/Debug/d_a_e_yd_leafD.rel
   hash: 538a4d3f6510fa3883faa8e0b69b4052fefba1ff
   symbols: config/ShieldD/rels/d_a_e_yd_leafD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_yd_leafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_yd_leafD.map
+  name: d_a_e_yd_leaf
 
 - object: files/rel/RVL/Debug/d_a_e_ygD.rel
   hash: 119b27a42c8cb549326d4312097adc27a44adff4
   symbols: config/ShieldD/rels/d_a_e_ygD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ygD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ygD.map
+  name: d_a_e_yg
 
 - object: files/rel/RVL/Debug/d_a_e_yhD.rel
   hash: d0688ec9ca02a4c3efb96fd965df9d34975e0152
   symbols: config/ShieldD/rels/d_a_e_yhD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_yhD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_yhD.map
+  name: d_a_e_yh
 
 - object: files/rel/RVL/Debug/d_a_e_ykD.rel
   hash: 76e697be8401a588ced83351c480ecbefdb79112
   symbols: config/ShieldD/rels/d_a_e_ykD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ykD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ykD.map
+  name: d_a_e_yk
 
 - object: files/rel/RVL/Debug/d_a_e_ymbD.rel
   hash: daa4f6275ef4ae8d2b68628b18fafd6e3d110250
   symbols: config/ShieldD/rels/d_a_e_ymbD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ymbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ymbD.map
+  name: d_a_e_ymb
 
 - object: files/rel/RVL/Debug/d_a_e_ymD.rel
   hash: fb0a64b8715240cc4d3a94a75c34597e895dc7e9
   symbols: config/ShieldD/rels/d_a_e_ymD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ymD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ymD.map
+  name: d_a_e_ym
 
 - object: files/rel/RVL/Debug/d_a_e_ym_tagD.rel
   hash: 0bbc45a90acc6e8230c5d954902db90f368089e0
   symbols: config/ShieldD/rels/d_a_e_ym_tagD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_ym_tagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_ym_tagD.map
+  name: d_a_e_ym_tag
 
 - object: files/rel/RVL/Debug/d_a_e_yrD.rel
   hash: 8bbfcdf7c2253460c3c75a06e2a90ae750478283
   symbols: config/ShieldD/rels/d_a_e_yrD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_yrD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_yrD.map
+  name: d_a_e_yr
 
 - object: files/rel/RVL/Debug/d_a_e_zhD.rel
   hash: 6fb968788354cf688ede567e0a9b38c5e14b3423
   symbols: config/ShieldD/rels/d_a_e_zhD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_zhD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_zhD.map
+  name: d_a_e_zh
 
 - object: files/rel/RVL/Debug/d_a_e_zmD.rel
   hash: fdb07aba72b378e234d7c99cd787f484261308d2
   symbols: config/ShieldD/rels/d_a_e_zmD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_zmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_zmD.map
+  name: d_a_e_zm
 
 - object: files/rel/RVL/Debug/d_a_e_zsD.rel
   hash: ca63b6654d6081f0748f42f208b31e8b0583b9a7
   symbols: config/ShieldD/rels/d_a_e_zsD/symbols.txt
   splits: config/ShieldD/rels/d_a_e_zsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_e_zsD.map
+  name: d_a_e_zs
 
 - object: files/rel/RVL/Debug/d_a_formation_mngD.rel
   hash: 8d04b2eff58062e30f8d0c779f6bde083b706776
   symbols: config/ShieldD/rels/d_a_formation_mngD/symbols.txt
   splits: config/ShieldD/rels/d_a_formation_mngD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_formation_mngD.map
+  name: d_a_formation_mng
 
 - object: files/rel/RVL/Debug/d_a_frD.rel
   hash: 16e029a24b85b7a2c613c86106c26d0de82987c3
   symbols: config/ShieldD/rels/d_a_frD/symbols.txt
   splits: config/ShieldD/rels/d_a_frD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_frD.map
+  name: d_a_fr
 
 - object: files/rel/RVL/Debug/d_a_guard_mngD.rel
   hash: 1c90263fef1e7bd8054fa7b0e2feed8f9ce59566
   symbols: config/ShieldD/rels/d_a_guard_mngD/symbols.txt
   splits: config/ShieldD/rels/d_a_guard_mngD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_guard_mngD.map
+  name: d_a_guard_mng
 
 - object: files/rel/RVL/Debug/d_a_hitobjD.rel
   hash: 44752b905656d96e671ece337a5c983cd6f74b6b
   symbols: config/ShieldD/rels/d_a_hitobjD/symbols.txt
   splits: config/ShieldD/rels/d_a_hitobjD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_hitobjD.map
+  name: d_a_hitobj
 
 - object: files/rel/RVL/Debug/d_a_horseD.rel
   hash: 39c07db6c1af9047941316a18e41c02c35f32c0a
   symbols: config/ShieldD/rels/d_a_horseD/symbols.txt
   splits: config/ShieldD/rels/d_a_horseD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_horseD.map
+  name: d_a_horse
 
 - object: files/rel/RVL/Debug/d_a_hozeldaD.rel
   hash: cf3e178bbc9de7c831a7e16e641a549c6a4a880b
   symbols: config/ShieldD/rels/d_a_hozeldaD/symbols.txt
   splits: config/ShieldD/rels/d_a_hozeldaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_hozeldaD.map
+  name: d_a_hozelda
 
 - object: files/rel/RVL/Debug/d_a_izumi_gateD.rel
   hash: 7123f8c936855768f651278142baad10dcc64879
   symbols: config/ShieldD/rels/d_a_izumi_gateD/symbols.txt
   splits: config/ShieldD/rels/d_a_izumi_gateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_izumi_gateD.map
+  name: d_a_izumi_gate
 
 - object: files/rel/RVL/Debug/d_a_kagoD.rel
   hash: 0a72aa702873069cdddeb0396cdc5df9faf6d623
   symbols: config/ShieldD/rels/d_a_kagoD/symbols.txt
   splits: config/ShieldD/rels/d_a_kagoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kagoD.map
+  name: d_a_kago
 
 - object: files/rel/RVL/Debug/d_a_kytag00D.rel
   hash: da65dea095721fd4945e2185f8842253772d0467
   symbols: config/ShieldD/rels/d_a_kytag00D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag00D.map
+  name: d_a_kytag00
 
 - object: files/rel/RVL/Debug/d_a_kytag02D.rel
   hash: f11d307b37140ee1608d62306862a85d394a41ed
   symbols: config/ShieldD/rels/d_a_kytag02D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag02D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag02D.map
+  name: d_a_kytag02
 
 - object: files/rel/RVL/Debug/d_a_kytag03D.rel
   hash: ecbb5e531ff66cce4c01fb7fdb0192cc1ed4846c
   symbols: config/ShieldD/rels/d_a_kytag03D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag03D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag03D.map
+  name: d_a_kytag03
 
 - object: files/rel/RVL/Debug/d_a_kytag04D.rel
   hash: 08825f6f787338675ad9f673aec624f26725cf2b
   symbols: config/ShieldD/rels/d_a_kytag04D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag04D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag04D.map
+  name: d_a_kytag04
 
 - object: files/rel/RVL/Debug/d_a_kytag05D.rel
   hash: d67fba78f279515d3e421669bbff6acb22b24aeb
   symbols: config/ShieldD/rels/d_a_kytag05D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag05D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag05D.map
+  name: d_a_kytag05
 
 - object: files/rel/RVL/Debug/d_a_kytag06D.rel
   hash: a142d676d5dc272be4e7d493cc1ff070ba2d98b6
   symbols: config/ShieldD/rels/d_a_kytag06D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag06D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag06D.map
+  name: d_a_kytag06
 
 - object: files/rel/RVL/Debug/d_a_kytag07D.rel
   hash: d3ae81dcdf51cf63a6dbb26849781036437c5d16
   symbols: config/ShieldD/rels/d_a_kytag07D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag07D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag07D.map
+  name: d_a_kytag07
 
 - object: files/rel/RVL/Debug/d_a_kytag08D.rel
   hash: aa0f7d503a762fdbc4744abe0ebb4ed2968d0f6c
   symbols: config/ShieldD/rels/d_a_kytag08D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag08D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag08D.map
+  name: d_a_kytag08
 
 - object: files/rel/RVL/Debug/d_a_kytag09D.rel
   hash: 0684c27e558d9bc1e5ecb654dd6e4adbc694ce03
   symbols: config/ShieldD/rels/d_a_kytag09D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag09D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag09D.map
+  name: d_a_kytag09
 
 - object: files/rel/RVL/Debug/d_a_kytag10D.rel
   hash: 844b847dbe5d9426c2484fd1bc0f495c3f23926f
   symbols: config/ShieldD/rels/d_a_kytag10D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag10D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag10D.map
+  name: d_a_kytag10
 
 - object: files/rel/RVL/Debug/d_a_kytag11D.rel
   hash: aabd940ba402b479a1eba4e852b6f40a4b9ccb90
   symbols: config/ShieldD/rels/d_a_kytag11D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag11D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag11D.map
+  name: d_a_kytag11
 
 - object: files/rel/RVL/Debug/d_a_kytag12D.rel
   hash: b5cdc7cc050889d5e4c8e60fff6adfa01acf9b40
   symbols: config/ShieldD/rels/d_a_kytag12D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag12D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag12D.map
+  name: d_a_kytag12
 
 - object: files/rel/RVL/Debug/d_a_kytag13D.rel
   hash: 18bf14f1ed6ea9a2eb1dfacdc0534bf77fa82f8f
   symbols: config/ShieldD/rels/d_a_kytag13D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag13D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag13D.map
+  name: d_a_kytag13
 
 - object: files/rel/RVL/Debug/d_a_kytag14D.rel
   hash: 72de02495fd591e8dba47de9fe271042b08a105a
   symbols: config/ShieldD/rels/d_a_kytag14D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag14D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag14D.map
+  name: d_a_kytag14
 
 - object: files/rel/RVL/Debug/d_a_kytag15D.rel
   hash: 8dfe1afd193f890fb3f4229f587e75299cdc2c8d
   symbols: config/ShieldD/rels/d_a_kytag15D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag15D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag15D.map
+  name: d_a_kytag15
 
 - object: files/rel/RVL/Debug/d_a_kytag16D.rel
   hash: b2dc09c4b4a35b059b17e48428093a345d3640a5
   symbols: config/ShieldD/rels/d_a_kytag16D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag16D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag16D.map
+  name: d_a_kytag16
 
 - object: files/rel/RVL/Debug/d_a_kytag17D.rel
   hash: df1a676fcfa37e97c4444d8f1d666c7c645a0f42
   symbols: config/ShieldD/rels/d_a_kytag17D/symbols.txt
   splits: config/ShieldD/rels/d_a_kytag17D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_kytag17D.map
+  name: d_a_kytag17
 
 - object: files/rel/RVL/Debug/d_a_L7demo_drD.rel
   hash: f8631666f2f163dd0d5c8e0a56af82f4db5c525a
   symbols: config/ShieldD/rels/d_a_L7demo_drD/symbols.txt
   splits: config/ShieldD/rels/d_a_L7demo_drD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_L7demo_drD.map
+  name: d_a_L7demo_dr
 
 - object: files/rel/RVL/Debug/d_a_L7low_drD.rel
   hash: 22ccf35f33dc61c2b6bd27dd4f8e60ba5d8d5141
   symbols: config/ShieldD/rels/d_a_L7low_drD/symbols.txt
   splits: config/ShieldD/rels/d_a_L7low_drD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_L7low_drD.map
+  name: d_a_L7low_dr
 
 - object: files/rel/RVL/Debug/d_a_L7op_demo_drD.rel
   hash: 12a27b9dfe1b69bd7b58de4bb0652f2a0b8e152f
   symbols: config/ShieldD/rels/d_a_L7op_demo_drD/symbols.txt
   splits: config/ShieldD/rels/d_a_L7op_demo_drD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_L7op_demo_drD.map
+  name: d_a_L7op_demo_dr
 
 - object: files/rel/RVL/Debug/d_a_mantD.rel
   hash: 6b92d4a64578a7c799e0da48a9ccf0ba0e70b161
   symbols: config/ShieldD/rels/d_a_mantD/symbols.txt
   splits: config/ShieldD/rels/d_a_mantD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_mantD.map
+  name: d_a_mant
   extract:
   - symbol: l_Egnd_mantTEX
     binary: assets/l_Egnd_mantTEX.bin
@@ -1110,3414 +1289,3983 @@ modules:
   symbols: config/ShieldD/rels/d_a_mg_fishD/symbols.txt
   splits: config/ShieldD/rels/d_a_mg_fishD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_mg_fishD.map
+  name: d_a_mg_fish
 
 - object: files/rel/RVL/Debug/d_a_mg_fshopD.rel
   hash: 8eb84a57ae761bdd520acd42846037b652fbc2e1
   symbols: config/ShieldD/rels/d_a_mg_fshopD/symbols.txt
   splits: config/ShieldD/rels/d_a_mg_fshopD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_mg_fshopD.map
+  name: d_a_mg_fshop
 
 - object: files/rel/RVL/Debug/d_a_mg_rodD.rel
   hash: 87f19cdf9eb9df5e0c5f41bf93fc8e72808e35ce
   symbols: config/ShieldD/rels/d_a_mg_rodD/symbols.txt
   splits: config/ShieldD/rels/d_a_mg_rodD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_mg_rodD.map
+  name: d_a_mg_rod
 
 - object: files/rel/RVL/Debug/d_a_midnaD.rel
   hash: 24a7ba36638fc95f35f2af6baa4cf451512a5b93
   symbols: config/ShieldD/rels/d_a_midnaD/symbols.txt
   splits: config/ShieldD/rels/d_a_midnaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_midnaD.map
+  name: d_a_midna
 
 - object: files/rel/RVL/Debug/d_a_mirrorD.rel
   hash: 275e0559dede3c51135ec9388e2d9e1a294322db
   symbols: config/ShieldD/rels/d_a_mirrorD/symbols.txt
   splits: config/ShieldD/rels/d_a_mirrorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_mirrorD.map
+  name: d_a_mirror
 
 - object: files/rel/RVL/Debug/d_a_movie_playerD.rel
   hash: bf80fe101f8708e3acf985287f64b4d4ba744857
   symbols: config/ShieldD/rels/d_a_movie_playerD/symbols.txt
   splits: config/ShieldD/rels/d_a_movie_playerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_movie_playerD.map
+  name: d_a_movie_player
 
 - object: files/rel/RVL/Debug/d_a_mynaD.rel
   hash: 7f723133b9e2b8b1a6144ee4bca2760597fdcbab
   symbols: config/ShieldD/rels/d_a_mynaD/symbols.txt
   splits: config/ShieldD/rels/d_a_mynaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_mynaD.map
+  name: d_a_myna
 
 - object: files/rel/RVL/Debug/d_a_nbombD.rel
   hash: 8ba85548f00f2c98e75f471793396a54572f1494
   symbols: config/ShieldD/rels/d_a_nbombD/symbols.txt
   splits: config/ShieldD/rels/d_a_nbombD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_nbombD.map
+  name: d_a_nbomb
 
 - object: files/rel/RVL/Debug/d_a_niD.rel
   hash: fd5912a8e7065b969789099884b0a5d5a6c3b151
   symbols: config/ShieldD/rels/d_a_niD/symbols.txt
   splits: config/ShieldD/rels/d_a_niD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_niD.map
+  name: d_a_ni
 
 - object: files/rel/RVL/Debug/d_a_no_chg_roomD.rel
   hash: 0095d900749ad7094f0fd5201445475580a00929
   symbols: config/ShieldD/rels/d_a_no_chg_roomD/symbols.txt
   splits: config/ShieldD/rels/d_a_no_chg_roomD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_no_chg_roomD.map
+  name: d_a_no_chg_room
 
 - object: files/rel/RVL/Debug/d_a_npc_aruD.rel
   hash: 530136ca5dafd0287a81162987abc387c55efa34
   symbols: config/ShieldD/rels/d_a_npc_aruD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_aruD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_aruD.map
+  name: d_a_npc_aru
 
 - object: files/rel/RVL/Debug/d_a_npc_ashBD.rel
   hash: 6a8c05614b5db5b7b3367dc11a11eec77860c824
   symbols: config/ShieldD/rels/d_a_npc_ashBD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_ashBD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_ashBD.map
+  name: d_a_npc_ashB
 
 - object: files/rel/RVL/Debug/d_a_npc_ashD.rel
   hash: c674dda516c95a2156d5dd10c43a556f00c1c0e1
   symbols: config/ShieldD/rels/d_a_npc_ashD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_ashD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_ashD.map
+  name: d_a_npc_ash
 
 - object: files/rel/RVL/Debug/d_a_npc_bansD.rel
   hash: 11de1bdb0256a27ded05314c74121e66a39f4a13
   symbols: config/ShieldD/rels/d_a_npc_bansD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_bansD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_bansD.map
+  name: d_a_npc_bans
 
 - object: files/rel/RVL/Debug/d_a_npc_besuD.rel
   hash: 65bdedf73e37baf7a4be0d08642f60dcdcca100d
   symbols: config/ShieldD/rels/d_a_npc_besuD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_besuD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_besuD.map
+  name: d_a_npc_besu
 
 - object: files/rel/RVL/Debug/d_a_npc_blue_nsD.rel
   hash: 389269b5ffc281efe75ee49698a055b4d95ea5d4
   symbols: config/ShieldD/rels/d_a_npc_blue_nsD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_blue_nsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_blue_nsD.map
+  name: d_a_npc_blue_ns
 
 - object: files/rel/RVL/Debug/d_a_npc_bouD.rel
   hash: 6110425a9a59582153a27541d1c988daed66d982
   symbols: config/ShieldD/rels/d_a_npc_bouD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_bouD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_bouD.map
+  name: d_a_npc_bou
 
 - object: files/rel/RVL/Debug/d_a_npc_bouSD.rel
   hash: 4eadebe1210a94afc207b675c49298bcd6017179
   symbols: config/ShieldD/rels/d_a_npc_bouSD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_bouSD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_bouSD.map
+  name: d_a_npc_bouS
 
 - object: files/rel/RVL/Debug/d_a_npc_cdn3D.rel
   hash: e57121f390879f272741975d67c127a31102c16d
   symbols: config/ShieldD/rels/d_a_npc_cdn3D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_cdn3D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_cdn3D.map
+  name: d_a_npc_cdn3
 
 - object: files/rel/RVL/Debug/d_a_npc_chatD.rel
   hash: e5dbe67df5d60d53ca0bb7faa185cca31364ff02
   symbols: config/ShieldD/rels/d_a_npc_chatD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_chatD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_chatD.map
+  name: d_a_npc_chat
 
 - object: files/rel/RVL/Debug/d_a_npc_chinD.rel
   hash: 46d787f88530a16de3010b0cd045f0e37c204931
   symbols: config/ShieldD/rels/d_a_npc_chinD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_chinD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_chinD.map
+  name: d_a_npc_chin
 
 - object: files/rel/RVL/Debug/d_a_npc_clerkaD.rel
   hash: bf30e02dcb437505024d8209b68eb52555c6317a
   symbols: config/ShieldD/rels/d_a_npc_clerkaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_clerkaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_clerkaD.map
+  name: d_a_npc_clerka
 
 - object: files/rel/RVL/Debug/d_a_npc_clerkbD.rel
   hash: 78ed272ea160875e3d4899ee9b3ce8a5789fa9ce
   symbols: config/ShieldD/rels/d_a_npc_clerkbD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_clerkbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_clerkbD.map
+  name: d_a_npc_clerkb
 
 - object: files/rel/RVL/Debug/d_a_npc_clerktD.rel
   hash: 739c94f938febc16a55aa37908008680d703326c
   symbols: config/ShieldD/rels/d_a_npc_clerktD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_clerktD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_clerktD.map
+  name: d_a_npc_clerkt
 
 - object: files/rel/RVL/Debug/d_a_npc_coachD.rel
   hash: 14eb18a53ceb72bf249b78da641dde409c71c796
   symbols: config/ShieldD/rels/d_a_npc_coachD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_coachD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_coachD.map
+  name: d_a_npc_coach
 
 - object: files/rel/RVL/Debug/d_a_npc_dfD.rel
   hash: 7dda7a2cbf4e55eb47c7c876ee1cdc87a0d1a993
   symbols: config/ShieldD/rels/d_a_npc_dfD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_dfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_dfD.map
+  name: d_a_npc_df
 
 - object: files/rel/RVL/Debug/d_a_npc_docD.rel
   hash: 5b18b95e7b0ee1e171c9bf9645c93f4a4dfef800
   symbols: config/ShieldD/rels/d_a_npc_docD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_docD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_docD.map
+  name: d_a_npc_doc
 
 - object: files/rel/RVL/Debug/d_a_npc_doorboyD.rel
   hash: 71647257320fb8ce2846542c86544419df7d57e8
   symbols: config/ShieldD/rels/d_a_npc_doorboyD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_doorboyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_doorboyD.map
+  name: d_a_npc_doorboy
 
 - object: files/rel/RVL/Debug/d_a_npc_drainSolD.rel
   hash: b223ca6ded1bf2d2e6889e8d3f8d07965b3190a5
   symbols: config/ShieldD/rels/d_a_npc_drainSolD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_drainSolD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_drainSolD.map
+  name: d_a_npc_drainSol
 
 - object: files/rel/RVL/Debug/d_a_npc_duD.rel
   hash: d560342824a921a9aaff62e0540c6f8a88626ae3
   symbols: config/ShieldD/rels/d_a_npc_duD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_duD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_duD.map
+  name: d_a_npc_du
 
 - object: files/rel/RVL/Debug/d_a_npc_fairyD.rel
   hash: 4712b288756ecdb30214763262e3659c5773f1d5
   symbols: config/ShieldD/rels/d_a_npc_fairyD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_fairyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_fairyD.map
+  name: d_a_npc_fairy
 
 - object: files/rel/RVL/Debug/d_a_npc_fairy_seireiD.rel
   hash: 2d85785e3e733ad111d4d67217c4c4224ea990fe
   symbols: config/ShieldD/rels/d_a_npc_fairy_seireiD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_fairy_seireiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_fairy_seireiD.map
+  name: d_a_npc_fairy_seirei
 
 - object: files/rel/RVL/Debug/d_a_npc_fguardD.rel
   hash: 06769f21928ce30d10c7443e52e35b1ec8396457
   symbols: config/ShieldD/rels/d_a_npc_fguardD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_fguardD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_fguardD.map
+  name: d_a_npc_fguard
 
 - object: files/rel/RVL/Debug/d_a_npc_fishD.rel
   hash: 45de0568ffac2034e2cd4a6c1b84ced64a7224bc
   symbols: config/ShieldD/rels/d_a_npc_fishD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_fishD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_fishD.map
+  name: d_a_npc_fish
 
 - object: files/rel/RVL/Debug/d_a_npc_gndD.rel
   hash: 0a1912c02e4de07ae4ce478796aea8cc30d85945
   symbols: config/ShieldD/rels/d_a_npc_gndD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_gndD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_gndD.map
+  name: d_a_npc_gnd
 
 - object: files/rel/RVL/Debug/d_a_npc_graD.rel
   hash: 27dfb57fc7658114be6e6335567ed2d90af0964f
   symbols: config/ShieldD/rels/d_a_npc_graD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_graD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_graD.map
+  name: d_a_npc_gra
 
 - object: files/rel/RVL/Debug/d_a_npc_grcD.rel
   hash: 4112aaa389b1a755817ed7a8a6da6126b5b1fc92
   symbols: config/ShieldD/rels/d_a_npc_grcD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grcD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grcD.map
+  name: d_a_npc_grc
 
 - object: files/rel/RVL/Debug/d_a_npc_grdD.rel
   hash: 79aa3821a89697aa1010d9eb416bbdbd5cf9fadb
   symbols: config/ShieldD/rels/d_a_npc_grdD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grdD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grdD.map
+  name: d_a_npc_grd
 
 - object: files/rel/RVL/Debug/d_a_npc_grmcD.rel
   hash: a005160ac49dbeaf9572dc038d4caa2eaf4fdc18
   symbols: config/ShieldD/rels/d_a_npc_grmcD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grmcD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grmcD.map
+  name: d_a_npc_grmc
 
 - object: files/rel/RVL/Debug/d_a_npc_grmD.rel
   hash: bb8b71f027e91e94b8f127f0c9ec8b7fc2829584
   symbols: config/ShieldD/rels/d_a_npc_grmD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grmD.map
+  name: d_a_npc_grm
 
 - object: files/rel/RVL/Debug/d_a_npc_groD.rel
   hash: a4740cebd2ccad9bb8c6807b8bcaf0f5d9d686d8
   symbols: config/ShieldD/rels/d_a_npc_groD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_groD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_groD.map
+  name: d_a_npc_gro
 
 - object: files/rel/RVL/Debug/d_a_npc_grrD.rel
   hash: 8bb8cc949f25d24fa936fe6ef815e1e172d13567
   symbols: config/ShieldD/rels/d_a_npc_grrD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grrD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grrD.map
+  name: d_a_npc_grr
 
 - object: files/rel/RVL/Debug/d_a_npc_grsD.rel
   hash: 091121d775575958f044f9612884f78b0335d61e
   symbols: config/ShieldD/rels/d_a_npc_grsD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grsD.map
+  name: d_a_npc_grs
 
 - object: files/rel/RVL/Debug/d_a_npc_grzD.rel
   hash: f57af9ff8e23ea1b4c0b95a381f8070155de0a56
   symbols: config/ShieldD/rels/d_a_npc_grzD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_grzD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_grzD.map
+  name: d_a_npc_grz
 
 - object: files/rel/RVL/Debug/d_a_npc_guardD.rel
   hash: ffb1404aed4f01f6d76fc5d5f42f95c02002b88d
   symbols: config/ShieldD/rels/d_a_npc_guardD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_guardD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_guardD.map
+  name: d_a_npc_guard
 
 - object: files/rel/RVL/Debug/d_a_npc_gwolfD.rel
   hash: bee05392c6a32339e4c25c56f3d9a2725e25fc1b
   symbols: config/ShieldD/rels/d_a_npc_gwolfD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_gwolfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_gwolfD.map
+  name: d_a_npc_gwolf
 
 - object: files/rel/RVL/Debug/d_a_npc_hanjoD.rel
   hash: b12ce0d87066dcbf1da559e0a774be6116cb205a
   symbols: config/ShieldD/rels/d_a_npc_hanjoD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_hanjoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_hanjoD.map
+  name: d_a_npc_hanjo
 
 - object: files/rel/RVL/Debug/d_a_npc_henna0D.rel
   hash: 31363cb298e84d84a77c12401ad95d8f6a60cfaa
   symbols: config/ShieldD/rels/d_a_npc_henna0D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_henna0D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_henna0D.map
+  name: d_a_npc_henna0
 
 - object: files/rel/RVL/Debug/d_a_npc_hennaD.rel
   hash: be17d335a8e7380a37cba7472b327efe36ea2392
   symbols: config/ShieldD/rels/d_a_npc_hennaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_hennaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_hennaD.map
+  name: d_a_npc_henna
 
 - object: files/rel/RVL/Debug/d_a_npc_hozD.rel
   hash: 4e035ee9b4b630f8364739c90f226e0b937611a9
   symbols: config/ShieldD/rels/d_a_npc_hozD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_hozD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_hozD.map
+  name: d_a_npc_hoz
 
 - object: files/rel/RVL/Debug/d_a_npc_impalD.rel
   hash: 5311c64abe2dfb81f00f750985b08949070fadf2
   symbols: config/ShieldD/rels/d_a_npc_impalD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_impalD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_impalD.map
+  name: d_a_npc_impal
 
 - object: files/rel/RVL/Debug/d_a_npc_inkoD.rel
   hash: fe0e5fbc50791d963c3a700720c0d0ea52f3ca43
   symbols: config/ShieldD/rels/d_a_npc_inkoD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_inkoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_inkoD.map
+  name: d_a_npc_inko
 
 - object: files/rel/RVL/Debug/d_a_npc_insD.rel
   hash: fd2706b90229d55759ce052afbae97207c9ed72c
   symbols: config/ShieldD/rels/d_a_npc_insD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_insD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_insD.map
+  name: d_a_npc_ins
 
 - object: files/rel/RVL/Debug/d_a_npc_jagarD.rel
   hash: c743eeaa9ad687e3e11bcdb852d8eb81be083b5e
   symbols: config/ShieldD/rels/d_a_npc_jagarD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_jagarD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_jagarD.map
+  name: d_a_npc_jagar
 
 - object: files/rel/RVL/Debug/d_a_npc_kakashiD.rel
   hash: edba4031d805eebf54166e6f4943bb4b59f7a080
   symbols: config/ShieldD/rels/d_a_npc_kakashiD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kakashiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kakashiD.map
+  name: d_a_npc_kakashi
 
 - object: files/rel/RVL/Debug/d_a_npc_kasi_hanaD.rel
   hash: a2b2be4990829f2e136ecb72db3d6d464c1e0f07
   symbols: config/ShieldD/rels/d_a_npc_kasi_hanaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kasi_hanaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kasi_hanaD.map
+  name: d_a_npc_kasi_hana
 
 - object: files/rel/RVL/Debug/d_a_npc_kasi_kyuD.rel
   hash: 379c80b22cbb9b505c65688c43395836c766d326
   symbols: config/ShieldD/rels/d_a_npc_kasi_kyuD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kasi_kyuD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kasi_kyuD.map
+  name: d_a_npc_kasi_kyu
 
 - object: files/rel/RVL/Debug/d_a_npc_kasi_michD.rel
   hash: 3b84a2eb384728c45bfad05a974a3e603c29459a
   symbols: config/ShieldD/rels/d_a_npc_kasi_michD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kasi_michD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kasi_michD.map
+  name: d_a_npc_kasi_mich
 
 - object: files/rel/RVL/Debug/d_a_npc_kdkD.rel
   hash: cc5232508a79d6c6ec61d27656f59e4d224db519
   symbols: config/ShieldD/rels/d_a_npc_kdkD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kdkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kdkD.map
+  name: d_a_npc_kdk
 
 - object: files/rel/RVL/Debug/d_a_npc_kkriD.rel
   hash: 12ee27cdb33371eadf5e82d088b0c84a1334d226
   symbols: config/ShieldD/rels/d_a_npc_kkriD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kkriD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kkriD.map
+  name: d_a_npc_kkri
 
 - object: files/rel/RVL/Debug/d_a_npc_knD.rel
   hash: e55c8c3b41adb2eac38dce348b2422d6ca5ece84
   symbols: config/ShieldD/rels/d_a_npc_knD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_knD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_knD.map
+  name: d_a_npc_kn
 
 - object: files/rel/RVL/Debug/d_a_npc_knjD.rel
   hash: 7fa532abb371aa577de1abf2079559f21d740c6c
   symbols: config/ShieldD/rels/d_a_npc_knjD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_knjD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_knjD.map
+  name: d_a_npc_knj
 
 - object: files/rel/RVL/Debug/d_a_npc_kolinbD.rel
   hash: 6049606d744edc675bf7c6e158b1b936d6f13fae
   symbols: config/ShieldD/rels/d_a_npc_kolinbD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kolinbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kolinbD.map
+  name: d_a_npc_kolinb
 
 - object: files/rel/RVL/Debug/d_a_npc_kolinD.rel
   hash: e8c0bd8a9a13415bf649098c10825390a7ab548e
   symbols: config/ShieldD/rels/d_a_npc_kolinD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kolinD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kolinD.map
+  name: d_a_npc_kolin
 
 - object: files/rel/RVL/Debug/d_a_npc_ksD.rel
   hash: a2afcbb145460bc36dbc1b8d04d9ddd38e1c6585
   symbols: config/ShieldD/rels/d_a_npc_ksD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_ksD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_ksD.map
+  name: d_a_npc_ks
 
 - object: files/rel/RVL/Debug/d_a_npc_kyuryD.rel
   hash: 780b40fd34c81582a301affd72408c559c778f47
   symbols: config/ShieldD/rels/d_a_npc_kyuryD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_kyuryD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_kyuryD.map
+  name: d_a_npc_kyury
 
 - object: files/rel/RVL/Debug/d_a_npc_lenD.rel
   hash: 938a33f16e0ddbd47a4761e5cd41364b820ebe7a
   symbols: config/ShieldD/rels/d_a_npc_lenD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_lenD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_lenD.map
+  name: d_a_npc_len
 
 - object: files/rel/RVL/Debug/d_a_npc_lfD.rel
   hash: 571b996f9674686ca808b25d3082559418680212
   symbols: config/ShieldD/rels/d_a_npc_lfD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_lfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_lfD.map
+  name: d_a_npc_lf
 
 - object: files/rel/RVL/Debug/d_a_npc_ludD.rel
   hash: f28aa7eb7f280f17fb24991fc9fe5773e990bbaa
   symbols: config/ShieldD/rels/d_a_npc_ludD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_ludD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_ludD.map
+  name: d_a_npc_lud
 
 - object: files/rel/RVL/Debug/d_a_npc_maroD.rel
   hash: 840254a8b492df316eda5e67b8294c17ae952124
   symbols: config/ShieldD/rels/d_a_npc_maroD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_maroD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_maroD.map
+  name: d_a_npc_maro
 
 - object: files/rel/RVL/Debug/d_a_npc_midpD.rel
   hash: 49e14cce7fb0e7c1c1342359ff8b7477fc208f40
   symbols: config/ShieldD/rels/d_a_npc_midpD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_midpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_midpD.map
+  name: d_a_npc_midp
 
 - object: files/rel/RVL/Debug/d_a_npc_moiD.rel
   hash: 5ee9cb11e4a76b6c52d59c317276efaf3ba84003
   symbols: config/ShieldD/rels/d_a_npc_moiD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_moiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_moiD.map
+  name: d_a_npc_moi
 
 - object: files/rel/RVL/Debug/d_a_npc_moirD.rel
   hash: 785b706391dc769754c643c6615760bc00e9067d
   symbols: config/ShieldD/rels/d_a_npc_moirD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_moirD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_moirD.map
+  name: d_a_npc_moir
 
 - object: files/rel/RVL/Debug/d_a_npc_myna2D.rel
   hash: f3e4996e9b12cc7bc30c852f5df369789428e6ad
   symbols: config/ShieldD/rels/d_a_npc_myna2D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_myna2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_myna2D.map
+  name: d_a_npc_myna2
 
 - object: files/rel/RVL/Debug/d_a_npc_neD.rel
   hash: 662e9d854e4cf6d9b7892c13b72158f684b82867
   symbols: config/ShieldD/rels/d_a_npc_neD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_neD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_neD.map
+  name: d_a_npc_ne
 
 - object: files/rel/RVL/Debug/d_a_npc_p2D.rel
   hash: d3c73c0a0bf21c54fc505d68f8afbf7c20d2b029
   symbols: config/ShieldD/rels/d_a_npc_p2D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_p2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_p2D.map
+  name: d_a_npc_p2
 
 - object: files/rel/RVL/Debug/d_a_npc_pachi_besuD.rel
   hash: f3f2a7f04e654d9d67a2aa8255d57a53f0e099ab
   symbols: config/ShieldD/rels/d_a_npc_pachi_besuD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_pachi_besuD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_pachi_besuD.map
+  name: d_a_npc_pachi_besu
 
 - object: files/rel/RVL/Debug/d_a_npc_pachi_maroD.rel
   hash: ee7577fea11068ecdac3edd7a41a8f8f64ac7915
   symbols: config/ShieldD/rels/d_a_npc_pachi_maroD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_pachi_maroD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_pachi_maroD.map
+  name: d_a_npc_pachi_maro
 
 - object: files/rel/RVL/Debug/d_a_npc_pachi_taroD.rel
   hash: f688f9b0af697935ec20c5196f49f5c11c82d520
   symbols: config/ShieldD/rels/d_a_npc_pachi_taroD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_pachi_taroD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_pachi_taroD.map
+  name: d_a_npc_pachi_taro
 
 - object: files/rel/RVL/Debug/d_a_npc_passer2D.rel
   hash: ca4e374595a2e693fa8b2a09dcfb524e2fb1cc1a
   symbols: config/ShieldD/rels/d_a_npc_passer2D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_passer2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_passer2D.map
+  name: d_a_npc_passer2
 
 - object: files/rel/RVL/Debug/d_a_npc_passerD.rel
   hash: aaf3ed36ed06cdd01a05e3166df8a4c6a6dbaf91
   symbols: config/ShieldD/rels/d_a_npc_passerD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_passerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_passerD.map
+  name: d_a_npc_passer
 
 - object: files/rel/RVL/Debug/d_a_npc_postD.rel
   hash: 4494771dc412e573d64355c7f33fca93e98e6a98
   symbols: config/ShieldD/rels/d_a_npc_postD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_postD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_postD.map
+  name: d_a_npc_post
 
 - object: files/rel/RVL/Debug/d_a_npc_pouyaD.rel
   hash: 39db2da9c7218f41612aa53bdd386d9bd9042d00
   symbols: config/ShieldD/rels/d_a_npc_pouyaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_pouyaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_pouyaD.map
+  name: d_a_npc_pouya
 
 - object: files/rel/RVL/Debug/d_a_npc_prayerD.rel
   hash: d2277a95d7bc42a48735d32c04c881616e3a6b96
   symbols: config/ShieldD/rels/d_a_npc_prayerD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_prayerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_prayerD.map
+  name: d_a_npc_prayer
 
 - object: files/rel/RVL/Debug/d_a_npc_racaD.rel
   hash: 107d66628f59d479138b96d69b6ebb94df378808
   symbols: config/ShieldD/rels/d_a_npc_racaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_racaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_racaD.map
+  name: d_a_npc_raca
 
 - object: files/rel/RVL/Debug/d_a_npc_rafrelD.rel
   hash: a938a3f1eb43a1880d94fb378c3253b69f7c7323
   symbols: config/ShieldD/rels/d_a_npc_rafrelD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_rafrelD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_rafrelD.map
+  name: d_a_npc_rafrel
 
 - object: files/rel/RVL/Debug/d_a_npc_saruD.rel
   hash: 2eaf3fffed3ee467cf1db5a3ea13321054cb006a
   symbols: config/ShieldD/rels/d_a_npc_saruD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_saruD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_saruD.map
+  name: d_a_npc_saru
 
 - object: files/rel/RVL/Debug/d_a_npc_seibD.rel
   hash: 64d0c197d6b3fc0e7997ec5e5ab1fb2a3556022a
   symbols: config/ShieldD/rels/d_a_npc_seibD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_seibD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_seibD.map
+  name: d_a_npc_seib
 
 - object: files/rel/RVL/Debug/d_a_npc_seicD.rel
   hash: f900e80ebdd17107b0316115a995e8d94041f7cf
   symbols: config/ShieldD/rels/d_a_npc_seicD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_seicD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_seicD.map
+  name: d_a_npc_seic
 
 - object: files/rel/RVL/Debug/d_a_npc_seidD.rel
   hash: a5fa826430a204d366776bf24b14adb7ab18b583
   symbols: config/ShieldD/rels/d_a_npc_seidD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_seidD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_seidD.map
+  name: d_a_npc_seid
 
 - object: files/rel/RVL/Debug/d_a_npc_seira2D.rel
   hash: 9b5f4a1f50750282c583ccfe7481d55554f4698a
   symbols: config/ShieldD/rels/d_a_npc_seira2D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_seira2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_seira2D.map
+  name: d_a_npc_seira2
 
 - object: files/rel/RVL/Debug/d_a_npc_seiraD.rel
   hash: 70c1b9f02309b122c8738ce327cf45758544fd03
   symbols: config/ShieldD/rels/d_a_npc_seiraD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_seiraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_seiraD.map
+  name: d_a_npc_seira
 
 - object: files/rel/RVL/Debug/d_a_npc_seireiD.rel
   hash: 5666bfcb496daabcc911f63287a20d42ec328c63
   symbols: config/ShieldD/rels/d_a_npc_seireiD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_seireiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_seireiD.map
+  name: d_a_npc_seirei
 
 - object: files/rel/RVL/Debug/d_a_npc_shadD.rel
   hash: f4d03ecec6869a14763fa320db0e4a3cee19e145
   symbols: config/ShieldD/rels/d_a_npc_shadD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_shadD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_shadD.map
+  name: d_a_npc_shad
 
 - object: files/rel/RVL/Debug/d_a_npc_shamanD.rel
   hash: 2d2dc07c2fd2265bdf88f787a5fa4e5fb27101d3
   symbols: config/ShieldD/rels/d_a_npc_shamanD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_shamanD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_shamanD.map
+  name: d_a_npc_shaman
 
 - object: files/rel/RVL/Debug/d_a_npc_shoeD.rel
   hash: 5bd125f654387d9195fea3e123b1e60b49959c1c
   symbols: config/ShieldD/rels/d_a_npc_shoeD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_shoeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_shoeD.map
+  name: d_a_npc_shoe
 
 - object: files/rel/RVL/Debug/d_a_npc_shop0D.rel
   hash: f82a9092857570d1c146719f1072b676c05d0618
   symbols: config/ShieldD/rels/d_a_npc_shop0D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_shop0D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_shop0D.map
+  name: d_a_npc_shop0
 
 - object: files/rel/RVL/Debug/d_a_npc_shop_maroD.rel
   hash: b3c73dd2c727561405e170398e8f1640239f1603
   symbols: config/ShieldD/rels/d_a_npc_shop_maroD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_shop_maroD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_shop_maroD.map
+  name: d_a_npc_shop_maro
 
 - object: files/rel/RVL/Debug/d_a_npc_solaD.rel
   hash: 193eab0f17ee2ddb1235ed88eb6abc4865f8e047
   symbols: config/ShieldD/rels/d_a_npc_solaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_solaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_solaD.map
+  name: d_a_npc_sola
 
 - object: files/rel/RVL/Debug/d_a_npc_soldierAD.rel
   hash: e628a829fa44ddb0e92f8f7b6d2638ec26d87d8d
   symbols: config/ShieldD/rels/d_a_npc_soldierAD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_soldierAD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_soldierAD.map
+  name: d_a_npc_soldierA
 
 - object: files/rel/RVL/Debug/d_a_npc_soldierBD.rel
   hash: ca218ced6aaad0b1a5065c1c827639d20dfb8add
   symbols: config/ShieldD/rels/d_a_npc_soldierBD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_soldierBD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_soldierBD.map
+  name: d_a_npc_soldierB
 
 - object: files/rel/RVL/Debug/d_a_npc_sqD.rel
   hash: cfbe28654ce69a68eb42a764a1c71416a217b045
   symbols: config/ShieldD/rels/d_a_npc_sqD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_sqD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_sqD.map
+  name: d_a_npc_sq
 
 - object: files/rel/RVL/Debug/d_a_npc_taroD.rel
   hash: b9fae378b952814ab5f414f5f5eb0d7306fbf904
   symbols: config/ShieldD/rels/d_a_npc_taroD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_taroD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_taroD.map
+  name: d_a_npc_taro
 
 - object: files/rel/RVL/Debug/d_a_npc_theBD.rel
   hash: fec7e17934c40ad5a1d4aa831b72cbd4d7c017a9
   symbols: config/ShieldD/rels/d_a_npc_theBD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_theBD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_theBD.map
+  name: d_a_npc_theB
 
 - object: files/rel/RVL/Debug/d_a_npc_theD.rel
   hash: c9765c747d9f0473d8d92014c5bff339150454e5
   symbols: config/ShieldD/rels/d_a_npc_theD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_theD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_theD.map
+  name: d_a_npc_the
 
 - object: files/rel/RVL/Debug/d_a_npc_tkcD.rel
   hash: d03b40997173786669abc1722018f9ee9e1ccabf
   symbols: config/ShieldD/rels/d_a_npc_tkcD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_tkcD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_tkcD.map
+  name: d_a_npc_tkc
 
 - object: files/rel/RVL/Debug/d_a_npc_tkD.rel
   hash: 977cdd0df76b24d910f70dc39f335c6b71ec5110
   symbols: config/ShieldD/rels/d_a_npc_tkD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_tkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_tkD.map
+  name: d_a_npc_tk
 
 - object: files/rel/RVL/Debug/d_a_npc_tkj2D.rel
   hash: 003ae68bbb68837d3c935a25cee8892eaf9fafe8
   symbols: config/ShieldD/rels/d_a_npc_tkj2D/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_tkj2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_tkj2D.map
+  name: d_a_npc_tkj2
 
 - object: files/rel/RVL/Debug/d_a_npc_tkjD.rel
   hash: 83af75e01654de06f57d84b93a09e03fef13dfde
   symbols: config/ShieldD/rels/d_a_npc_tkjD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_tkjD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_tkjD.map
+  name: d_a_npc_tkj
 
 - object: files/rel/RVL/Debug/d_a_npc_tksD.rel
   hash: 67d4d27c36c155439176f1bbaaa8c1133b9bd82a
   symbols: config/ShieldD/rels/d_a_npc_tksD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_tksD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_tksD.map
+  name: d_a_npc_tks
 
 - object: files/rel/RVL/Debug/d_a_npc_tobyD.rel
   hash: e7c116fa4756257b5335a16d6bef7d8595cb9d1a
   symbols: config/ShieldD/rels/d_a_npc_tobyD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_tobyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_tobyD.map
+  name: d_a_npc_toby
 
 - object: files/rel/RVL/Debug/d_a_npc_trD.rel
   hash: e764cece96dae56a70821114534cc581c1554b3f
   symbols: config/ShieldD/rels/d_a_npc_trD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_trD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_trD.map
+  name: d_a_npc_tr
 
 - object: files/rel/RVL/Debug/d_a_npc_uriD.rel
   hash: e1b99c207d166bcccd01b0ab55c5d0fa762f704f
   symbols: config/ShieldD/rels/d_a_npc_uriD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_uriD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_uriD.map
+  name: d_a_npc_uri
 
 - object: files/rel/RVL/Debug/d_a_npc_wormD.rel
   hash: 06b31ba06afd76f1214f25ab132d61fe8d5abcbc
   symbols: config/ShieldD/rels/d_a_npc_wormD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_wormD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_wormD.map
+  name: d_a_npc_worm
 
 - object: files/rel/RVL/Debug/d_a_npc_wrestlerD.rel
   hash: 8317a4fbfa24aa42ab132a4ccc36b28a2a5eb992
   symbols: config/ShieldD/rels/d_a_npc_wrestlerD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_wrestlerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_wrestlerD.map
+  name: d_a_npc_wrestler
 
 - object: files/rel/RVL/Debug/d_a_npc_yamidD.rel
   hash: ee04dad81ff72daee56f8fbc9559def2ed559113
   symbols: config/ShieldD/rels/d_a_npc_yamidD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_yamidD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_yamidD.map
+  name: d_a_npc_yamid
 
 - object: files/rel/RVL/Debug/d_a_npc_yamisD.rel
   hash: 17941b71cd0f35f40e4f1a117d15109ace965df2
   symbols: config/ShieldD/rels/d_a_npc_yamisD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_yamisD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_yamisD.map
+  name: d_a_npc_yamis
 
 - object: files/rel/RVL/Debug/d_a_npc_yamitD.rel
   hash: c7c4d591aa9bbf9f79062a69d86d41657402c7b9
   symbols: config/ShieldD/rels/d_a_npc_yamitD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_yamitD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_yamitD.map
+  name: d_a_npc_yamit
 
 - object: files/rel/RVL/Debug/d_a_npc_yeliaD.rel
   hash: cbff549102758084e802a5b1cecbc078460ff806
   symbols: config/ShieldD/rels/d_a_npc_yeliaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_yeliaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_yeliaD.map
+  name: d_a_npc_yelia
 
 - object: files/rel/RVL/Debug/d_a_npc_ykmD.rel
   hash: 1f385d1d7844a25a11f3e87d8b8a99247f000245
   symbols: config/ShieldD/rels/d_a_npc_ykmD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_ykmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_ykmD.map
+  name: d_a_npc_ykm
 
 - object: files/rel/RVL/Debug/d_a_npc_ykwD.rel
   hash: 43222570274b152dcd21b06a300ede72907500e4
   symbols: config/ShieldD/rels/d_a_npc_ykwD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_ykwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_ykwD.map
+  name: d_a_npc_ykw
 
 - object: files/rel/RVL/Debug/d_a_npc_zanbD.rel
   hash: 316a908ef02242b7e5ac945afa55b858631bb5b5
   symbols: config/ShieldD/rels/d_a_npc_zanbD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zanbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zanbD.map
+  name: d_a_npc_zanb
 
 - object: files/rel/RVL/Debug/d_a_npc_zantD.rel
   hash: d6d6150bb08bdfacb4e5028956ab3e5f9c11e923
   symbols: config/ShieldD/rels/d_a_npc_zantD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zantD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zantD.map
+  name: d_a_npc_zant
 
 - object: files/rel/RVL/Debug/d_a_npc_zeldaD.rel
   hash: f572a9a6d71c14a0141fb1a2117ab2561d515285
   symbols: config/ShieldD/rels/d_a_npc_zeldaD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zeldaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zeldaD.map
+  name: d_a_npc_zelda
 
 - object: files/rel/RVL/Debug/d_a_npc_zelRD.rel
   hash: b2e5f675f485222c6002db4cf2bf10f576a788dd
   symbols: config/ShieldD/rels/d_a_npc_zelRD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zelRD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zelRD.map
+  name: d_a_npc_zelR
 
 - object: files/rel/RVL/Debug/d_a_npc_zelRoD.rel
   hash: d5fc13d93ac77526a7b62ae87a11cac55dee0856
   symbols: config/ShieldD/rels/d_a_npc_zelRoD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zelRoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zelRoD.map
+  name: d_a_npc_zelRo
 
 - object: files/rel/RVL/Debug/d_a_npc_zraD.rel
   hash: 57f5090c30282045214f61ff5bf4cbc4b85090ed
   symbols: config/ShieldD/rels/d_a_npc_zraD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zraD.map
+  name: d_a_npc_zra
 
 - object: files/rel/RVL/Debug/d_a_npc_zrcD.rel
   hash: 53bde1271f4d25b5ca6f780c6d65055a2d4d10a3
   symbols: config/ShieldD/rels/d_a_npc_zrcD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zrcD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zrcD.map
+  name: d_a_npc_zrc
 
 - object: files/rel/RVL/Debug/d_a_npc_zrzD.rel
   hash: aec1355ad5bf0f5353c0a23a8e9d4f695614cdbe
   symbols: config/ShieldD/rels/d_a_npc_zrzD/symbols.txt
   splits: config/ShieldD/rels/d_a_npc_zrzD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_npc_zrzD.map
+  name: d_a_npc_zrz
 
 - object: files/rel/RVL/Debug/d_a_obj_amiShutterD.rel
   hash: 56645f598d92f3d1653bfd0b73f60cf4731267f6
   symbols: config/ShieldD/rels/d_a_obj_amiShutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_amiShutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_amiShutterD.map
+  name: d_a_obj_amiShutter
 
 - object: files/rel/RVL/Debug/d_a_obj_ariD.rel
   hash: de46cce82f0283c3b89d037f4b3da4429b044a52
   symbols: config/ShieldD/rels/d_a_obj_ariD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ariD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ariD.map
+  name: d_a_obj_ari
 
 - object: files/rel/RVL/Debug/d_a_obj_automataD.rel
   hash: b084babada2a35bf99b15c229350750ab6bcfb7b
   symbols: config/ShieldD/rels/d_a_obj_automataD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_automataD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_automataD.map
+  name: d_a_obj_automata
 
 - object: files/rel/RVL/Debug/d_a_obj_avalancheD.rel
   hash: 6efccf216b87a5cd61f50f2f25d55c7d828136cc
   symbols: config/ShieldD/rels/d_a_obj_avalancheD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_avalancheD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_avalancheD.map
+  name: d_a_obj_avalanche
 
 - object: files/rel/RVL/Debug/d_a_obj_balloonD.rel
   hash: 0436fba3ffaa242b42908b45824f2b79b541426a
   symbols: config/ShieldD/rels/d_a_obj_balloonD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_balloonD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_balloonD.map
+  name: d_a_obj_balloon
 
 - object: files/rel/RVL/Debug/d_a_obj_barDeskD.rel
   hash: 92026877111679cfab115c891e0b8e85e0c243ac
   symbols: config/ShieldD/rels/d_a_obj_barDeskD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_barDeskD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_barDeskD.map
+  name: d_a_obj_barDesk
 
 - object: files/rel/RVL/Debug/d_a_obj_battaD.rel
   hash: d5a9a683f199a89d863c202d9d636579832976dc
   symbols: config/ShieldD/rels/d_a_obj_battaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_battaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_battaD.map
+  name: d_a_obj_batta
 
 - object: files/rel/RVL/Debug/d_a_obj_bboxD.rel
   hash: a1e3da354c3394c3f99d12db37113bfa09ad59e3
   symbols: config/ShieldD/rels/d_a_obj_bboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bboxD.map
+  name: d_a_obj_bbox
 
 - object: files/rel/RVL/Debug/d_a_obj_bedD.rel
   hash: 464e4a676718351172fd924c21c2adf1d8d9c047
   symbols: config/ShieldD/rels/d_a_obj_bedD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bedD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bedD.map
+  name: d_a_obj_bed
 
 - object: files/rel/RVL/Debug/d_a_obj_bemosD.rel
   hash: 0b53fc30e56bd80f4527b4deb9f5a5bcf65a59b0
   symbols: config/ShieldD/rels/d_a_obj_bemosD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bemosD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bemosD.map
+  name: d_a_obj_bemos
 
 - object: files/rel/RVL/Debug/d_a_obj_bhashiD.rel
   hash: 9e8effd0230ce3a2a266fcea2e5e4382a945a231
   symbols: config/ShieldD/rels/d_a_obj_bhashiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bhashiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bhashiD.map
+  name: d_a_obj_bhashi
 
 - object: files/rel/RVL/Debug/d_a_obj_bhbridgeD.rel
   hash: 7850d6ab01c0e3d3e0288fdc77264afa4c1ff333
   symbols: config/ShieldD/rels/d_a_obj_bhbridgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bhbridgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bhbridgeD.map
+  name: d_a_obj_bhbridge
 
 - object: files/rel/RVL/Debug/d_a_obj_bkdoorD.rel
   hash: 59690d6e98ba66273a1137727df0bf811279e13c
   symbols: config/ShieldD/rels/d_a_obj_bkdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bkdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bkdoorD.map
+  name: d_a_obj_bkdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_bky_rockD.rel
   hash: 91459c859dd2b6640efd69fe87806c024f1966c6
   symbols: config/ShieldD/rels/d_a_obj_bky_rockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bky_rockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bky_rockD.map
+  name: d_a_obj_bky_rock
 
 - object: files/rel/RVL/Debug/d_a_obj_bk_leafD.rel
   hash: 0d3424af27a228374e4406401560bdea28afd8e3
   symbols: config/ShieldD/rels/d_a_obj_bk_leafD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bk_leafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bk_leafD.map
+  name: d_a_obj_bk_leaf
 
 - object: files/rel/RVL/Debug/d_a_obj_bmshutterD.rel
   hash: cf7dd12c203cde5999ffb1653708df51be101d08
   symbols: config/ShieldD/rels/d_a_obj_bmshutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bmshutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bmshutterD.map
+  name: d_a_obj_bmshutter
 
 - object: files/rel/RVL/Debug/d_a_obj_bmWindowD.rel
   hash: 4c6955e1b836b7e14308986792de8084f06144fc
   symbols: config/ShieldD/rels/d_a_obj_bmWindowD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bmWindowD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bmWindowD.map
+  name: d_a_obj_bmWindow
 
 - object: files/rel/RVL/Debug/d_a_obj_bombfD.rel
   hash: bb2c83ddee7831d6f98b63558ecb1310def9e0a7
   symbols: config/ShieldD/rels/d_a_obj_bombfD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bombfD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bombfD.map
+  name: d_a_obj_bombf
 
 - object: files/rel/RVL/Debug/d_a_obj_bosswarpD.rel
   hash: 6c49d92ffc3b507eb9227c6fdf67ce42d2a36a80
   symbols: config/ShieldD/rels/d_a_obj_bosswarpD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bosswarpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bosswarpD.map
+  name: d_a_obj_bosswarp
 
 - object: files/rel/RVL/Debug/d_a_obj_boumatoD.rel
   hash: eacb9e2e8546a6d0fa630373d47008cbd6e26cf4
   symbols: config/ShieldD/rels/d_a_obj_boumatoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_boumatoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_boumatoD.map
+  name: d_a_obj_boumato
 
 - object: files/rel/RVL/Debug/d_a_obj_brakeeffD.rel
   hash: 9bc9bfd217465c54d9fc00d477110e49dd187185
   symbols: config/ShieldD/rels/d_a_obj_brakeeffD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_brakeeffD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_brakeeffD.map
+  name: d_a_obj_brakeeff
 
 - object: files/rel/RVL/Debug/d_a_obj_brgD.rel
   hash: f134f4ce175f242f853bbacffffaa69d2bb944fc
   symbols: config/ShieldD/rels/d_a_obj_brgD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_brgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_brgD.map
+  name: d_a_obj_brg
 
 - object: files/rel/RVL/Debug/d_a_obj_bsGateD.rel
   hash: d5d3644fb26b5d6826ede7326054bfe36c06db99
   symbols: config/ShieldD/rels/d_a_obj_bsGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bsGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bsGateD.map
+  name: d_a_obj_bsGate
 
 - object: files/rel/RVL/Debug/d_a_obj_bubblePilarD.rel
   hash: 5b6aaf23677247e345f6864fb2a4384dbd0c6a72
   symbols: config/ShieldD/rels/d_a_obj_bubblePilarD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_bubblePilarD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_bubblePilarD.map
+  name: d_a_obj_bubblePilar
 
 - object: files/rel/RVL/Debug/d_a_obj_burnboxD.rel
   hash: a2bd56ff6deb8527a3251b577c158e715d3ead30
   symbols: config/ShieldD/rels/d_a_obj_burnboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_burnboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_burnboxD.map
+  name: d_a_obj_burnbox
 
 - object: files/rel/RVL/Debug/d_a_obj_carryD.rel
   hash: e23b9b0e43b0737e4c85ba8984d9e0690d899f65
   symbols: config/ShieldD/rels/d_a_obj_carryD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_carryD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_carryD.map
+  name: d_a_obj_carry
 
 - object: files/rel/RVL/Debug/d_a_obj_catdoorD.rel
   hash: 1f9682c5b7494546d4065a54b7e472355d827326
   symbols: config/ShieldD/rels/d_a_obj_catdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_catdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_catdoorD.map
+  name: d_a_obj_catdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_cbD.rel
   hash: 9e620e1b2590e785b6f8f05dac36a72a4c699412
   symbols: config/ShieldD/rels/d_a_obj_cbD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cbD.map
+  name: d_a_obj_cb
 
 - object: files/rel/RVL/Debug/d_a_obj_cblockD.rel
   hash: 0d53d5df55a29958fa9bbdd7c6138e886cc418fa
   symbols: config/ShieldD/rels/d_a_obj_cblockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cblockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cblockD.map
+  name: d_a_obj_cblock
 
 - object: files/rel/RVL/Debug/d_a_obj_cboardD.rel
   hash: 1042b883874d8091faede02c9ceaf94a01182e74
   symbols: config/ShieldD/rels/d_a_obj_cboardD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cboardD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cboardD.map
+  name: d_a_obj_cboard
 
 - object: files/rel/RVL/Debug/d_a_obj_cdoorD.rel
   hash: 1354746be70555e1eda0b0a610c71494535d4a69
   symbols: config/ShieldD/rels/d_a_obj_cdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cdoorD.map
+  name: d_a_obj_cdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_chandelierD.rel
   hash: 5104d7cea48fe20cb05ed08029ac5517b54d6822
   symbols: config/ShieldD/rels/d_a_obj_chandelierD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_chandelierD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_chandelierD.map
+  name: d_a_obj_chandelier
 
 - object: files/rel/RVL/Debug/d_a_obj_chestD.rel
   hash: 45c3f1e5e06576d576a47c496e37316f269927f0
   symbols: config/ShieldD/rels/d_a_obj_chestD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_chestD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_chestD.map
+  name: d_a_obj_chest
 
 - object: files/rel/RVL/Debug/d_a_obj_choD.rel
   hash: 0a8233edde0f4d67754c893a9010a53baba103ba
   symbols: config/ShieldD/rels/d_a_obj_choD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_choD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_choD.map
+  name: d_a_obj_cho
 
 - object: files/rel/RVL/Debug/d_a_obj_cowdoorD.rel
   hash: 46e201237cec32a74ce87b9c4eb7bc11a2590f48
   symbols: config/ShieldD/rels/d_a_obj_cowdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cowdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cowdoorD.map
+  name: d_a_obj_cowdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_cropeD.rel
   hash: 0c197f3838e97aeebe0615872c4833fbf29c3d60
   symbols: config/ShieldD/rels/d_a_obj_cropeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cropeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cropeD.map
+  name: d_a_obj_crope
 
 - object: files/rel/RVL/Debug/d_a_obj_crvfenceD.rel
   hash: 8f6352eff45900ead1ab6f0380c2524b96a5fa3f
   symbols: config/ShieldD/rels/d_a_obj_crvfenceD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crvfenceD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crvfenceD.map
+  name: d_a_obj_crvfence
 
 - object: files/rel/RVL/Debug/d_a_obj_crvgateD.rel
   hash: 22de01a9c423a17fd84c96c4e61e87ee559d619d
   symbols: config/ShieldD/rels/d_a_obj_crvgateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crvgateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crvgateD.map
+  name: d_a_obj_crvgate
 
 - object: files/rel/RVL/Debug/d_a_obj_crvhahenD.rel
   hash: 8cf8c9bb1572fd6bd9bde13ce842f596e5fbfe02
   symbols: config/ShieldD/rels/d_a_obj_crvhahenD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crvhahenD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crvhahenD.map
+  name: d_a_obj_crvhahen
 
 - object: files/rel/RVL/Debug/d_a_obj_crvlh_downD.rel
   hash: 36fe640595fa9beb0fd9c6859557d959996615f5
   symbols: config/ShieldD/rels/d_a_obj_crvlh_downD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crvlh_downD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crvlh_downD.map
+  name: d_a_obj_crvlh_down
 
 - object: files/rel/RVL/Debug/d_a_obj_crvlh_upD.rel
   hash: 2ac08e10c3bbd84d5777678746fecae9e854cb35
   symbols: config/ShieldD/rels/d_a_obj_crvlh_upD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crvlh_upD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crvlh_upD.map
+  name: d_a_obj_crvlh_up
 
 - object: files/rel/RVL/Debug/d_a_obj_crvsteelD.rel
   hash: f406bd45af9a0cd6b50b00a8d620a0a42ffc152b
   symbols: config/ShieldD/rels/d_a_obj_crvsteelD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crvsteelD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crvsteelD.map
+  name: d_a_obj_crvsteel
 
 - object: files/rel/RVL/Debug/d_a_obj_crystalD.rel
   hash: 96131842d6a42d525e02e03d5c96b4623c95ae6c
   symbols: config/ShieldD/rels/d_a_obj_crystalD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_crystalD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_crystalD.map
+  name: d_a_obj_crystal
 
 - object: files/rel/RVL/Debug/d_a_obj_cwallD.rel
   hash: a216a6f4592453c67cb6806217af0ce5363d85f9
   symbols: config/ShieldD/rels/d_a_obj_cwallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_cwallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_cwallD.map
+  name: d_a_obj_cwall
 
 - object: files/rel/RVL/Debug/d_a_obj_damCpsD.rel
   hash: 830e90185fe6f99efbfb886d93246f416af3e643
   symbols: config/ShieldD/rels/d_a_obj_damCpsD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_damCpsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_damCpsD.map
+  name: d_a_obj_damCps
 
 - object: files/rel/RVL/Debug/d_a_obj_danD.rel
   hash: 6dcd2690269c114e412b4b788a4fcc643f0422c5
   symbols: config/ShieldD/rels/d_a_obj_danD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_danD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_danD.map
+  name: d_a_obj_dan
 
 - object: files/rel/RVL/Debug/d_a_obj_dighollD.rel
   hash: 83f0c8f91a1e757acd604768c6cccd82beefcefc
   symbols: config/ShieldD/rels/d_a_obj_dighollD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_dighollD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_dighollD.map
+  name: d_a_obj_digholl
 
 - object: files/rel/RVL/Debug/d_a_obj_digplaceD.rel
   hash: 4dcf414f0da4d442b136a17933acc98043ba6c27
   symbols: config/ShieldD/rels/d_a_obj_digplaceD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_digplaceD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_digplaceD.map
+  name: d_a_obj_digplace
 
 - object: files/rel/RVL/Debug/d_a_obj_digsnowD.rel
   hash: a742161ff292884b696af916e9c44c45d698d7f2
   symbols: config/ShieldD/rels/d_a_obj_digsnowD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_digsnowD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_digsnowD.map
+  name: d_a_obj_digsnow
 
 - object: files/rel/RVL/Debug/d_a_obj_dmelevatorD.rel
   hash: 43a8bc6241e2975be741f5d46523c69715965b0a
   symbols: config/ShieldD/rels/d_a_obj_dmelevatorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_dmelevatorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_dmelevatorD.map
+  name: d_a_obj_dmelevator
 
 - object: files/rel/RVL/Debug/d_a_obj_dropD.rel
   hash: bb95e94ea14a5092f936f964b10f5fbd9042a057
   symbols: config/ShieldD/rels/d_a_obj_dropD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_dropD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_dropD.map
+  name: d_a_obj_drop
 
 - object: files/rel/RVL/Debug/d_a_obj_dustD.rel
   hash: 52cdf57e9a6b409e88d79f2bb4296c498b4f45dc
   symbols: config/ShieldD/rels/d_a_obj_dustD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_dustD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_dustD.map
+  name: d_a_obj_dust
 
 - object: files/rel/RVL/Debug/d_a_obj_effD.rel
   hash: 82ac1ea6100a00bae1dafe589c7ba2ddc5ba1fe6
   symbols: config/ShieldD/rels/d_a_obj_effD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_effD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_effD.map
+  name: d_a_obj_eff
 
 - object: files/rel/RVL/Debug/d_a_obj_enemy_createD.rel
   hash: 274944481a29122a8edf582a746612efa80f3cce
   symbols: config/ShieldD/rels/d_a_obj_enemy_createD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_enemy_createD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_enemy_createD.map
+  name: d_a_obj_enemy_create
 
 - object: files/rel/RVL/Debug/d_a_obj_fallobjD.rel
   hash: ca4389d9b511351974a1696e75f47cb6975d8dc1
   symbols: config/ShieldD/rels/d_a_obj_fallobjD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fallobjD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fallobjD.map
+  name: d_a_obj_fallobj
 
 - object: files/rel/RVL/Debug/d_a_obj_fanD.rel
   hash: 0011e3d98e42170bafe07a3454ea5ad2b5612df0
   symbols: config/ShieldD/rels/d_a_obj_fanD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fanD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fanD.map
+  name: d_a_obj_fan
 
 - object: files/rel/RVL/Debug/d_a_obj_fchainD.rel
   hash: fd936db66c02752f4b5f0e6ef1ed77760cef334e
   symbols: config/ShieldD/rels/d_a_obj_fchainD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fchainD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fchainD.map
+  name: d_a_obj_fchain
 
 - object: files/rel/RVL/Debug/d_a_obj_firepillar2D.rel
   hash: fb277de367f140f0376c08e4b29db854393f49a3
   symbols: config/ShieldD/rels/d_a_obj_firepillar2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_firepillar2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_firepillar2D.map
+  name: d_a_obj_firepillar2
 
 - object: files/rel/RVL/Debug/d_a_obj_firepillarD.rel
   hash: 6a3f3242913f4de56786edbedecb08e642219df9
   symbols: config/ShieldD/rels/d_a_obj_firepillarD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_firepillarD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_firepillarD.map
+  name: d_a_obj_firepillar
 
 - object: files/rel/RVL/Debug/d_a_obj_fireWood2D.rel
   hash: d6ce941f5e918f16468fe40a27994d01f7273b86
   symbols: config/ShieldD/rels/d_a_obj_fireWood2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fireWood2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fireWood2D.map
+  name: d_a_obj_fireWood2
 
 - object: files/rel/RVL/Debug/d_a_obj_fireWoodD.rel
   hash: 7f00925401928a2805f1e28487a0c8d69c22260e
   symbols: config/ShieldD/rels/d_a_obj_fireWoodD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fireWoodD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fireWoodD.map
+  name: d_a_obj_fireWood
 
 - object: files/rel/RVL/Debug/d_a_obj_flag2D.rel
   hash: 5bb421ee7bd03e1e29981f223abf9194ab07ed85
   symbols: config/ShieldD/rels/d_a_obj_flag2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_flag2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_flag2D.map
+  name: d_a_obj_flag2
 
 - object: files/rel/RVL/Debug/d_a_obj_flag3D.rel
   hash: 71320986396e415f8591da0403d620587f2555ed
   symbols: config/ShieldD/rels/d_a_obj_flag3D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_flag3D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_flag3D.map
+  name: d_a_obj_flag3
 
 - object: files/rel/RVL/Debug/d_a_obj_flagD.rel
   hash: 6961c9b147b686d4858417be648ada6afa6b9fac
   symbols: config/ShieldD/rels/d_a_obj_flagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_flagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_flagD.map
+  name: d_a_obj_flag
 
 - object: files/rel/RVL/Debug/d_a_obj_fmobjD.rel
   hash: a007c32bc1aacd6b4a3902f8e55075c45aa8dfdd
   symbols: config/ShieldD/rels/d_a_obj_fmobjD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fmobjD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fmobjD.map
+  name: d_a_obj_fmobj
 
 - object: files/rel/RVL/Debug/d_a_obj_foodD.rel
   hash: 7d2211705cb50eaf6ac8be1f39d85b286bff2498
   symbols: config/ShieldD/rels/d_a_obj_foodD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_foodD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_foodD.map
+  name: d_a_obj_food
 
 - object: files/rel/RVL/Debug/d_a_obj_fwD.rel
   hash: 64dd4144eb26c7ccd3d517214d93917d477ebbd9
   symbols: config/ShieldD/rels/d_a_obj_fwD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_fwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_fwD.map
+  name: d_a_obj_fw
 
 - object: files/rel/RVL/Debug/d_a_obj_gadgetD.rel
   hash: c2a61afd5a9ea6d95372726d0aa15ea0e3b8d4a5
   symbols: config/ShieldD/rels/d_a_obj_gadgetD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gadgetD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gadgetD.map
+  name: d_a_obj_gadget
 
 - object: files/rel/RVL/Debug/d_a_obj_ganonwall2D.rel
   hash: 367ff89a0b05f60f689018780922c24b8174efb6
   symbols: config/ShieldD/rels/d_a_obj_ganonwall2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ganonwall2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ganonwall2D.map
+  name: d_a_obj_ganonwall2
 
 - object: files/rel/RVL/Debug/d_a_obj_ganonwallD.rel
   hash: 9286a23ae1485518928c1b3193f9d30e38a1426b
   symbols: config/ShieldD/rels/d_a_obj_ganonwallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ganonwallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ganonwallD.map
+  name: d_a_obj_ganonwall
 
 - object: files/rel/RVL/Debug/d_a_obj_gbD.rel
   hash: 452d1cd83ca2be2a397b3d0bd401beae416c4bf6
   symbols: config/ShieldD/rels/d_a_obj_gbD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gbD.map
+  name: d_a_obj_gb
 
 - object: files/rel/RVL/Debug/d_a_obj_geyserD.rel
   hash: 33164a3c2509f6f82a2a6074e09fc2b945d6a8a9
   symbols: config/ShieldD/rels/d_a_obj_geyserD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_geyserD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_geyserD.map
+  name: d_a_obj_geyser
 
 - object: files/rel/RVL/Debug/d_a_obj_glowSphereD.rel
   hash: 0c532f306765863bda17772435ab91498f427f83
   symbols: config/ShieldD/rels/d_a_obj_glowSphereD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_glowSphereD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_glowSphereD.map
+  name: d_a_obj_glowSphere
 
 - object: files/rel/RVL/Debug/d_a_obj_gmD.rel
   hash: e00550ccaf4a8aff3e73eebd8cfa0934a577ba4c
   symbols: config/ShieldD/rels/d_a_obj_gmD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gmD.map
+  name: d_a_obj_gm
 
 - object: files/rel/RVL/Debug/d_a_obj_goGateD.rel
   hash: c4d6a3ce5b4c7f00a93ff856009fe42ba5dead6d
   symbols: config/ShieldD/rels/d_a_obj_goGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_goGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_goGateD.map
+  name: d_a_obj_goGate
 
 - object: files/rel/RVL/Debug/d_a_obj_gomikabeD.rel
   hash: 63753b302993bbf5ab6302a6d697510d3e369ad1
   symbols: config/ShieldD/rels/d_a_obj_gomikabeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gomikabeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gomikabeD.map
+  name: d_a_obj_gomikabe
 
 - object: files/rel/RVL/Debug/d_a_obj_gpTaruD.rel
   hash: 82d77fc21577105da11dec1f51deb9a92c71ce69
   symbols: config/ShieldD/rels/d_a_obj_gpTaruD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gpTaruD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gpTaruD.map
+  name: d_a_obj_gpTaru
 
 - object: files/rel/RVL/Debug/d_a_obj_gra2D.rel
   hash: 8b4de37763abb2a5ef9f67985d2371cd98a509bd
   symbols: config/ShieldD/rels/d_a_obj_gra2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gra2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gra2D.map
+  name: d_a_obj_gra2
 
 - object: files/rel/RVL/Debug/d_a_obj_grave_stoneD.rel
   hash: bb9b607cc9f9b077dc91b5b46d275f8825c89785
   symbols: config/ShieldD/rels/d_a_obj_grave_stoneD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_grave_stoneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_grave_stoneD.map
+  name: d_a_obj_grave_stone
 
 - object: files/rel/RVL/Debug/d_a_obj_graWallD.rel
   hash: 3ede3ed233f6080b3532d832fcae0844a575baf6
   symbols: config/ShieldD/rels/d_a_obj_graWallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_graWallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_graWallD.map
+  name: d_a_obj_graWall
 
 - object: files/rel/RVL/Debug/d_a_obj_gra_rockD.rel
   hash: 9a4de713d03bb13a976472a8dd3aa78f73082df3
   symbols: config/ShieldD/rels/d_a_obj_gra_rockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_gra_rockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_gra_rockD.map
+  name: d_a_obj_gra_rock
 
 - object: files/rel/RVL/Debug/d_a_obj_groundwaterD.rel
   hash: 61493ee7ce3991ea1fccddd18fd48ced9ff1a069
   symbols: config/ShieldD/rels/d_a_obj_groundwaterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_groundwaterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_groundwaterD.map
+  name: d_a_obj_groundwater
 
 - object: files/rel/RVL/Debug/d_a_obj_grz_rockD.rel
   hash: 1beebc94016b2c92cbd2b6db9c7f4dab512eb59d
   symbols: config/ShieldD/rels/d_a_obj_grz_rockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_grz_rockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_grz_rockD.map
+  name: d_a_obj_grz_rock
 
 - object: files/rel/RVL/Debug/d_a_obj_hakai_brlD.rel
   hash: 021c50669ea81ba3dd4e599764078dfbaf30ac9a
   symbols: config/ShieldD/rels/d_a_obj_hakai_brlD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hakai_brlD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hakai_brlD.map
+  name: d_a_obj_hakai_brl
 
 - object: files/rel/RVL/Debug/d_a_obj_hakai_ftrD.rel
   hash: b19b1f3abffd9dcce3cbb94cdeddce3b7f14e78c
   symbols: config/ShieldD/rels/d_a_obj_hakai_ftrD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hakai_ftrD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hakai_ftrD.map
+  name: d_a_obj_hakai_ftr
 
 - object: files/rel/RVL/Debug/d_a_obj_hasu2D.rel
   hash: 4c95bf1a307e8ccf4c0160115a54914fc1a76aa4
   symbols: config/ShieldD/rels/d_a_obj_hasu2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hasu2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hasu2D.map
+  name: d_a_obj_hasu2
 
 - object: files/rel/RVL/Debug/d_a_obj_hataD.rel
   hash: 83ef2f93a8df9c551054de0730b4fa1afe2c3f48
   symbols: config/ShieldD/rels/d_a_obj_hataD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hataD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hataD.map
+  name: d_a_obj_hata
 
 - object: files/rel/RVL/Debug/d_a_obj_hbD.rel
   hash: b35cd987ca69392f5d4c913c5bb8877e5e812ebc
   symbols: config/ShieldD/rels/d_a_obj_hbD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hbD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hbD.map
+  name: d_a_obj_hb
 
 - object: files/rel/RVL/Debug/d_a_obj_hbombkoyaD.rel
   hash: 43fcb44cef064c77b489c677d23e207d1a2020e1
   symbols: config/ShieldD/rels/d_a_obj_hbombkoyaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hbombkoyaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hbombkoyaD.map
+  name: d_a_obj_hbombkoya
 
 - object: files/rel/RVL/Debug/d_a_obj_heavySwD.rel
   hash: c845eb39badf8a871508678cc518a69ea70753b2
   symbols: config/ShieldD/rels/d_a_obj_heavySwD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_heavySwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_heavySwD.map
+  name: d_a_obj_heavySw
 
 - object: files/rel/RVL/Debug/d_a_obj_hfutaD.rel
   hash: 2ab6727c360e8920ecbbd7f8744a0901e4cd7481
   symbols: config/ShieldD/rels/d_a_obj_hfutaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hfutaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hfutaD.map
+  name: d_a_obj_hfuta
 
 - object: files/rel/RVL/Debug/d_a_obj_hhashiD.rel
   hash: 1304d3a3d520898c4f6cc7a169c7be3ba5f24448
   symbols: config/ShieldD/rels/d_a_obj_hhashiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hhashiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hhashiD.map
+  name: d_a_obj_hhashi
 
 - object: files/rel/RVL/Debug/d_a_obj_hsTargetD.rel
   hash: 4e672e85bd397da74d43d2595f880137718ad69e
   symbols: config/ShieldD/rels/d_a_obj_hsTargetD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_hsTargetD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_hsTargetD.map
+  name: d_a_obj_hsTarget
 
 - object: files/rel/RVL/Debug/d_a_obj_h_sakuD.rel
   hash: b702c371cb3d5433474ca1d62dac475b8e0e94f3
   symbols: config/ShieldD/rels/d_a_obj_h_sakuD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_h_sakuD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_h_sakuD.map
+  name: d_a_obj_h_saku
 
 - object: files/rel/RVL/Debug/d_a_obj_iceblockD.rel
   hash: fb27c614f30353512b30ec146e474b59ef75347b
   symbols: config/ShieldD/rels/d_a_obj_iceblockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_iceblockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_iceblockD.map
+  name: d_a_obj_iceblock
 
 - object: files/rel/RVL/Debug/d_a_obj_iceleafD.rel
   hash: 61fd9e61c13bfb824441d337bfb2738d14932075
   symbols: config/ShieldD/rels/d_a_obj_iceleafD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_iceleafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_iceleafD.map
+  name: d_a_obj_iceleaf
 
 - object: files/rel/RVL/Debug/d_a_obj_ice_lD.rel
   hash: 606f4ce779ce149ac9c238b1f75e572c79e015f3
   symbols: config/ShieldD/rels/d_a_obj_ice_lD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ice_lD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ice_lD.map
+  name: d_a_obj_ice_l
 
 - object: files/rel/RVL/Debug/d_a_obj_ice_sD.rel
   hash: 25daa7888caf499a336022dcbbee98f6ba0a5773
   symbols: config/ShieldD/rels/d_a_obj_ice_sD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ice_sD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ice_sD.map
+  name: d_a_obj_ice_s
 
 - object: files/rel/RVL/Debug/d_a_obj_ihasiD.rel
   hash: 680ca7ab18ec983686cac7c6e66454092c8eb25a
   symbols: config/ShieldD/rels/d_a_obj_ihasiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ihasiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ihasiD.map
+  name: d_a_obj_ihasi
 
 - object: files/rel/RVL/Debug/d_a_obj_inoboneD.rel
   hash: a6ecd350b86918048f0fbbd34ae2106e622499de
   symbols: config/ShieldD/rels/d_a_obj_inoboneD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_inoboneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_inoboneD.map
+  name: d_a_obj_inobone
 
 - object: files/rel/RVL/Debug/d_a_obj_itaD.rel
   hash: 348a0d227e0bf2b7a02921a6f6672b5371c0167a
   symbols: config/ShieldD/rels/d_a_obj_itaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_itaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_itaD.map
+  name: d_a_obj_ita
 
 - object: files/rel/RVL/Debug/d_a_obj_itamatoD.rel
   hash: fea5f1f55350a3542ea2d11a91dde4524140bb26
   symbols: config/ShieldD/rels/d_a_obj_itamatoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_itamatoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_itamatoD.map
+  name: d_a_obj_itamato
 
 - object: files/rel/RVL/Debug/d_a_obj_itoD.rel
   hash: 1c7f23829f366a8aed7e562b2ab2c552c24eec2b
   symbols: config/ShieldD/rels/d_a_obj_itoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_itoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_itoD.map
+  name: d_a_obj_ito
 
 - object: files/rel/RVL/Debug/d_a_obj_kabutoD.rel
   hash: 11d9d08de124f71ee84e308e8909e0792bc60362
   symbols: config/ShieldD/rels/d_a_obj_kabutoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kabutoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kabutoD.map
+  name: d_a_obj_kabuto
 
 - object: files/rel/RVL/Debug/d_a_obj_kagD.rel
   hash: 0e5c2596db7be8f36ec9b939b7aaa300e49b761e
   symbols: config/ShieldD/rels/d_a_obj_kagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kagD.map
+  name: d_a_obj_kag
 
 - object: files/rel/RVL/Debug/d_a_obj_kageD.rel
   hash: dc3465525d31a2beb219ef16187b6c546901c55b
   symbols: config/ShieldD/rels/d_a_obj_kageD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kageD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kageD.map
+  name: d_a_obj_kage
 
 - object: files/rel/RVL/Debug/d_a_obj_kagoD.rel
   hash: 5e0bde66b655a50e4cbd0d08896528c957899db4
   symbols: config/ShieldD/rels/d_a_obj_kagoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kagoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kagoD.map
+  name: d_a_obj_kago
 
 - object: files/rel/RVL/Debug/d_a_obj_kaisouD.rel
   hash: d7c0f895297f5b346eca3f4df445affbe0a4ece8
   symbols: config/ShieldD/rels/d_a_obj_kaisouD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kaisouD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kaisouD.map
+  name: d_a_obj_kaisou
 
 - object: files/rel/RVL/Debug/d_a_obj_kamakiriD.rel
   hash: 88a8310a0b84b320c5cbe0074600fb53dc797735
   symbols: config/ShieldD/rels/d_a_obj_kamakiriD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kamakiriD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kamakiriD.map
+  name: d_a_obj_kamakiri
 
 - object: files/rel/RVL/Debug/d_a_obj_kanban2D.rel
   hash: 4fe836b6a035a97f87dc3a890916742325bcaf86
   symbols: config/ShieldD/rels/d_a_obj_kanban2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kanban2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kanban2D.map
+  name: d_a_obj_kanban2
 
 - object: files/rel/RVL/Debug/d_a_obj_kanteraD.rel
   hash: 42c9a2223881ffb042c02f2cb29888d05f828a6d
   symbols: config/ShieldD/rels/d_a_obj_kanteraD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kanteraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kanteraD.map
+  name: d_a_obj_kantera
 
 - object: files/rel/RVL/Debug/d_a_obj_katatsumuriD.rel
   hash: 9ae49ee27a4252fd10fbcc8875106df7a9043a7a
   symbols: config/ShieldD/rels/d_a_obj_katatsumuriD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_katatsumuriD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_katatsumuriD.map
+  name: d_a_obj_katatsumuri
 
 - object: files/rel/RVL/Debug/d_a_obj_kazenekoD.rel
   hash: c6814b39a1acb9d36c20e648e24829554bcd33f8
   symbols: config/ShieldD/rels/d_a_obj_kazenekoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kazenekoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kazenekoD.map
+  name: d_a_obj_kazeneko
 
 - object: files/rel/RVL/Debug/d_a_obj_kbacketD.rel
   hash: 7d657d30e858da1b879ed218a72d36f825296f69
   symbols: config/ShieldD/rels/d_a_obj_kbacketD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kbacketD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kbacketD.map
+  name: d_a_obj_kbacket
 
 - object: files/rel/RVL/Debug/d_a_obj_kboxD.rel
   hash: 026cf2b133f7d364985b767ab352b22791ffcd3d
   symbols: config/ShieldD/rels/d_a_obj_kboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kboxD.map
+  name: d_a_obj_kbox
 
 - object: files/rel/RVL/Debug/d_a_obj_keyD.rel
   hash: ffdbb2abf0062a251eb956ab62e77b7e568c9495
   symbols: config/ShieldD/rels/d_a_obj_keyD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_keyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_keyD.map
+  name: d_a_obj_key
 
 - object: files/rel/RVL/Debug/d_a_obj_keyholeD.rel
   hash: c6addc9e6459b4b0475740641cc799bb4b456768
   symbols: config/ShieldD/rels/d_a_obj_keyholeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_keyholeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_keyholeD.map
+  name: d_a_obj_keyhole
 
 - object: files/rel/RVL/Debug/d_a_obj_kgateD.rel
   hash: 4bfa3e4432bf184ecd7fd8ae615dc3449be05d6e
   symbols: config/ShieldD/rels/d_a_obj_kgateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kgateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kgateD.map
+  name: d_a_obj_kgate
 
 - object: files/rel/RVL/Debug/d_a_obj_kiD.rel
   hash: dc52f722fc50bd26bc98a23d4f9b0fa59d7ee31c
   symbols: config/ShieldD/rels/d_a_obj_kiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kiD.map
+  name: d_a_obj_ki
 
 - object: files/rel/RVL/Debug/d_a_obj_kiPotD.rel
   hash: 8135e777e1a7113a9de40e27b0388ae18c275b4b
   symbols: config/ShieldD/rels/d_a_obj_kiPotD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kiPotD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kiPotD.map
+  name: d_a_obj_kiPot
 
 - object: files/rel/RVL/Debug/d_a_obj_kitaD.rel
   hash: c468e95c2b85e9e661e167aa695075bb04bf2ac2
   symbols: config/ShieldD/rels/d_a_obj_kitaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kitaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kitaD.map
+  name: d_a_obj_kita
 
 - object: files/rel/RVL/Debug/d_a_obj_kjgjsD.rel
   hash: f583db8b926a2ee7451bf7eedc082b707e91b450
   symbols: config/ShieldD/rels/d_a_obj_kjgjsD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kjgjsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kjgjsD.map
+  name: d_a_obj_kjgjs
 
 - object: files/rel/RVL/Debug/d_a_obj_kkanbanD.rel
   hash: df8cab7a8a4120fed8a9ad1dc1db4ccd91b43c3e
   symbols: config/ShieldD/rels/d_a_obj_kkanbanD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kkanbanD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kkanbanD.map
+  name: d_a_obj_kkanban
 
 - object: files/rel/RVL/Debug/d_a_obj_klift00D.rel
   hash: a36c053f2150cedd935e64375c2e9b6f4ae81469
   symbols: config/ShieldD/rels/d_a_obj_klift00D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_klift00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_klift00D.map
+  name: d_a_obj_klift00
 
 - object: files/rel/RVL/Debug/d_a_obj_knBulletD.rel
   hash: b6952b5c955903cbf560e511c2f9dec913d62d06
   symbols: config/ShieldD/rels/d_a_obj_knBulletD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_knBulletD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_knBulletD.map
+  name: d_a_obj_knBullet
 
 - object: files/rel/RVL/Debug/d_a_obj_kshutterD.rel
   hash: 38a3a30bbeeaec8b45b66461c3b777149efb52f9
   symbols: config/ShieldD/rels/d_a_obj_kshutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kshutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kshutterD.map
+  name: d_a_obj_kshutter
 
 - object: files/rel/RVL/Debug/d_a_obj_ktOnFireD.rel
   hash: cf753a6bf7dfe84903b842bbfb5910342da9c68a
   symbols: config/ShieldD/rels/d_a_obj_ktOnFireD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ktOnFireD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ktOnFireD.map
+  name: d_a_obj_ktOnFire
 
 - object: files/rel/RVL/Debug/d_a_obj_kuwagataD.rel
   hash: 0bf8f9d656c491e340066721658d176da0d0afef
   symbols: config/ShieldD/rels/d_a_obj_kuwagataD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kuwagataD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kuwagataD.map
+  name: d_a_obj_kuwagata
 
 - object: files/rel/RVL/Debug/d_a_obj_kwheel00D.rel
   hash: f56b6b58351c9e3ceb8649b00c9adf8305fa71c5
   symbols: config/ShieldD/rels/d_a_obj_kwheel00D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kwheel00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kwheel00D.map
+  name: d_a_obj_kwheel00
 
 - object: files/rel/RVL/Debug/d_a_obj_kwheel01D.rel
   hash: 3616dca8ff1490d9503c795fae3056cef156ac02
   symbols: config/ShieldD/rels/d_a_obj_kwheel01D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kwheel01D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kwheel01D.map
+  name: d_a_obj_kwheel01
 
 - object: files/rel/RVL/Debug/d_a_obj_kznkarmD.rel
   hash: 6c3a51b2216c20b14eedacbe35419dd9cc3cf127
   symbols: config/ShieldD/rels/d_a_obj_kznkarmD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_kznkarmD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_kznkarmD.map
+  name: d_a_obj_kznkarm
 
 - object: files/rel/RVL/Debug/d_a_obj_ladderD.rel
   hash: 300e1c46235aa00075d42826d66956cc1ced265f
   symbols: config/ShieldD/rels/d_a_obj_ladderD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ladderD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ladderD.map
+  name: d_a_obj_ladder
 
 - object: files/rel/RVL/Debug/d_a_obj_laundryD.rel
   hash: 18c0c25fc272843059b4c77c148308627d632ff3
   symbols: config/ShieldD/rels/d_a_obj_laundryD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_laundryD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_laundryD.map
+  name: d_a_obj_laundry
 
 - object: files/rel/RVL/Debug/d_a_obj_laundry_ropeD.rel
   hash: 124773cedc646f7eeb1193f4c5a043fd3b1cd078
   symbols: config/ShieldD/rels/d_a_obj_laundry_ropeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_laundry_ropeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_laundry_ropeD.map
+  name: d_a_obj_laundry_rope
 
 - object: files/rel/RVL/Debug/d_a_obj_lboxD.rel
   hash: bbf513fc9cd818427447637775e9b6130a62b20b
   symbols: config/ShieldD/rels/d_a_obj_lboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lboxD.map
+  name: d_a_obj_lbox
 
 - object: files/rel/RVL/Debug/d_a_obj_life_containerD.rel
   hash: f892ddac4d2a8841f039f40205a55e50f5147b14
   symbols: config/ShieldD/rels/d_a_obj_life_containerD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_life_containerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_life_containerD.map
+  name: d_a_obj_life_container
 
 - object: files/rel/RVL/Debug/d_a_obj_lpD.rel
   hash: e86070775fe227ed6fbf50150bc529dc805d9f61
   symbols: config/ShieldD/rels/d_a_obj_lpD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lpD.map
+  name: d_a_obj_lp
 
 - object: files/rel/RVL/Debug/d_a_obj_lv1Candle00D.rel
   hash: 5c1eaadfaffde0c3f84ae1e7a880afe385efc433
   symbols: config/ShieldD/rels/d_a_obj_lv1Candle00D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv1Candle00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv1Candle00D.map
+  name: d_a_obj_lv1Candle00
 
 - object: files/rel/RVL/Debug/d_a_obj_lv1Candle01D.rel
   hash: c05c6e6feb555826c902aca996e697c46a5ef371
   symbols: config/ShieldD/rels/d_a_obj_lv1Candle01D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv1Candle01D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv1Candle01D.map
+  name: d_a_obj_lv1Candle01
 
 - object: files/rel/RVL/Debug/d_a_obj_lv2CandleD.rel
   hash: 62ceb50a96608fc62a2640889c8e2002f6822d4c
   symbols: config/ShieldD/rels/d_a_obj_lv2CandleD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv2CandleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv2CandleD.map
+  name: d_a_obj_lv2Candle
 
 - object: files/rel/RVL/Debug/d_a_obj_lv3CandleD.rel
   hash: 807207c57058f40ec8f77f767ba15ed25d12f28d
   symbols: config/ShieldD/rels/d_a_obj_lv3CandleD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv3CandleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv3CandleD.map
+  name: d_a_obj_lv3Candle
 
 - object: files/rel/RVL/Debug/d_a_obj_lv3saka00D.rel
   hash: d6a607ec1a8bca71f2cd0c3a7d5c214f155defd3
   symbols: config/ShieldD/rels/d_a_obj_lv3saka00D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv3saka00D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv3saka00D.map
+  name: d_a_obj_lv3saka00
 
 - object: files/rel/RVL/Debug/d_a_obj_lv3Water2D.rel
   hash: cffce42633ccb4ec5880afa8713e5c6015c84fec
   symbols: config/ShieldD/rels/d_a_obj_lv3Water2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv3Water2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv3Water2D.map
+  name: d_a_obj_lv3Water2
 
 - object: files/rel/RVL/Debug/d_a_obj_lv3WaterBD.rel
   hash: 7c6938cc4fb449588cb434b7e8be5715d632ce7f
   symbols: config/ShieldD/rels/d_a_obj_lv3WaterBD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv3WaterBD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv3WaterBD.map
+  name: d_a_obj_lv3WaterB
 
 - object: files/rel/RVL/Debug/d_a_obj_lv3WaterD.rel
   hash: a86833d8f0ed785ab349a01115780108e053b831
   symbols: config/ShieldD/rels/d_a_obj_lv3WaterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv3WaterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv3WaterD.map
+  name: d_a_obj_lv3Water
 
 - object: files/rel/RVL/Debug/d_a_obj_lv3waterEffD.rel
   hash: 411dd19b5c6ba1f6d277522c2738d5b3682144bc
   symbols: config/ShieldD/rels/d_a_obj_lv3waterEffD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv3waterEffD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv3waterEffD.map
+  name: d_a_obj_lv3waterEff
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4bridgeD.rel
   hash: e596b286cceb411d7f8ee496350cbf0ba83df412
   symbols: config/ShieldD/rels/d_a_obj_lv4bridgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4bridgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4bridgeD.map
+  name: d_a_obj_lv4bridge
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4CandleDemoTagD.rel
   hash: 80bc13f616c2b362c260d65a643b4711d7197b38
   symbols: config/ShieldD/rels/d_a_obj_lv4CandleDemoTagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4CandleDemoTagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4CandleDemoTagD.map
+  name: d_a_obj_lv4CandleDemoTag
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4CandleTagD.rel
   hash: 7fb2c86bdc500de7859d4cfddeac7fea0e711412
   symbols: config/ShieldD/rels/d_a_obj_lv4CandleTagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4CandleTagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4CandleTagD.map
+  name: d_a_obj_lv4CandleTag
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4chandelierD.rel
   hash: 75c1470bb1682e55d634e210b558a7aeeaee79d8
   symbols: config/ShieldD/rels/d_a_obj_lv4chandelierD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4chandelierD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4chandelierD.map
+  name: d_a_obj_lv4chandelier
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4digsandD.rel
   hash: d4571f5ad34230756b9e54fc45b9257331bee06b
   symbols: config/ShieldD/rels/d_a_obj_lv4digsandD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4digsandD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4digsandD.map
+  name: d_a_obj_lv4digsand
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4EdShutterD.rel
   hash: bba8d5674f6dd146482a08086aa1104bff247a4a
   symbols: config/ShieldD/rels/d_a_obj_lv4EdShutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4EdShutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4EdShutterD.map
+  name: d_a_obj_lv4EdShutter
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4floorD.rel
   hash: c0d48f2e1e85d6b19ad011b4a2caaa76bce4cffe
   symbols: config/ShieldD/rels/d_a_obj_lv4floorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4floorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4floorD.map
+  name: d_a_obj_lv4floor
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4GateD.rel
   hash: 9b41f65ca51b15c93f1037b98a839cb1f4a8ba61
   symbols: config/ShieldD/rels/d_a_obj_lv4GateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4GateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4GateD.map
+  name: d_a_obj_lv4Gate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4gearD.rel
   hash: 3f04943b6f406b3de1e3f3f966600f810a311eb5
   symbols: config/ShieldD/rels/d_a_obj_lv4gearD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4gearD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4gearD.map
+  name: d_a_obj_lv4gear
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4HsTargetD.rel
   hash: cc313b50392938cc215975849d02979f6a3a965e
   symbols: config/ShieldD/rels/d_a_obj_lv4HsTargetD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4HsTargetD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4HsTargetD.map
+  name: d_a_obj_lv4HsTarget
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4PoGateD.rel
   hash: 27ea67ca5cd46102c65f908f44fd908932da742e
   symbols: config/ShieldD/rels/d_a_obj_lv4PoGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4PoGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4PoGateD.map
+  name: d_a_obj_lv4PoGate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4prelvtrD.rel
   hash: dcd6ead97ca46bedede46e78675d0493908fbfe4
   symbols: config/ShieldD/rels/d_a_obj_lv4prelvtrD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4prelvtrD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4prelvtrD.map
+  name: d_a_obj_lv4prelvtr
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4prwallD.rel
   hash: fee7cbd24dbe56b5941dc353219afef0a091901a
   symbols: config/ShieldD/rels/d_a_obj_lv4prwallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4prwallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4prwallD.map
+  name: d_a_obj_lv4prwall
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4RailWallD.rel
   hash: 4233a69076475689d45cfc8020003a17e94f32ec
   symbols: config/ShieldD/rels/d_a_obj_lv4RailWallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4RailWallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4RailWallD.map
+  name: d_a_obj_lv4RailWall
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4sandD.rel
   hash: 251e3ce34117da81b1c25cdb065657513119ca17
   symbols: config/ShieldD/rels/d_a_obj_lv4sandD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4sandD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4sandD.map
+  name: d_a_obj_lv4sand
 
 - object: files/rel/RVL/Debug/d_a_obj_lv4SlideWallD.rel
   hash: c9c9776a62ec20ee5460775d5de35d121839e965
   symbols: config/ShieldD/rels/d_a_obj_lv4SlideWallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv4SlideWallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv4SlideWallD.map
+  name: d_a_obj_lv4SlideWall
 
 - object: files/rel/RVL/Debug/d_a_obj_lv5FloorBoardD.rel
   hash: 251d918ee6fb21406f2774df1efdc224363e5cd3
   symbols: config/ShieldD/rels/d_a_obj_lv5FloorBoardD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv5FloorBoardD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv5FloorBoardD.map
+  name: d_a_obj_lv5FloorBoard
 
 - object: files/rel/RVL/Debug/d_a_obj_lv5IceWallD.rel
   hash: 22002d729dff7a72b5d817132b503ef09ed473c8
   symbols: config/ShieldD/rels/d_a_obj_lv5IceWallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv5IceWallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv5IceWallD.map
+  name: d_a_obj_lv5IceWall
 
 - object: files/rel/RVL/Debug/d_a_obj_Lv5KeyD.rel
   hash: d3b19ab337a51573be4d65d2f252f9972265c301
   symbols: config/ShieldD/rels/d_a_obj_Lv5KeyD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_Lv5KeyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_Lv5KeyD.map
+  name: d_a_obj_Lv5Key
 
 - object: files/rel/RVL/Debug/d_a_obj_lv5SwIceD.rel
   hash: d5cebb34e40717ff601f7b0b06ca75135d82ea0b
   symbols: config/ShieldD/rels/d_a_obj_lv5SwIceD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv5SwIceD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv5SwIceD.map
+  name: d_a_obj_lv5SwIce
 
 - object: files/rel/RVL/Debug/d_a_obj_lv5ychndlrD.rel
   hash: cf25b45777574fd4c1c0202755e3a52e4498681c
   symbols: config/ShieldD/rels/d_a_obj_lv5ychndlrD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv5ychndlrD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv5ychndlrD.map
+  name: d_a_obj_lv5ychndlr
 
 - object: files/rel/RVL/Debug/d_a_obj_lv5yiblltrayD.rel
   hash: fd58d40982f277842f7154229c545f8e7571aabc
   symbols: config/ShieldD/rels/d_a_obj_lv5yiblltrayD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv5yiblltrayD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv5yiblltrayD.map
+  name: d_a_obj_lv5yiblltray
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6bemos2D.rel
   hash: ad91e69905f593b12f4994448201839052be8511
   symbols: config/ShieldD/rels/d_a_obj_lv6bemos2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6bemos2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6bemos2D.map
+  name: d_a_obj_lv6bemos2
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6bemosD.rel
   hash: e606b156e20f3a7b84957c4cb8a5e4213f67fc97
   symbols: config/ShieldD/rels/d_a_obj_lv6bemosD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6bemosD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6bemosD.map
+  name: d_a_obj_lv6bemos
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6ChangeGateD.rel
   hash: 6c13e180b0f7046eac3c733ec35dd95f60bd21b5
   symbols: config/ShieldD/rels/d_a_obj_lv6ChangeGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6ChangeGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6ChangeGateD.map
+  name: d_a_obj_lv6ChangeGate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6egateD.rel
   hash: 3b14f0b17cd507ac8f8ce6ff49d0284f2870ca9a
   symbols: config/ShieldD/rels/d_a_obj_lv6egateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6egateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6egateD.map
+  name: d_a_obj_lv6egate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6elevtaD.rel
   hash: 5b735e5474c5e09787e2de0a40bcbd8decff786e
   symbols: config/ShieldD/rels/d_a_obj_lv6elevtaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6elevtaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6elevtaD.map
+  name: d_a_obj_lv6elevta
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6FurikoTrapD.rel
   hash: 12b566690ae4c4ac725d5dace1236b7d8984bd08
   symbols: config/ShieldD/rels/d_a_obj_lv6FurikoTrapD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6FurikoTrapD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6FurikoTrapD.map
+  name: d_a_obj_lv6FurikoTrap
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6LblockD.rel
   hash: f01f3010e4f315e757040d81e8a8acd4fdee174f
   symbols: config/ShieldD/rels/d_a_obj_lv6LblockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6LblockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6LblockD.map
+  name: d_a_obj_lv6Lblock
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6SwGateD.rel
   hash: 10871ddd9f0f9363890c60ec685d69adb1f4faac
   symbols: config/ShieldD/rels/d_a_obj_lv6SwGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6SwGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6SwGateD.map
+  name: d_a_obj_lv6SwGate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6swturnD.rel
   hash: 7a2b1f1278f145f7fc70170fe8d8ccae94593482
   symbols: config/ShieldD/rels/d_a_obj_lv6swturnD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6swturnD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6swturnD.map
+  name: d_a_obj_lv6swturn
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6SzGateD.rel
   hash: cd5c591a8097c1aec30b0c1d8010fb53a7114ea8
   symbols: config/ShieldD/rels/d_a_obj_lv6SzGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6SzGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6SzGateD.map
+  name: d_a_obj_lv6SzGate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6TenbinD.rel
   hash: e6bc1bc27dfbcf89b2d77da425640bc13bb8dd6f
   symbols: config/ShieldD/rels/d_a_obj_lv6TenbinD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6TenbinD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6TenbinD.map
+  name: d_a_obj_lv6Tenbin
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6TogeRollD.rel
   hash: 659d51492aadfe3277bf01d63193bb22614e8552
   symbols: config/ShieldD/rels/d_a_obj_lv6TogeRollD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6TogeRollD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6TogeRollD.map
+  name: d_a_obj_lv6TogeRoll
 
 - object: files/rel/RVL/Debug/d_a_obj_lv6TogeTrapD.rel
   hash: a926de12c496f00c096f4b60452e6bebf5eb3a71
   symbols: config/ShieldD/rels/d_a_obj_lv6TogeTrapD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv6TogeTrapD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv6TogeTrapD.map
+  name: d_a_obj_lv6TogeTrap
 
 - object: files/rel/RVL/Debug/d_a_obj_lv7bridgeD.rel
   hash: 851aca2a2d28ca2ee000c27074258a61d7efe9c5
   symbols: config/ShieldD/rels/d_a_obj_lv7bridgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv7bridgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv7bridgeD.map
+  name: d_a_obj_lv7bridge
 
 - object: files/rel/RVL/Debug/d_a_obj_lv7BsGateD.rel
   hash: f10b57c8fe6bd196fab0ff561da9ef756a64d928
   symbols: config/ShieldD/rels/d_a_obj_lv7BsGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv7BsGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv7BsGateD.map
+  name: d_a_obj_lv7BsGate
 
 - object: files/rel/RVL/Debug/d_a_obj_lv7PropellerYD.rel
   hash: f08b0dd28b30120c735bba937e3cb1c8593020a8
   symbols: config/ShieldD/rels/d_a_obj_lv7PropellerYD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv7PropellerYD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv7PropellerYD.map
+  name: d_a_obj_lv7PropellerY
 
 - object: files/rel/RVL/Debug/d_a_obj_lv8KekkaiTrapD.rel
   hash: 82361955a29539e6d7db4174c7bfcea9d67de0fc
   symbols: config/ShieldD/rels/d_a_obj_lv8KekkaiTrapD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv8KekkaiTrapD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv8KekkaiTrapD.map
+  name: d_a_obj_lv8KekkaiTrap
 
 - object: files/rel/RVL/Debug/d_a_obj_lv8LiftD.rel
   hash: e74113c0fe15971b9707ae1aaf66a40a3f6d51ee
   symbols: config/ShieldD/rels/d_a_obj_lv8LiftD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv8LiftD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv8LiftD.map
+  name: d_a_obj_lv8Lift
 
 - object: files/rel/RVL/Debug/d_a_obj_lv8OptiLiftD.rel
   hash: 5e90dca410165057600ecf874615bb06e797d72f
   symbols: config/ShieldD/rels/d_a_obj_lv8OptiLiftD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv8OptiLiftD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv8OptiLiftD.map
+  name: d_a_obj_lv8OptiLift
 
 - object: files/rel/RVL/Debug/d_a_obj_lv8UdFloorD.rel
   hash: 88dea5c5760f18eaa58e70067f5222eef19e73cd
   symbols: config/ShieldD/rels/d_a_obj_lv8UdFloorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv8UdFloorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv8UdFloorD.map
+  name: d_a_obj_lv8UdFloor
 
 - object: files/rel/RVL/Debug/d_a_obj_lv9SwShutterD.rel
   hash: a43c3901053be86e570b9e434f2c502fde20b1d2
   symbols: config/ShieldD/rels/d_a_obj_lv9SwShutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_lv9SwShutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_lv9SwShutterD.map
+  name: d_a_obj_lv9SwShutter
 
 - object: files/rel/RVL/Debug/d_a_obj_magLiftD.rel
   hash: abf912f910766967425caf697cfe6a6639ed5e84
   symbols: config/ShieldD/rels/d_a_obj_magLiftD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_magLiftD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_magLiftD.map
+  name: d_a_obj_magLift
 
 - object: files/rel/RVL/Debug/d_a_obj_magLiftRotD.rel
   hash: 31ce29f0c75454ea6266b6c6f8f622ae03c19559
   symbols: config/ShieldD/rels/d_a_obj_magLiftRotD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_magLiftRotD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_magLiftRotD.map
+  name: d_a_obj_magLiftRot
 
 - object: files/rel/RVL/Debug/d_a_obj_magne_armD.rel
   hash: 56206e280833ad9473ee4e0c756f4e2d57704c50
   symbols: config/ShieldD/rels/d_a_obj_magne_armD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_magne_armD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_magne_armD.map
+  name: d_a_obj_magne_arm
 
 - object: files/rel/RVL/Debug/d_a_obj_makiD.rel
   hash: 626a78832928f2748661916fb89ff3d2d9122337
   symbols: config/ShieldD/rels/d_a_obj_makiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_makiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_makiD.map
+  name: d_a_obj_maki
 
 - object: files/rel/RVL/Debug/d_a_obj_master_swordD.rel
   hash: 361acd3dae0bd4631780989d4fcbafa5e3aba6c2
   symbols: config/ShieldD/rels/d_a_obj_master_swordD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_master_swordD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_master_swordD.map
+  name: d_a_obj_master_sword
 
 - object: files/rel/RVL/Debug/d_a_obj_matoD.rel
   hash: 85772ce3ce10381e943c1d2d3035ff30728aca73
   symbols: config/ShieldD/rels/d_a_obj_matoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_matoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_matoD.map
+  name: d_a_obj_mato
 
 - object: files/rel/RVL/Debug/d_a_obj_metalboxD.rel
   hash: 2597cff2b589ab2441d260ddcbe30b29575485d2
   symbols: config/ShieldD/rels/d_a_obj_metalboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_metalboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_metalboxD.map
+  name: d_a_obj_metalbox
 
 - object: files/rel/RVL/Debug/d_a_obj_mgateD.rel
   hash: eb14670aab153f84295d8e87c416bc17bdc5e1cf
   symbols: config/ShieldD/rels/d_a_obj_mgateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mgateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mgateD.map
+  name: d_a_obj_mgate
 
 - object: files/rel/RVL/Debug/d_a_obj_mholeD.rel
   hash: 8350b5aab0aba19516d0127c996b09fb64873122
   symbols: config/ShieldD/rels/d_a_obj_mholeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mholeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mholeD.map
+  name: d_a_obj_mhole
 
 - object: files/rel/RVL/Debug/d_a_obj_mieD.rel
   hash: 5188e9d74a8e9f88154e992296e36c58b6bf388a
   symbols: config/ShieldD/rels/d_a_obj_mieD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mieD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mieD.map
+  name: d_a_obj_mie
 
 - object: files/rel/RVL/Debug/d_a_obj_mirror_6poleD.rel
   hash: 7ead028d9aae7f8a3f4a7f3863e3194975c7f8e9
   symbols: config/ShieldD/rels/d_a_obj_mirror_6poleD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mirror_6poleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mirror_6poleD.map
+  name: d_a_obj_mirror_6pole
 
 - object: files/rel/RVL/Debug/d_a_obj_mirror_chainD.rel
   hash: 2eb787c6cef56371fd82adfd5fc9e82dfa681d68
   symbols: config/ShieldD/rels/d_a_obj_mirror_chainD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mirror_chainD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mirror_chainD.map
+  name: d_a_obj_mirror_chain
 
 - object: files/rel/RVL/Debug/d_a_obj_mirror_sandD.rel
   hash: 40dafdde47ed7c5c7469e9036aba70cef05f597f
   symbols: config/ShieldD/rels/d_a_obj_mirror_sandD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mirror_sandD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mirror_sandD.map
+  name: d_a_obj_mirror_sand
 
 - object: files/rel/RVL/Debug/d_a_obj_mirror_screwD.rel
   hash: e73b50c2bbd9a87cbb5ff0a04e0d7d90ff41d7ed
   symbols: config/ShieldD/rels/d_a_obj_mirror_screwD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mirror_screwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mirror_screwD.map
+  name: d_a_obj_mirror_screw
 
 - object: files/rel/RVL/Debug/d_a_obj_mirror_tableD.rel
   hash: 3130706d4316bbc77c62ada6257ef101fb2fed2c
   symbols: config/ShieldD/rels/d_a_obj_mirror_tableD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mirror_tableD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mirror_tableD.map
+  name: d_a_obj_mirror_table
 
 - object: files/rel/RVL/Debug/d_a_obj_moveboxD.rel
   hash: c80686a6785ae1a2216fbed5b18f3b8950248085
   symbols: config/ShieldD/rels/d_a_obj_moveboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_moveboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_moveboxD.map
+  name: d_a_obj_movebox
 
 - object: files/rel/RVL/Debug/d_a_obj_msimaD.rel
   hash: 261568849734bd732c10b41024a5686448214dc7
   symbols: config/ShieldD/rels/d_a_obj_msimaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_msimaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_msimaD.map
+  name: d_a_obj_msima
 
 - object: files/rel/RVL/Debug/d_a_obj_mvstairD.rel
   hash: be9f0019bab4a92a870350bcc7405f438799931a
   symbols: config/ShieldD/rels/d_a_obj_mvstairD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_mvstairD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_mvstairD.map
+  name: d_a_obj_mvstair
 
 - object: files/rel/RVL/Debug/d_a_obj_myoganD.rel
   hash: 4ac17efdbdfe2500561aeabffec90cbf157bed11
   symbols: config/ShieldD/rels/d_a_obj_myoganD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_myoganD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_myoganD.map
+  name: d_a_obj_myogan
 
 - object: files/rel/RVL/Debug/d_a_obj_nagaisuD.rel
   hash: bbc88f7beb00284ff148abf1eddd8578bbe7414d
   symbols: config/ShieldD/rels/d_a_obj_nagaisuD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_nagaisuD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_nagaisuD.map
+  name: d_a_obj_nagaisu
 
 - object: files/rel/RVL/Debug/d_a_obj_nameplateD.rel
   hash: 3c05a48fdf2f8a2b0f57b8a111d9e0cbe65e61a6
   symbols: config/ShieldD/rels/d_a_obj_nameplateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_nameplateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_nameplateD.map
+  name: d_a_obj_nameplate
 
 - object: files/rel/RVL/Debug/d_a_obj_nanD.rel
   hash: 9099a97f073a9f5e7069473a23edba9402390514
   symbols: config/ShieldD/rels/d_a_obj_nanD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_nanD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_nanD.map
+  name: d_a_obj_nan
 
 - object: files/rel/RVL/Debug/d_a_obj_ndoorD.rel
   hash: c6e3814302cd6b3b1dddf7b9e6ebea9abe858ecf
   symbols: config/ShieldD/rels/d_a_obj_ndoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ndoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ndoorD.map
+  name: d_a_obj_ndoor
 
 - object: files/rel/RVL/Debug/d_a_obj_nouguD.rel
   hash: 07f3be029c51a4343f2d8ba60f5cd03772ccbe3b
   symbols: config/ShieldD/rels/d_a_obj_nouguD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_nouguD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_nouguD.map
+  name: d_a_obj_nougu
 
 - object: files/rel/RVL/Debug/d_a_obj_octhashiD.rel
   hash: 6fbb29f4afead972b07fdbf1ce54ba47fdd41be4
   symbols: config/ShieldD/rels/d_a_obj_octhashiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_octhashiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_octhashiD.map
+  name: d_a_obj_octhashi
 
 - object: files/rel/RVL/Debug/d_a_obj_oiltuboD.rel
   hash: 23f607e476e7b91badc36575e97c557d60e3b577
   symbols: config/ShieldD/rels/d_a_obj_oiltuboD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_oiltuboD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_oiltuboD.map
+  name: d_a_obj_oiltubo
 
 - object: files/rel/RVL/Debug/d_a_obj_onsenD.rel
   hash: 8bcfd405aac32dfca2499b24651fdafc807d394a
   symbols: config/ShieldD/rels/d_a_obj_onsenD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_onsenD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_onsenD.map
+  name: d_a_obj_onsen
 
 - object: files/rel/RVL/Debug/d_a_obj_onsenFireD.rel
   hash: d411b5e553132af0ccf7663d357a33dfeee67a9b
   symbols: config/ShieldD/rels/d_a_obj_onsenFireD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_onsenFireD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_onsenFireD.map
+  name: d_a_obj_onsenFire
 
 - object: files/rel/RVL/Debug/d_a_obj_onsenTaruD.rel
   hash: 2d52378fbd7b1c8abd065cb499262e0031dc0309
   symbols: config/ShieldD/rels/d_a_obj_onsenTaruD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_onsenTaruD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_onsenTaruD.map
+  name: d_a_obj_onsenTaru
 
 - object: files/rel/RVL/Debug/d_a_obj_ornament_clothD.rel
   hash: 89e6d66811e2d71ce235ee90af0e9cbf7ea813f6
   symbols: config/ShieldD/rels/d_a_obj_ornament_clothD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ornament_clothD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ornament_clothD.map
+  name: d_a_obj_ornament_cloth
 
 - object: files/rel/RVL/Debug/d_a_obj_pdoorD.rel
   hash: f8fbdbdafd102f8802c63337e7b4ab7be34f3175
   symbols: config/ShieldD/rels/d_a_obj_pdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pdoorD.map
+  name: d_a_obj_pdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_pdtileD.rel
   hash: 5334e74612abdc5e02065b8fc92b4df49afad52e
   symbols: config/ShieldD/rels/d_a_obj_pdtileD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pdtileD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pdtileD.map
+  name: d_a_obj_pdtile
 
 - object: files/rel/RVL/Debug/d_a_obj_pdwallD.rel
   hash: 6789cd5d271e24d3ba08ca0d23c0b7d921315604
   symbols: config/ShieldD/rels/d_a_obj_pdwallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pdwallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pdwallD.map
+  name: d_a_obj_pdwall
 
 - object: files/rel/RVL/Debug/d_a_obj_pictureD.rel
   hash: cd5778159ce597f828f93f3444bc3c1625596315
   symbols: config/ShieldD/rels/d_a_obj_pictureD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pictureD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pictureD.map
+  name: d_a_obj_picture
 
 - object: files/rel/RVL/Debug/d_a_obj_pillarD.rel
   hash: 3164f85a701c919061179e4c7942a498b613a45f
   symbols: config/ShieldD/rels/d_a_obj_pillarD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pillarD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pillarD.map
+  name: d_a_obj_pillar
 
 - object: files/rel/RVL/Debug/d_a_obj_pleafD.rel
   hash: 971ff9ab4edce83aea9533d2e58374ec3935921a
   symbols: config/ShieldD/rels/d_a_obj_pleafD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pleafD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pleafD.map
+  name: d_a_obj_pleaf
 
 - object: files/rel/RVL/Debug/d_a_obj_poCandleD.rel
   hash: 0b9ca7ba6c7bb58b0b1b8eb38fe84a13b27aa036
   symbols: config/ShieldD/rels/d_a_obj_poCandleD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_poCandleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_poCandleD.map
+  name: d_a_obj_poCandle
 
 - object: files/rel/RVL/Debug/d_a_obj_poFireD.rel
   hash: 8fe9102cf0c9861beff696c8f7f22d5baa415ffc
   symbols: config/ShieldD/rels/d_a_obj_poFireD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_poFireD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_poFireD.map
+  name: d_a_obj_poFire
 
 - object: files/rel/RVL/Debug/d_a_obj_poTboxD.rel
   hash: 0a2ac3501cb9f5b003c45582c50593f5a699a810
   symbols: config/ShieldD/rels/d_a_obj_poTboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_poTboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_poTboxD.map
+  name: d_a_obj_poTbox
 
 - object: files/rel/RVL/Debug/d_a_obj_propD.rel
   hash: ccfba3c3fc4a262442303b066d1be6837a10b659
   symbols: config/ShieldD/rels/d_a_obj_propD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_propD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_propD.map
+  name: d_a_obj_prop
 
 - object: files/rel/RVL/Debug/d_a_obj_pumpkinD.rel
   hash: e1cf03b4d1465f722bc7bc80fbe2f0e5366dda5d
   symbols: config/ShieldD/rels/d_a_obj_pumpkinD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_pumpkinD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_pumpkinD.map
+  name: d_a_obj_pumpkin
 
 - object: files/rel/RVL/Debug/d_a_obj_rcircleD.rel
   hash: 0905d32228430833aa8056218515c1dc52cb35d7
   symbols: config/ShieldD/rels/d_a_obj_rcircleD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rcircleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rcircleD.map
+  name: d_a_obj_rcircle
 
 - object: files/rel/RVL/Debug/d_a_obj_rfHoleD.rel
   hash: 1c5b4d85b23b84e348c5b03221753e29f46d74e9
   symbols: config/ShieldD/rels/d_a_obj_rfHoleD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rfHoleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rfHoleD.map
+  name: d_a_obj_rfHole
 
 - object: files/rel/RVL/Debug/d_a_obj_rgateD.rel
   hash: 7b29a2cfe28643dcd931a16d7e3372785010d6f7
   symbols: config/ShieldD/rels/d_a_obj_rgateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rgateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rgateD.map
+  name: d_a_obj_rgate
 
 - object: files/rel/RVL/Debug/d_a_obj_riverrockD.rel
   hash: 9e75698950f9bda5cc963280d294ca564eaf116b
   symbols: config/ShieldD/rels/d_a_obj_riverrockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_riverrockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_riverrockD.map
+  name: d_a_obj_riverrock
 
 - object: files/rel/RVL/Debug/d_a_obj_rockD.rel
   hash: f8c44dd8d24c164287536b159ae2c4d7a66e6e98
   symbols: config/ShieldD/rels/d_a_obj_rockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rockD.map
+  name: d_a_obj_rock
 
 - object: files/rel/RVL/Debug/d_a_obj_rope_bridgeD.rel
   hash: a787f9da73fef6523ad4b016c3843daeb0b6c27b
   symbols: config/ShieldD/rels/d_a_obj_rope_bridgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rope_bridgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rope_bridgeD.map
+  name: d_a_obj_rope_bridge
 
 - object: files/rel/RVL/Debug/d_a_obj_rotBridgeD.rel
   hash: c6c8d568a7226a3116f8e33f89bbacdf5d8d3bc1
   symbols: config/ShieldD/rels/d_a_obj_rotBridgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rotBridgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rotBridgeD.map
+  name: d_a_obj_rotBridge
 
 - object: files/rel/RVL/Debug/d_a_obj_rotenD.rel
   hash: 68c0c855d5040fd74ca4e52ffa4d781d909a3275
   symbols: config/ShieldD/rels/d_a_obj_rotenD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rotenD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rotenD.map
+  name: d_a_obj_roten
 
 - object: files/rel/RVL/Debug/d_a_obj_rotTrapD.rel
   hash: e20ab129de5e0bdc2eecf1a23ad6eb1b86410f7c
   symbols: config/ShieldD/rels/d_a_obj_rotTrapD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rotTrapD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rotTrapD.map
+  name: d_a_obj_rotTrap
 
 - object: files/rel/RVL/Debug/d_a_obj_rstairD.rel
   hash: 890d7a7442297ad2b42f92d8d04d359809356611
   symbols: config/ShieldD/rels/d_a_obj_rstairD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rstairD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rstairD.map
+  name: d_a_obj_rstair
 
 - object: files/rel/RVL/Debug/d_a_obj_rwD.rel
   hash: 9a0ccd056572d99827abb0dba0263940f4830ece
   symbols: config/ShieldD/rels/d_a_obj_rwD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_rwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_rwD.map
+  name: d_a_obj_rw
 
 - object: files/rel/RVL/Debug/d_a_obj_saidanD.rel
   hash: 74ad8b605c2de180a72811467755f8cf5f25af54
   symbols: config/ShieldD/rels/d_a_obj_saidanD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_saidanD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_saidanD.map
+  name: d_a_obj_saidan
 
 - object: files/rel/RVL/Debug/d_a_obj_sakuitaD.rel
   hash: 28ca7a8bf35609b8ed3c7cd466e952923250ac30
   symbols: config/ShieldD/rels/d_a_obj_sakuitaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sakuitaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sakuitaD.map
+  name: d_a_obj_sakuita
 
 - object: files/rel/RVL/Debug/d_a_obj_sakuita_ropeD.rel
   hash: 7cb89b08b556add07242b59f5c94538b5065e88c
   symbols: config/ShieldD/rels/d_a_obj_sakuita_ropeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sakuita_ropeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sakuita_ropeD.map
+  name: d_a_obj_sakuita_rope
 
 - object: files/rel/RVL/Debug/d_a_obj_scannonD.rel
   hash: 93262aa28285f46203381e8d4085d73241bb6554
   symbols: config/ShieldD/rels/d_a_obj_scannonD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_scannonD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_scannonD.map
+  name: d_a_obj_scannon
 
 - object: files/rel/RVL/Debug/d_a_obj_scannon_crsD.rel
   hash: b2c05dabd4a6449514e570d79dbe5c90c2169216
   symbols: config/ShieldD/rels/d_a_obj_scannon_crsD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_scannon_crsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_scannon_crsD.map
+  name: d_a_obj_scannon_crs
 
 - object: files/rel/RVL/Debug/d_a_obj_scannon_tenD.rel
   hash: 91aad8b47143b237eb4f02be563cab21eb87bc34
   symbols: config/ShieldD/rels/d_a_obj_scannon_tenD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_scannon_tenD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_scannon_tenD.map
+  name: d_a_obj_scannon_ten
 
 - object: files/rel/RVL/Debug/d_a_obj_sekidoorD.rel
   hash: c159eed2e33312e4dc64d516f89284787cd0314f
   symbols: config/ShieldD/rels/d_a_obj_sekidoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sekidoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sekidoorD.map
+  name: d_a_obj_sekidoor
 
 - object: files/rel/RVL/Debug/d_a_obj_sekizoaD.rel
   hash: 4f5cf0cd4d31c09b51a4e49e239e2d1d0d4ce7f6
   symbols: config/ShieldD/rels/d_a_obj_sekizoaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sekizoaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sekizoaD.map
+  name: d_a_obj_sekizoa
 
 - object: files/rel/RVL/Debug/d_a_obj_sekizoD.rel
   hash: b9e579742fbba059b458155c16e42cbf5240513d
   symbols: config/ShieldD/rels/d_a_obj_sekizoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sekizoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sekizoD.map
+  name: d_a_obj_sekizo
 
 - object: files/rel/RVL/Debug/d_a_obj_shieldD.rel
   hash: 44b0108126c300f99419a1578493df6eb8dc2237
   symbols: config/ShieldD/rels/d_a_obj_shieldD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_shieldD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_shieldD.map
+  name: d_a_obj_shield
 
 - object: files/rel/RVL/Debug/d_a_obj_smallkeyD.rel
   hash: 9066ee0542f2ff3c63f18d468466a9f599eaf276
   symbols: config/ShieldD/rels/d_a_obj_smallkeyD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_smallkeyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_smallkeyD.map
+  name: d_a_obj_smallkey
 
 - object: files/rel/RVL/Debug/d_a_obj_smgdoorD.rel
   hash: 14c93d5d61bba8fc6dcafa6607465176c94206c6
   symbols: config/ShieldD/rels/d_a_obj_smgdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_smgdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_smgdoorD.map
+  name: d_a_obj_smgdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_smokeD.rel
   hash: 587e1ca5bcdcf64f6c01c1d992c04bf6cf28bbe7
   symbols: config/ShieldD/rels/d_a_obj_smokeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_smokeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_smokeD.map
+  name: d_a_obj_smoke
 
 - object: files/rel/RVL/Debug/d_a_obj_smtileD.rel
   hash: 21eb9cac42c75a8f77ec6d213328691c0fb849ec
   symbols: config/ShieldD/rels/d_a_obj_smtileD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_smtileD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_smtileD.map
+  name: d_a_obj_smtile
 
 - object: files/rel/RVL/Debug/d_a_obj_smw_stoneD.rel
   hash: ebfb6b68b1f3aa361770ec7b1259d31e43fca8c4
   symbols: config/ShieldD/rels/d_a_obj_smw_stoneD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_smw_stoneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_smw_stoneD.map
+  name: d_a_obj_smw_stone
 
 - object: files/rel/RVL/Debug/d_a_obj_sm_doorD.rel
   hash: 550a566fc44e93ae93017a8965a97c4e3fe3e6f8
   symbols: config/ShieldD/rels/d_a_obj_sm_doorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sm_doorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sm_doorD.map
+  name: d_a_obj_sm_door
 
 - object: files/rel/RVL/Debug/d_a_obj_snowEffTagD.rel
   hash: 27d82c4ff4c1849210da17840f26f06df483da82
   symbols: config/ShieldD/rels/d_a_obj_snowEffTagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_snowEffTagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_snowEffTagD.map
+  name: d_a_obj_snowEffTag
 
 - object: files/rel/RVL/Debug/d_a_obj_snow_soupD.rel
   hash: afead59a94f2f61d57b60f789d39fc4333157bc9
   symbols: config/ShieldD/rels/d_a_obj_snow_soupD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_snow_soupD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_snow_soupD.map
+  name: d_a_obj_snow_soup
 
 - object: files/rel/RVL/Debug/d_a_obj_soD.rel
   hash: 47f6b7af5aa7f965f1487eb09a7297b67467ad12
   symbols: config/ShieldD/rels/d_a_obj_soD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_soD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_soD.map
+  name: d_a_obj_so
 
 - object: files/rel/RVL/Debug/d_a_obj_spinLiftD.rel
   hash: 1659775424eaf6113905febcf38fb030b3072e34
   symbols: config/ShieldD/rels/d_a_obj_spinLiftD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_spinLiftD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_spinLiftD.map
+  name: d_a_obj_spinLift
 
 - object: files/rel/RVL/Debug/d_a_obj_ss_drinkD.rel
   hash: ea755fb55def230a4a9ee3ce5dd55dc466af340a
   symbols: config/ShieldD/rels/d_a_obj_ss_drinkD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ss_drinkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ss_drinkD.map
+  name: d_a_obj_ss_drink
 
 - object: files/rel/RVL/Debug/d_a_obj_ss_itemD.rel
   hash: 703f56937ad64eb188cd37ddb484a38118554ee4
   symbols: config/ShieldD/rels/d_a_obj_ss_itemD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ss_itemD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ss_itemD.map
+  name: d_a_obj_ss_item
 
 - object: files/rel/RVL/Debug/d_a_obj_stairBlockD.rel
   hash: 9559e89d79e28afb10fcb83e36988afb9499f6b2
   symbols: config/ShieldD/rels/d_a_obj_stairBlockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_stairBlockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_stairBlockD.map
+  name: d_a_obj_stairBlock
 
 - object: files/rel/RVL/Debug/d_a_obj_stickD.rel
   hash: f2799b8d958ee533415e091826230ab7b2fa5d59
   symbols: config/ShieldD/rels/d_a_obj_stickD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_stickD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_stickD.map
+  name: d_a_obj_stick
 
 - object: files/rel/RVL/Debug/d_a_obj_stoneD.rel
   hash: 129298ff37540de2965609646d09901b5e2f893e
   symbols: config/ShieldD/rels/d_a_obj_stoneD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_stoneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_stoneD.map
+  name: d_a_obj_stone
 
 - object: files/rel/RVL/Debug/d_a_obj_stoneMarkD.rel
   hash: b4d7e4f34422847ff86d8b1e6cc107fd9f02717d
   symbols: config/ShieldD/rels/d_a_obj_stoneMarkD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_stoneMarkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_stoneMarkD.map
+  name: d_a_obj_stoneMark
 
 - object: files/rel/RVL/Debug/d_a_obj_stopper2D.rel
   hash: 139498e8b2c3c7f2cded27b1c89653a76deae86f
   symbols: config/ShieldD/rels/d_a_obj_stopper2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_stopper2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_stopper2D.map
+  name: d_a_obj_stopper2
 
 - object: files/rel/RVL/Debug/d_a_obj_stopperD.rel
   hash: 929d3b22bed1f075b7d6d730702768eac6fb66fd
   symbols: config/ShieldD/rels/d_a_obj_stopperD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_stopperD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_stopperD.map
+  name: d_a_obj_stopper
 
 - object: files/rel/RVL/Debug/d_a_obj_suisyaD.rel
   hash: 9b5c5614da37cf5e4855813b4e4d5f591f4d1a3c
   symbols: config/ShieldD/rels/d_a_obj_suisyaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_suisyaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_suisyaD.map
+  name: d_a_obj_suisya
 
 - object: files/rel/RVL/Debug/d_a_obj_sWallShutterD.rel
   hash: 33468dc00e5966d3ba48336b2e123b797faeddfd
   symbols: config/ShieldD/rels/d_a_obj_sWallShutterD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_sWallShutterD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_sWallShutterD.map
+  name: d_a_obj_sWallShutter
 
 - object: files/rel/RVL/Debug/d_a_obj_swBallAD.rel
   hash: 15d43977488de8171c97a975c5ea1b380c5a56cc
   symbols: config/ShieldD/rels/d_a_obj_swBallAD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swBallAD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swBallAD.map
+  name: d_a_obj_swBallA
 
 - object: files/rel/RVL/Debug/d_a_obj_swBallBD.rel
   hash: 8ecc80a75a0c0326ea1056812eb1857227ff1089
   symbols: config/ShieldD/rels/d_a_obj_swBallBD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swBallBD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swBallBD.map
+  name: d_a_obj_swBallB
 
 - object: files/rel/RVL/Debug/d_a_obj_swBallCD.rel
   hash: 211d7d56c53fe11138a383f106371dc8baeca72e
   symbols: config/ShieldD/rels/d_a_obj_swBallCD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swBallCD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swBallCD.map
+  name: d_a_obj_swBallC
 
 - object: files/rel/RVL/Debug/d_a_obj_swchainD.rel
   hash: ac70442bb798dd5c1840b520ae3392cba595cb83
   symbols: config/ShieldD/rels/d_a_obj_swchainD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swchainD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swchainD.map
+  name: d_a_obj_swchain
 
 - object: files/rel/RVL/Debug/d_a_obj_swD.rel
   hash: 26a7fd894fa24759d856c8ace64cf185c86919ea
   symbols: config/ShieldD/rels/d_a_obj_swD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swD.map
+  name: d_a_obj_sw
 
 - object: files/rel/RVL/Debug/d_a_obj_swhangD.rel
   hash: b02a3d501b27fcbf20a9bfd965a5939c05814eb3
   symbols: config/ShieldD/rels/d_a_obj_swhangD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swhangD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swhangD.map
+  name: d_a_obj_swhang
 
 - object: files/rel/RVL/Debug/d_a_obj_swLightD.rel
   hash: 84b5f528e39d9835e36f575d04af2c940d806c97
   symbols: config/ShieldD/rels/d_a_obj_swLightD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swLightD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swLightD.map
+  name: d_a_obj_swLight
 
 - object: files/rel/RVL/Debug/d_a_obj_swordD.rel
   hash: 2bcbb20fe7b9a8f0ff3394bbc266bb4488033a06
   symbols: config/ShieldD/rels/d_a_obj_swordD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swordD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swordD.map
+  name: d_a_obj_sword
 
 - object: files/rel/RVL/Debug/d_a_obj_swpropellerD.rel
   hash: eb9a62f3ef76cc40b17f39ecdf2cc79bda285dda
   symbols: config/ShieldD/rels/d_a_obj_swpropellerD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swpropellerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swpropellerD.map
+  name: d_a_obj_swpropeller
 
 - object: files/rel/RVL/Debug/d_a_obj_swpush2D.rel
   hash: 4b9309722daffa734fb6b7be89b72e374ca36a11
   symbols: config/ShieldD/rels/d_a_obj_swpush2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swpush2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swpush2D.map
+  name: d_a_obj_swpush2
 
 - object: files/rel/RVL/Debug/d_a_obj_swpush5D.rel
   hash: bcc96577e7b24cc9779bdb021c414404db8e8ef3
   symbols: config/ShieldD/rels/d_a_obj_swpush5D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swpush5D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swpush5D.map
+  name: d_a_obj_swpush5
 
 - object: files/rel/RVL/Debug/d_a_obj_swpushD.rel
   hash: 66983ee5467c31c273bef862852ba2377bec1e9f
   symbols: config/ShieldD/rels/d_a_obj_swpushD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swpushD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swpushD.map
+  name: d_a_obj_swpush
 
 - object: files/rel/RVL/Debug/d_a_obj_swspinnerD.rel
   hash: b653c40c8e60db4380f0ab683a81df0292a2e22e
   symbols: config/ShieldD/rels/d_a_obj_swspinnerD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swspinnerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swspinnerD.map
+  name: d_a_obj_swspinner
 
 - object: files/rel/RVL/Debug/d_a_obj_swturnD.rel
   hash: 4ccab64b51f431810b9cb4bf12cc6661cc03a00a
   symbols: config/ShieldD/rels/d_a_obj_swturnD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_swturnD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_swturnD.map
+  name: d_a_obj_swturn
 
 - object: files/rel/RVL/Debug/d_a_obj_syRockD.rel
   hash: f3c773cce52150b301b608da2425429d6543e635
   symbols: config/ShieldD/rels/d_a_obj_syRockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_syRockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_syRockD.map
+  name: d_a_obj_syRock
 
 - object: files/rel/RVL/Debug/d_a_obj_szbridgeD.rel
   hash: db49c671fbd39d70818844814f8f8cccdb5ddcce
   symbols: config/ShieldD/rels/d_a_obj_szbridgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_szbridgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_szbridgeD.map
+  name: d_a_obj_szbridge
 
 - object: files/rel/RVL/Debug/d_a_obj_tableD.rel
   hash: 3b26cd93d20c15e48c9fd85b1781035ed7e4a020
   symbols: config/ShieldD/rels/d_a_obj_tableD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tableD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tableD.map
+  name: d_a_obj_table
 
 - object: files/rel/RVL/Debug/d_a_obj_taFenceD.rel
   hash: 131a3b66b1effc80f6c31a9bf6b50a7af61f6030
   symbols: config/ShieldD/rels/d_a_obj_taFenceD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_taFenceD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_taFenceD.map
+  name: d_a_obj_taFence
 
 - object: files/rel/RVL/Debug/d_a_obj_takaraDaiD.rel
   hash: 58f4f94ce081dfd739077a2f57b3c56b82b2998e
   symbols: config/ShieldD/rels/d_a_obj_takaraDaiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_takaraDaiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_takaraDaiD.map
+  name: d_a_obj_takaraDai
 
 - object: files/rel/RVL/Debug/d_a_obj_tatigiD.rel
   hash: 2a5fd895eba66a23ea217c764ebcb87d67eefa50
   symbols: config/ShieldD/rels/d_a_obj_tatigiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tatigiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tatigiD.map
+  name: d_a_obj_tatigi
 
 - object: files/rel/RVL/Debug/d_a_obj_tenD.rel
   hash: d20d95ad8495213e650f787486a0230aa197a0aa
   symbols: config/ShieldD/rels/d_a_obj_tenD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tenD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tenD.map
+  name: d_a_obj_ten
 
 - object: files/rel/RVL/Debug/d_a_obj_testcubeD.rel
   hash: 51a2db38666f00f3340d2b21c2f7408ece0ad80f
   symbols: config/ShieldD/rels/d_a_obj_testcubeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_testcubeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_testcubeD.map
+  name: d_a_obj_testcube
 
 - object: files/rel/RVL/Debug/d_a_obj_tgakeD.rel
   hash: 701b32b2899c1ec39dfdf3817ca875183618e1cd
   symbols: config/ShieldD/rels/d_a_obj_tgakeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tgakeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tgakeD.map
+  name: d_a_obj_tgake
 
 - object: files/rel/RVL/Debug/d_a_obj_thashiD.rel
   hash: fba7722f7e556e9c4aeadc0e20dfd6b3942c2685
   symbols: config/ShieldD/rels/d_a_obj_thashiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_thashiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_thashiD.map
+  name: d_a_obj_thashi
 
 - object: files/rel/RVL/Debug/d_a_obj_thdoorD.rel
   hash: be011067a28ef899dbb33a19f7a269f1c48e8fc2
   symbols: config/ShieldD/rels/d_a_obj_thdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_thdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_thdoorD.map
+  name: d_a_obj_thdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_timeFireD.rel
   hash: d957423e29f49ab4967c1b3d28abd73af5909572
   symbols: config/ShieldD/rels/d_a_obj_timeFireD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_timeFireD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_timeFireD.map
+  name: d_a_obj_timeFire
 
 - object: files/rel/RVL/Debug/d_a_obj_timerD.rel
   hash: 15540fba10b30360b4cf025e92ff565d3ab28b5c
   symbols: config/ShieldD/rels/d_a_obj_timerD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_timerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_timerD.map
+  name: d_a_obj_timer
 
 - object: files/rel/RVL/Debug/d_a_obj_tksD.rel
   hash: 5c0fa20d5a33937ca83288da031a031525789208
   symbols: config/ShieldD/rels/d_a_obj_tksD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tksD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tksD.map
+  name: d_a_obj_tks
 
 - object: files/rel/RVL/Debug/d_a_obj_tmoonD.rel
   hash: 768004386e40570a231c570919c41c27736d8e50
   symbols: config/ShieldD/rels/d_a_obj_tmoonD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tmoonD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tmoonD.map
+  name: d_a_obj_tmoon
 
 - object: files/rel/RVL/Debug/d_a_obj_toaru_makiD.rel
   hash: 41ca7dc4dc7aa20d0cd2e94612d16343de05841f
   symbols: config/ShieldD/rels/d_a_obj_toaru_makiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_toaru_makiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_toaru_makiD.map
+  name: d_a_obj_toaru_maki
 
 - object: files/rel/RVL/Debug/d_a_obj_tobyD.rel
   hash: 6021b963d99a440a95ea9624eb5ef7eb9f396d46
   symbols: config/ShieldD/rels/d_a_obj_tobyD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tobyD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tobyD.map
+  name: d_a_obj_toby
 
 - object: files/rel/RVL/Debug/d_a_obj_tobyhouseD.rel
   hash: 7f0fce26c0edc7fde4f3972918028f871f5dc83c
   symbols: config/ShieldD/rels/d_a_obj_tobyhouseD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tobyhouseD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tobyhouseD.map
+  name: d_a_obj_tobyhouse
 
 - object: files/rel/RVL/Debug/d_a_obj_togeTrapD.rel
   hash: 0ac90f04e004cadc412fd5d8dda572be5923fa63
   symbols: config/ShieldD/rels/d_a_obj_togeTrapD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_togeTrapD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_togeTrapD.map
+  name: d_a_obj_togeTrap
 
 - object: files/rel/RVL/Debug/d_a_obj_tomboD.rel
   hash: 648a25324199cf3a96e421c5ed2f78d08c3758b1
   symbols: config/ShieldD/rels/d_a_obj_tomboD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tomboD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tomboD.map
+  name: d_a_obj_tombo
 
 - object: files/rel/RVL/Debug/d_a_obj_tornado2D.rel
   hash: c42c810cb8eacf35d84db48c53b6c8a6dc3ae49e
   symbols: config/ShieldD/rels/d_a_obj_tornado2D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tornado2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tornado2D.map
+  name: d_a_obj_tornado2
 
 - object: files/rel/RVL/Debug/d_a_obj_tornadoD.rel
   hash: b6365418403325b37ca14f051703ac870ffb4437
   symbols: config/ShieldD/rels/d_a_obj_tornadoD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tornadoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tornadoD.map
+  name: d_a_obj_tornado
 
 - object: files/rel/RVL/Debug/d_a_obj_tpD.rel
   hash: b87c0a69a45d78c4cac04613b15ff9023c911db0
   symbols: config/ShieldD/rels/d_a_obj_tpD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_tpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_tpD.map
+  name: d_a_obj_tp
 
 - object: files/rel/RVL/Debug/d_a_obj_treeshD.rel
   hash: 8d1c4a010dba2c76a80a963333baa9b1acb9ec05
   symbols: config/ShieldD/rels/d_a_obj_treeshD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_treeshD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_treeshD.map
+  name: d_a_obj_treesh
 
 - object: files/rel/RVL/Debug/d_a_obj_TuraraD.rel
   hash: 97807cb92a1cc48922964464d54ca00214ff4d99
   symbols: config/ShieldD/rels/d_a_obj_TuraraD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_TuraraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_TuraraD.map
+  name: d_a_obj_Turara
 
 - object: files/rel/RVL/Debug/d_a_obj_TvCdlstD.rel
   hash: 0c2f77a1e41941f448aea343992ef6e3d8b0557e
   symbols: config/ShieldD/rels/d_a_obj_TvCdlstD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_TvCdlstD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_TvCdlstD.map
+  name: d_a_obj_TvCdlst
 
 - object: files/rel/RVL/Debug/d_a_obj_twGateD.rel
   hash: a0d8f892404d5b1082226e2790312b3dec6b4a17
   symbols: config/ShieldD/rels/d_a_obj_twGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_twGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_twGateD.map
+  name: d_a_obj_twGate
 
 - object: files/rel/RVL/Debug/d_a_obj_udoorD.rel
   hash: f5a301c3dc788235850764afe267b180f07e2bf3
   symbols: config/ShieldD/rels/d_a_obj_udoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_udoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_udoorD.map
+  name: d_a_obj_udoor
 
 - object: files/rel/RVL/Debug/d_a_obj_usakuD.rel
   hash: 2bf92e8a196328083e2ba810f34dd2390b4970af
   symbols: config/ShieldD/rels/d_a_obj_usakuD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_usakuD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_usakuD.map
+  name: d_a_obj_usaku
 
 - object: files/rel/RVL/Debug/d_a_obj_vgroundD.rel
   hash: e5fc506cfdc3e07e27b16f9f1e87b42c30588069
   symbols: config/ShieldD/rels/d_a_obj_vgroundD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_vgroundD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_vgroundD.map
+  name: d_a_obj_vground
 
 - object: files/rel/RVL/Debug/d_a_obj_volcballD.rel
   hash: d2026c0ffdbdcc420d31be0d47b8cc2eb86ecc8c
   symbols: config/ShieldD/rels/d_a_obj_volcballD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_volcballD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_volcballD.map
+  name: d_a_obj_volcball
 
 - object: files/rel/RVL/Debug/d_a_obj_volcbomD.rel
   hash: e507bd77b8f0ed832c439a41c6adf078c62abcef
   symbols: config/ShieldD/rels/d_a_obj_volcbomD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_volcbomD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_volcbomD.map
+  name: d_a_obj_volcbom
 
 - object: files/rel/RVL/Debug/d_a_obj_warp_kbrgD.rel
   hash: 95fca30c03a49bfa14cbc613374586f71cccfb6e
   symbols: config/ShieldD/rels/d_a_obj_warp_kbrgD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_warp_kbrgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_warp_kbrgD.map
+  name: d_a_obj_warp_kbrg
 
 - object: files/rel/RVL/Debug/d_a_obj_warp_obrgD.rel
   hash: 60978f1572ef89c07246db48fc472927f05bd9d6
   symbols: config/ShieldD/rels/d_a_obj_warp_obrgD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_warp_obrgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_warp_obrgD.map
+  name: d_a_obj_warp_obrg
 
 - object: files/rel/RVL/Debug/d_a_obj_waterfallD.rel
   hash: 7852b8642beb6b259ae410f8025a6afc712e99ac
   symbols: config/ShieldD/rels/d_a_obj_waterfallD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_waterfallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_waterfallD.map
+  name: d_a_obj_waterfall
 
 - object: files/rel/RVL/Debug/d_a_obj_waterGateD.rel
   hash: 62f360277d233fadabd8d3c46a6b49e1237e1bf4
   symbols: config/ShieldD/rels/d_a_obj_waterGateD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_waterGateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_waterGateD.map
+  name: d_a_obj_waterGate
 
 - object: files/rel/RVL/Debug/d_a_obj_waterPillarD.rel
   hash: 070220e3746fd201e36e954f0da31f83df172cdd
   symbols: config/ShieldD/rels/d_a_obj_waterPillarD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_waterPillarD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_waterPillarD.map
+  name: d_a_obj_waterPillar
 
 - object: files/rel/RVL/Debug/d_a_obj_wchainD.rel
   hash: 31801a4f1c6ed52a89d6f1f0c8943ef42097625a
   symbols: config/ShieldD/rels/d_a_obj_wchainD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wchainD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wchainD.map
+  name: d_a_obj_wchain
 
 - object: files/rel/RVL/Debug/d_a_obj_wdStickD.rel
   hash: cfd0fff9bb690abcfd10bd6baf4a5ec93afff884
   symbols: config/ShieldD/rels/d_a_obj_wdStickD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wdStickD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wdStickD.map
+  name: d_a_obj_wdStick
 
 - object: files/rel/RVL/Debug/d_a_obj_web0D.rel
   hash: f86764375985e03a098b5c2ce06fcc925d178018
   symbols: config/ShieldD/rels/d_a_obj_web0D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_web0D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_web0D.map
+  name: d_a_obj_web0
 
 - object: files/rel/RVL/Debug/d_a_obj_web1D.rel
   hash: 93bb86a4cf586d3aac2e6f9fdc86ac8bd64ff681
   symbols: config/ShieldD/rels/d_a_obj_web1D/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_web1D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_web1D.map
+  name: d_a_obj_web1
 
 - object: files/rel/RVL/Debug/d_a_obj_well_coverD.rel
   hash: eb5aefb4072d3c4d09a851bdb58f328ca76fdacf
   symbols: config/ShieldD/rels/d_a_obj_well_coverD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_well_coverD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_well_coverD.map
+  name: d_a_obj_well_cover
 
 - object: files/rel/RVL/Debug/d_a_obj_wflagD.rel
   hash: 5c8aea732522bbad35ec5ef89b15299f6dca51ea
   symbols: config/ShieldD/rels/d_a_obj_wflagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wflagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wflagD.map
+  name: d_a_obj_wflag
 
 - object: files/rel/RVL/Debug/d_a_obj_windowD.rel
   hash: b7e7498eff40390b311061e128623b1386ae4d14
   symbols: config/ShieldD/rels/d_a_obj_windowD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_windowD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_windowD.map
+  name: d_a_obj_window
 
 - object: files/rel/RVL/Debug/d_a_obj_wind_stoneD.rel
   hash: b03ee022a8f6fd3122c925a9cedf91d9893f1e1f
   symbols: config/ShieldD/rels/d_a_obj_wind_stoneD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wind_stoneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wind_stoneD.map
+  name: d_a_obj_wind_stone
 
 - object: files/rel/RVL/Debug/d_a_obj_wood_pendulumD.rel
   hash: ba7484307c3f8e9b83098645f8af48eca5b5ed6b
   symbols: config/ShieldD/rels/d_a_obj_wood_pendulumD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wood_pendulumD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wood_pendulumD.map
+  name: d_a_obj_wood_pendulum
 
 - object: files/rel/RVL/Debug/d_a_obj_wood_statueD.rel
   hash: b627c37e6bc2da797e538ee281cc639f6ba04f36
   symbols: config/ShieldD/rels/d_a_obj_wood_statueD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wood_statueD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wood_statueD.map
+  name: d_a_obj_wood_statue
 
 - object: files/rel/RVL/Debug/d_a_obj_wswordD.rel
   hash: 8cd9909363f8a5755d9b9f5a881afdd5a9269683
   symbols: config/ShieldD/rels/d_a_obj_wswordD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_wswordD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_wswordD.map
+  name: d_a_obj_wsword
 
 - object: files/rel/RVL/Debug/d_a_obj_yel_bagD.rel
   hash: c8ea1726dbc48c9e0979036b015c417d1682ae7b
   symbols: config/ShieldD/rels/d_a_obj_yel_bagD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_yel_bagD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_yel_bagD.map
+  name: d_a_obj_yel_bag
 
 - object: files/rel/RVL/Debug/d_a_obj_yobikusaD.rel
   hash: fe62a34486c0bd4abe9d6c4c1b30207fb3870d9f
   symbols: config/ShieldD/rels/d_a_obj_yobikusaD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_yobikusaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_yobikusaD.map
+  name: d_a_obj_yobikusa
 
 - object: files/rel/RVL/Debug/d_a_obj_youseiD.rel
   hash: fe42bd561f3a8f3bd0456454ab088dca7d3e2b5a
   symbols: config/ShieldD/rels/d_a_obj_youseiD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_youseiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_youseiD.map
+  name: d_a_obj_yousei
 
 - object: files/rel/RVL/Debug/d_a_obj_ystoneD.rel
   hash: 9d1f3762aafcadc54c192188ac39d5361b4beba0
   symbols: config/ShieldD/rels/d_a_obj_ystoneD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_ystoneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_ystoneD.map
+  name: d_a_obj_ystone
 
 - object: files/rel/RVL/Debug/d_a_obj_Y_taihouD.rel
   hash: dd40b56c83ba4745e962096bff5e569464a53154
   symbols: config/ShieldD/rels/d_a_obj_Y_taihouD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_Y_taihouD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_Y_taihouD.map
+  name: d_a_obj_Y_taihou
 
 - object: files/rel/RVL/Debug/d_a_obj_zclothD.rel
   hash: acd1fecb6884d1d40b7024543010905024381faa
   symbols: config/ShieldD/rels/d_a_obj_zclothD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zclothD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zclothD.map
+  name: d_a_obj_zcloth
 
 - object: files/rel/RVL/Debug/d_a_obj_zdoorD.rel
   hash: fd2e2eb6133e7d25f6f066f0955f0fba7c8277ba
   symbols: config/ShieldD/rels/d_a_obj_zdoorD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zdoorD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zdoorD.map
+  name: d_a_obj_zdoor
 
 - object: files/rel/RVL/Debug/d_a_obj_zraMarkD.rel
   hash: 9d78b0f439b8c824be06ef23ef614f4a35e4c85c
   symbols: config/ShieldD/rels/d_a_obj_zraMarkD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zraMarkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zraMarkD.map
+  name: d_a_obj_zraMark
 
 - object: files/rel/RVL/Debug/d_a_obj_zra_freezeD.rel
   hash: 6cb249e695532c035c5faffd44397b8d58083ec6
   symbols: config/ShieldD/rels/d_a_obj_zra_freezeD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zra_freezeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zra_freezeD.map
+  name: d_a_obj_zra_freeze
 
 - object: files/rel/RVL/Debug/d_a_obj_zra_rockD.rel
   hash: 5b0a5242bb4c4685d7ca3070fd8e5abde0e839e0
   symbols: config/ShieldD/rels/d_a_obj_zra_rockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zra_rockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zra_rockD.map
+  name: d_a_obj_zra_rock
 
 - object: files/rel/RVL/Debug/d_a_obj_zrTuraraD.rel
   hash: 84a8a3426d8295e9eb42f3d16d0e0d8204535ecc
   symbols: config/ShieldD/rels/d_a_obj_zrTuraraD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zrTuraraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zrTuraraD.map
+  name: d_a_obj_zrTurara
 
 - object: files/rel/RVL/Debug/d_a_obj_zrTuraraRockD.rel
   hash: b131c044df128b33fcb4ee6d83952789b98b19bf
   symbols: config/ShieldD/rels/d_a_obj_zrTuraraRockD/symbols.txt
   splits: config/ShieldD/rels/d_a_obj_zrTuraraRockD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_obj_zrTuraraRockD.map
+  name: d_a_obj_zrTuraraRock
 
 - object: files/rel/RVL/Debug/d_a_passer_mngD.rel
   hash: e5b74698313f33a77dcfa4674a42839ac9e98bc4
   symbols: config/ShieldD/rels/d_a_passer_mngD/symbols.txt
   splits: config/ShieldD/rels/d_a_passer_mngD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_passer_mngD.map
+  name: d_a_passer_mng
 
 - object: files/rel/RVL/Debug/d_a_path_lineD.rel
   hash: 6cea405cf6a8ad01960919ea7978e3060d9ca4bd
   symbols: config/ShieldD/rels/d_a_path_lineD/symbols.txt
   splits: config/ShieldD/rels/d_a_path_lineD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_path_lineD.map
+  name: d_a_path_line
 
 - object: files/rel/RVL/Debug/d_a_peruD.rel
   hash: 362722d81bc392eebd4e80470f6580c2bac2ebf6
   symbols: config/ShieldD/rels/d_a_peruD/symbols.txt
   splits: config/ShieldD/rels/d_a_peruD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_peruD.map
+  name: d_a_peru
 
 - object: files/rel/RVL/Debug/d_a_ppolampD.rel
   hash: d1ab5f5379853b64a646ab63cbf2c19499c6eb23
   symbols: config/ShieldD/rels/d_a_ppolampD/symbols.txt
   splits: config/ShieldD/rels/d_a_ppolampD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_ppolampD.map
+  name: d_a_ppolamp
 
 - object: files/rel/RVL/Debug/d_a_scene_exit2D.rel
   hash: 83a7c1bd8f448ad1523457a173e42036706fd51f
   symbols: config/ShieldD/rels/d_a_scene_exit2D/symbols.txt
   splits: config/ShieldD/rels/d_a_scene_exit2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_scene_exit2D.map
+  name: d_a_scene_exit2
 
 - object: files/rel/RVL/Debug/d_a_scene_exitD.rel
   hash: b6b83780e0a80ce06348a04e318209c920641f42
   symbols: config/ShieldD/rels/d_a_scene_exitD/symbols.txt
   splits: config/ShieldD/rels/d_a_scene_exitD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_scene_exitD.map
+  name: d_a_scene_exit
 
 - object: files/rel/RVL/Debug/d_a_set_bgobjD.rel
   hash: 0a9e0cb82357ce434962a7d98cd8625a5753de2f
   symbols: config/ShieldD/rels/d_a_set_bgobjD/symbols.txt
   splits: config/ShieldD/rels/d_a_set_bgobjD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_set_bgobjD.map
+  name: d_a_set_bgobj
 
 - object: files/rel/RVL/Debug/d_a_skip_2DD.rel
   hash: d2e58cad7d6458c96f5ebd529b174e9e56003d5b
   symbols: config/ShieldD/rels/d_a_skip_2DD/symbols.txt
   splits: config/ShieldD/rels/d_a_skip_2DD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_skip_2DD.map
+  name: d_a_skip_2D
 
 - object: files/rel/RVL/Debug/d_a_spinnerD.rel
   hash: ef1f1310cd43dd778aa95f63136edcb3cab71f9d
   symbols: config/ShieldD/rels/d_a_spinnerD/symbols.txt
   splits: config/ShieldD/rels/d_a_spinnerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_spinnerD.map
+  name: d_a_spinner
 
 - object: files/rel/RVL/Debug/d_a_sqD.rel
   hash: ffd46e227558dc037a65b02ea422383436a01c59
   symbols: config/ShieldD/rels/d_a_sqD/symbols.txt
   splits: config/ShieldD/rels/d_a_sqD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_sqD.map
+  name: d_a_sq
 
 - object: files/rel/RVL/Debug/d_a_startAndGoalD.rel
   hash: 668311cf754e506d6b57e4d223558cbac1d9a5ad
   symbols: config/ShieldD/rels/d_a_startAndGoalD/symbols.txt
   splits: config/ShieldD/rels/d_a_startAndGoalD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_startAndGoalD.map
+  name: d_a_startAndGoal
 
 - object: files/rel/RVL/Debug/d_a_suspendD.rel
   hash: 406dd216fe78faf8334c1c37ecd6235c882a204d
   symbols: config/ShieldD/rels/d_a_suspendD/symbols.txt
   splits: config/ShieldD/rels/d_a_suspendD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_suspendD.map
+  name: d_a_suspend
 
 - object: files/rel/RVL/Debug/d_a_swBallD.rel
   hash: abeb0a20c0ca83908f03f5e524c250660d1ce840
   symbols: config/ShieldD/rels/d_a_swBallD/symbols.txt
   splits: config/ShieldD/rels/d_a_swBallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_swBallD.map
+  name: d_a_swBall
 
 - object: files/rel/RVL/Debug/d_a_swhit0D.rel
   hash: 3eb1b951990a1663b14e988c82fecea34317d747
   symbols: config/ShieldD/rels/d_a_swhit0D/symbols.txt
   splits: config/ShieldD/rels/d_a_swhit0D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_swhit0D.map
+  name: d_a_swhit0
 
 - object: files/rel/RVL/Debug/d_a_swLBallD.rel
   hash: eced5dfaa503cb85d0788d08508bcfd9ac54c7df
   symbols: config/ShieldD/rels/d_a_swLBallD/symbols.txt
   splits: config/ShieldD/rels/d_a_swLBallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_swLBallD.map
+  name: d_a_swLBall
 
 - object: files/rel/RVL/Debug/d_a_swTimeD.rel
   hash: 6daf2b24eee7c1aed381b175c4fbebd7bf04ede7
   symbols: config/ShieldD/rels/d_a_swTimeD/symbols.txt
   splits: config/ShieldD/rels/d_a_swTimeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_swTimeD.map
+  name: d_a_swTime
 
 - object: files/rel/RVL/Debug/d_a_tag_ajnotD.rel
   hash: 23616227eb3d2e03a6ed9ce682b1ce679ac7b596
   symbols: config/ShieldD/rels/d_a_tag_ajnotD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_ajnotD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_ajnotD.map
+  name: d_a_tag_ajnot
 
 - object: files/rel/RVL/Debug/d_a_tag_allmatoD.rel
   hash: 7e408f30eb99cf9a18d8b4dd120fd872a1e53057
   symbols: config/ShieldD/rels/d_a_tag_allmatoD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_allmatoD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_allmatoD.map
+  name: d_a_tag_allmato
 
 - object: files/rel/RVL/Debug/d_a_tag_arenaD.rel
   hash: cea9d9e36c904d9f0df86c6ac9c498ac25337717
   symbols: config/ShieldD/rels/d_a_tag_arenaD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_arenaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_arenaD.map
+  name: d_a_tag_arena
 
 - object: files/rel/RVL/Debug/d_a_tag_assistanceD.rel
   hash: fcc9c680e309807cc0a6186d0dee3c2b40f10ec3
   symbols: config/ShieldD/rels/d_a_tag_assistanceD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_assistanceD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_assistanceD.map
+  name: d_a_tag_assistance
 
 - object: files/rel/RVL/Debug/d_a_tag_attack_itemD.rel
   hash: 79dfd6c97234c25a81e71cbafa5dfa5abc295a83
   symbols: config/ShieldD/rels/d_a_tag_attack_itemD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_attack_itemD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_attack_itemD.map
+  name: d_a_tag_attack_item
 
 - object: files/rel/RVL/Debug/d_a_tag_attentionD.rel
   hash: e7881920457f22edf7bb6e1a3b7eddd6154dca03
   symbols: config/ShieldD/rels/d_a_tag_attentionD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_attentionD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_attentionD.map
+  name: d_a_tag_attention
 
 - object: files/rel/RVL/Debug/d_a_tag_bottle_itemD.rel
   hash: e22a5e25f4db37e7f94d53fd2ae5518f9efb7849
   symbols: config/ShieldD/rels/d_a_tag_bottle_itemD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_bottle_itemD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_bottle_itemD.map
+  name: d_a_tag_bottle_item
 
 - object: files/rel/RVL/Debug/d_a_tag_cameraD.rel
   hash: 35cde6f07c4fa45cdefbe10ecf4319e964182cea
   symbols: config/ShieldD/rels/d_a_tag_cameraD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_cameraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_cameraD.map
+  name: d_a_tag_camera
 
 - object: files/rel/RVL/Debug/d_a_tag_chgrestartD.rel
   hash: a9eb3332528f9861cb5addb0ae677af1bf67f41b
   symbols: config/ShieldD/rels/d_a_tag_chgrestartD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_chgrestartD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_chgrestartD.map
+  name: d_a_tag_chgrestart
 
 - object: files/rel/RVL/Debug/d_a_tag_chkpointD.rel
   hash: ee795c93a369e6e16c8a0d990e179020a0a5cfac
   symbols: config/ShieldD/rels/d_a_tag_chkpointD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_chkpointD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_chkpointD.map
+  name: d_a_tag_chkpoint
 
 - object: files/rel/RVL/Debug/d_a_tag_CstaSwD.rel
   hash: f6340d17902e010bbc250c848a8ef865a7fc893d
   symbols: config/ShieldD/rels/d_a_tag_CstaSwD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_CstaSwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_CstaSwD.map
+  name: d_a_tag_CstaSw
 
 - object: files/rel/RVL/Debug/d_a_tag_cswD.rel
   hash: 8d827a864bd4aa941f9239ba345a71205ae4608e
   symbols: config/ShieldD/rels/d_a_tag_cswD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_cswD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_cswD.map
+  name: d_a_tag_csw
 
 - object: files/rel/RVL/Debug/d_a_tag_escapeD.rel
   hash: 0bf01d097a43031873b58b766d13d0f600b3896c
   symbols: config/ShieldD/rels/d_a_tag_escapeD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_escapeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_escapeD.map
+  name: d_a_tag_escape
 
 - object: files/rel/RVL/Debug/d_a_tag_evtareaD.rel
   hash: 304eb28db6bae71249f621dbdb9f401d551704a6
   symbols: config/ShieldD/rels/d_a_tag_evtareaD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_evtareaD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_evtareaD.map
+  name: d_a_tag_evtarea
 
 - object: files/rel/RVL/Debug/d_a_tag_evtD.rel
   hash: 0d4d47ea3e8a49e6c7752a12f89fdf556c3d1fd8
   symbols: config/ShieldD/rels/d_a_tag_evtD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_evtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_evtD.map
+  name: d_a_tag_evt
 
 - object: files/rel/RVL/Debug/d_a_tag_evtmsgD.rel
   hash: 0dc14cde607a9563962d973c851f6c6647ed0bbe
   symbols: config/ShieldD/rels/d_a_tag_evtmsgD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_evtmsgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_evtmsgD.map
+  name: d_a_tag_evtmsg
 
 - object: files/rel/RVL/Debug/d_a_tag_firewallD.rel
   hash: ff87e048d9b95f682bf3c1ca1f6f70d4a3dafb79
   symbols: config/ShieldD/rels/d_a_tag_firewallD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_firewallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_firewallD.map
+  name: d_a_tag_firewall
 
 - object: files/rel/RVL/Debug/d_a_tag_graD.rel
   hash: 043458d1b36525577742daf27015014d835614d9
   symbols: config/ShieldD/rels/d_a_tag_graD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_graD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_graD.map
+  name: d_a_tag_gra
 
 - object: files/rel/RVL/Debug/d_a_tag_gstartD.rel
   hash: ce90c0da7377e40f827f113be48ce70ef4e90368
   symbols: config/ShieldD/rels/d_a_tag_gstartD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_gstartD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_gstartD.map
+  name: d_a_tag_gstart
 
 - object: files/rel/RVL/Debug/d_a_tag_guardD.rel
   hash: 7d92ff93f33346b77650bee63087a8e8ad921ddb
   symbols: config/ShieldD/rels/d_a_tag_guardD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_guardD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_guardD.map
+  name: d_a_tag_guard
 
 - object: files/rel/RVL/Debug/d_a_tag_hinitD.rel
   hash: e13f62f61642e4c20bdf6134e458cbfcaabc1b02
   symbols: config/ShieldD/rels/d_a_tag_hinitD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_hinitD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_hinitD.map
+  name: d_a_tag_hinit
 
 - object: files/rel/RVL/Debug/d_a_tag_hjumpD.rel
   hash: b5c1e48b2c12cbe1f0a448d088e39649c84c6db9
   symbols: config/ShieldD/rels/d_a_tag_hjumpD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_hjumpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_hjumpD.map
+  name: d_a_tag_hjump
 
 - object: files/rel/RVL/Debug/d_a_tag_howlD.rel
   hash: 6ecd53e0da7b1f42dddd337f1aa66da5c49c5a4f
   symbols: config/ShieldD/rels/d_a_tag_howlD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_howlD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_howlD.map
+  name: d_a_tag_howl
 
 - object: files/rel/RVL/Debug/d_a_tag_hstopD.rel
   hash: 7c9f244259fffbda3a22b05ea64a6095389f8f43
   symbols: config/ShieldD/rels/d_a_tag_hstopD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_hstopD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_hstopD.map
+  name: d_a_tag_hstop
 
 - object: files/rel/RVL/Debug/d_a_tag_instructionD.rel
   hash: 81cf49fe5421090f633d738a6eee4a15890fec2f
   symbols: config/ShieldD/rels/d_a_tag_instructionD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_instructionD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_instructionD.map
+  name: d_a_tag_instruction
 
 - object: files/rel/RVL/Debug/d_a_tag_kago_fallD.rel
   hash: c7fffe27316bb882d62cc402b2679245b52c3f97
   symbols: config/ShieldD/rels/d_a_tag_kago_fallD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_kago_fallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_kago_fallD.map
+  name: d_a_tag_kago_fall
 
 - object: files/rel/RVL/Debug/d_a_tag_kmsgD.rel
   hash: 423d9e42bf0f4de70a43279613cdaa258d0ab15c
   symbols: config/ShieldD/rels/d_a_tag_kmsgD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_kmsgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_kmsgD.map
+  name: d_a_tag_kmsg
 
 - object: files/rel/RVL/Debug/d_a_tag_lanternD.rel
   hash: 02ebc329ac14af00b8b9df3bff0d5a62250838b2
   symbols: config/ShieldD/rels/d_a_tag_lanternD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_lanternD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_lanternD.map
+  name: d_a_tag_lantern
 
 - object: files/rel/RVL/Debug/d_a_tag_lightballD.rel
   hash: 84bc7d3ab6366ebedae81d67d78b3b0f7de24594
   symbols: config/ShieldD/rels/d_a_tag_lightballD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_lightballD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_lightballD.map
+  name: d_a_tag_lightball
 
 - object: files/rel/RVL/Debug/d_a_tag_lv2prchkD.rel
   hash: 74d2e5e0d66754cc03dde9e35dd6c9cb16c085ba
   symbols: config/ShieldD/rels/d_a_tag_lv2prchkD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_lv2prchkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_lv2prchkD.map
+  name: d_a_tag_lv2prchk
 
 - object: files/rel/RVL/Debug/d_a_tag_lv5soupD.rel
   hash: 31e01eb9740ac1f42abddd80e8a15fad04283f84
   symbols: config/ShieldD/rels/d_a_tag_lv5soupD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_lv5soupD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_lv5soupD.map
+  name: d_a_tag_lv5soup
 
 - object: files/rel/RVL/Debug/d_a_tag_lv6CstaSwD.rel
   hash: a302910939340103022bd581a3c687bf625f507a
   symbols: config/ShieldD/rels/d_a_tag_lv6CstaSwD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_lv6CstaSwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_lv6CstaSwD.map
+  name: d_a_tag_lv6CstaSw
 
 - object: files/rel/RVL/Debug/d_a_tag_Lv6GateD.rel
   hash: c3ab3d25528a6769ecef08e4a791f31d1c628769
   symbols: config/ShieldD/rels/d_a_tag_Lv6GateD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_Lv6GateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_Lv6GateD.map
+  name: d_a_tag_Lv6Gate
 
 - object: files/rel/RVL/Debug/d_a_tag_Lv7GateD.rel
   hash: 07a0d7b461bada891819a97af8836f0962706fe7
   symbols: config/ShieldD/rels/d_a_tag_Lv7GateD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_Lv7GateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_Lv7GateD.map
+  name: d_a_tag_Lv7Gate
 
 - object: files/rel/RVL/Debug/d_a_tag_Lv8GateD.rel
   hash: 158c2cefb9dd17519bb434f88de4dcb1aa7e9ffe
   symbols: config/ShieldD/rels/d_a_tag_Lv8GateD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_Lv8GateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_Lv8GateD.map
+  name: d_a_tag_Lv8Gate
 
 - object: files/rel/RVL/Debug/d_a_tag_magneD.rel
   hash: e90a07b63a579d41c3ee92ed73ba37272b4c1fbe
   symbols: config/ShieldD/rels/d_a_tag_magneD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_magneD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_magneD.map
+  name: d_a_tag_magne
 
 - object: files/rel/RVL/Debug/d_a_tag_mhintD.rel
   hash: e0b678b9cfee8c32492740cab832051999eb615f
   symbols: config/ShieldD/rels/d_a_tag_mhintD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_mhintD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_mhintD.map
+  name: d_a_tag_mhint
 
 - object: files/rel/RVL/Debug/d_a_tag_mistD.rel
   hash: c16a0255b2abdfd4c5c3beadebad740f05bde972
   symbols: config/ShieldD/rels/d_a_tag_mistD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_mistD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_mistD.map
+  name: d_a_tag_mist
 
 - object: files/rel/RVL/Debug/d_a_tag_mmsgD.rel
   hash: 34157c51d46aa1e9c529835ecf40496c85e384f9
   symbols: config/ShieldD/rels/d_a_tag_mmsgD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_mmsgD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_mmsgD.map
+  name: d_a_tag_mmsg
 
 - object: files/rel/RVL/Debug/d_a_tag_mstopD.rel
   hash: dddb4c5cbaec6d7cccb272404bc7a105d44cf009
   symbols: config/ShieldD/rels/d_a_tag_mstopD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_mstopD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_mstopD.map
+  name: d_a_tag_mstop
 
 - object: files/rel/RVL/Debug/d_a_tag_mwaitD.rel
   hash: 671871d9e6eb640afc782d5b0bf646a972b76b24
   symbols: config/ShieldD/rels/d_a_tag_mwaitD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_mwaitD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_mwaitD.map
+  name: d_a_tag_mwait
 
 - object: files/rel/RVL/Debug/d_a_tag_myna2D.rel
   hash: a59fe6cf5fa8fb890a807c25a8f47e2f2c131097
   symbols: config/ShieldD/rels/d_a_tag_myna2D/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_myna2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_myna2D.map
+  name: d_a_tag_myna2
 
 - object: files/rel/RVL/Debug/d_a_tag_myna_lightD.rel
   hash: 70be82ea759c804b477a9c4d0dbd844dcfbba97b
   symbols: config/ShieldD/rels/d_a_tag_myna_lightD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_myna_lightD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_myna_lightD.map
+  name: d_a_tag_myna_light
 
 - object: files/rel/RVL/Debug/d_a_tag_pachiD.rel
   hash: d3f7bcd18adca25cd52aa92276b81933a5826e13
   symbols: config/ShieldD/rels/d_a_tag_pachiD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_pachiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_pachiD.map
+  name: d_a_tag_pachi
 
 - object: files/rel/RVL/Debug/d_a_tag_poFireD.rel
   hash: 4e026b1ffe8b475157a89096fb65dba727c6c3e0
   symbols: config/ShieldD/rels/d_a_tag_poFireD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_poFireD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_poFireD.map
+  name: d_a_tag_poFire
 
 - object: files/rel/RVL/Debug/d_a_tag_pushD.rel
   hash: 43df0c12ce76f81183abce0021334fe23e5e657d
   symbols: config/ShieldD/rels/d_a_tag_pushD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_pushD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_pushD.map
+  name: d_a_tag_push
 
 - object: files/rel/RVL/Debug/d_a_tag_qsD.rel
   hash: a36aac86fff39012aa1819bc7f9975601c912184
   symbols: config/ShieldD/rels/d_a_tag_qsD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_qsD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_qsD.map
+  name: d_a_tag_qs
 
 - object: files/rel/RVL/Debug/d_a_tag_ret_roomD.rel
   hash: 6af3cc891cf4e86c08cdb627a1264df8e3459337
   symbols: config/ShieldD/rels/d_a_tag_ret_roomD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_ret_roomD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_ret_roomD.map
+  name: d_a_tag_ret_room
 
 - object: files/rel/RVL/Debug/d_a_tag_river_backD.rel
   hash: f841096804d6efba616f4505605625975ed626bf
   symbols: config/ShieldD/rels/d_a_tag_river_backD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_river_backD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_river_backD.map
+  name: d_a_tag_river_back
 
 - object: files/rel/RVL/Debug/d_a_tag_rmbit_swD.rel
   hash: 3468b4bc76c221d8b415dec86c223384d85fab3a
   symbols: config/ShieldD/rels/d_a_tag_rmbit_swD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_rmbit_swD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_rmbit_swD.map
+  name: d_a_tag_rmbit_sw
 
 - object: files/rel/RVL/Debug/d_a_tag_scheduleD.rel
   hash: 20678563216cade8cc09e11730608f8a9946423c
   symbols: config/ShieldD/rels/d_a_tag_scheduleD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_scheduleD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_scheduleD.map
+  name: d_a_tag_schedule
 
 - object: files/rel/RVL/Debug/d_a_tag_setBallD.rel
   hash: a110723b2e3e4d87e5c09c1207215a490a133e31
   symbols: config/ShieldD/rels/d_a_tag_setBallD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_setBallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_setBallD.map
+  name: d_a_tag_setBall
 
 - object: files/rel/RVL/Debug/d_a_tag_setrestartD.rel
   hash: e9e5ed4075edc545966525c46a97f35c9b9a290b
   symbols: config/ShieldD/rels/d_a_tag_setrestartD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_setrestartD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_setrestartD.map
+  name: d_a_tag_setrestart
 
 - object: files/rel/RVL/Debug/d_a_tag_shop_cameraD.rel
   hash: bcfcffdcba9510c661916f3d5e9ae5da9adcc586
   symbols: config/ShieldD/rels/d_a_tag_shop_cameraD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_shop_cameraD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_shop_cameraD.map
+  name: d_a_tag_shop_camera
 
 - object: files/rel/RVL/Debug/d_a_tag_shop_itemD.rel
   hash: ae817172b5b69b8555dc1859595ac83385236214
   symbols: config/ShieldD/rels/d_a_tag_shop_itemD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_shop_itemD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_shop_itemD.map
+  name: d_a_tag_shop_item
 
 - object: files/rel/RVL/Debug/d_a_tag_smk_emtD.rel
   hash: 7c142e1c6e95ccc0c6d953f7e63a447e707417fa
   symbols: config/ShieldD/rels/d_a_tag_smk_emtD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_smk_emtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_smk_emtD.map
+  name: d_a_tag_smk_emt
 
 - object: files/rel/RVL/Debug/d_a_tag_spinnerD.rel
   hash: 9659ea4cabe98e72ca5455cb5f956acf62f8d78a
   symbols: config/ShieldD/rels/d_a_tag_spinnerD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_spinnerD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_spinnerD.map
+  name: d_a_tag_spinner
 
 - object: files/rel/RVL/Debug/d_a_tag_sppathD.rel
   hash: 04cd12de15e47a74f012ac3288fe76b52f7fcd3f
   symbols: config/ShieldD/rels/d_a_tag_sppathD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_sppathD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_sppathD.map
+  name: d_a_tag_sppath
 
 - object: files/rel/RVL/Debug/d_a_tag_springD.rel
   hash: 21d6624ccb7181d3bfa7b4e4dee00028037fcbd2
   symbols: config/ShieldD/rels/d_a_tag_springD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_springD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_springD.map
+  name: d_a_tag_spring
 
 - object: files/rel/RVL/Debug/d_a_tag_ss_drinkD.rel
   hash: 4a9dcf67330911452da116083876af11b6f5d096
   symbols: config/ShieldD/rels/d_a_tag_ss_drinkD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_ss_drinkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_ss_drinkD.map
+  name: d_a_tag_ss_drink
 
 - object: files/rel/RVL/Debug/d_a_tag_statue_evtD.rel
   hash: baee87b6ee03a4c38e20a1acb2adb58abc7618c4
   symbols: config/ShieldD/rels/d_a_tag_statue_evtD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_statue_evtD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_statue_evtD.map
+  name: d_a_tag_statue_evt
 
 - object: files/rel/RVL/Debug/d_a_tag_streamD.rel
   hash: 8345a6e38a554dc1f6f0cf495417bfd239d02427
   symbols: config/ShieldD/rels/d_a_tag_streamD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_streamD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_streamD.map
+  name: d_a_tag_stream
 
 - object: files/rel/RVL/Debug/d_a_tag_telopD.rel
   hash: 7cdedbcceafc4d80d511cc46feda3d37ad3fc509
   symbols: config/ShieldD/rels/d_a_tag_telopD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_telopD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_telopD.map
+  name: d_a_tag_telop
 
 - object: files/rel/RVL/Debug/d_a_tag_theB_hintD.rel
   hash: 4eec97339f78e1d6648a9dfd4d96490390880c62
   symbols: config/ShieldD/rels/d_a_tag_theB_hintD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_theB_hintD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_theB_hintD.map
+  name: d_a_tag_theB_hint
 
 - object: files/rel/RVL/Debug/d_a_tag_TWgateD.rel
   hash: 9d36fb95387daec8da8c88771d31470283114b44
   symbols: config/ShieldD/rels/d_a_tag_TWgateD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_TWgateD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_TWgateD.map
+  name: d_a_tag_TWgate
 
 - object: files/rel/RVL/Debug/d_a_tag_wara_howlD.rel
   hash: 18233ed065e46b4b78c8ae084b1d7f3249c5e4ed
   symbols: config/ShieldD/rels/d_a_tag_wara_howlD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_wara_howlD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_wara_howlD.map
+  name: d_a_tag_wara_howl
 
 - object: files/rel/RVL/Debug/d_a_tag_watchgeD.rel
   hash: 03bb878ecb209c6a8e6b5e13536a3feae2b0e1a0
   symbols: config/ShieldD/rels/d_a_tag_watchgeD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_watchgeD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_watchgeD.map
+  name: d_a_tag_watchge
 
 - object: files/rel/RVL/Debug/d_a_tag_waterfallD.rel
   hash: 3790ed43bc244151b6ba45224e25b04261c9a77a
   symbols: config/ShieldD/rels/d_a_tag_waterfallD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_waterfallD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_waterfallD.map
+  name: d_a_tag_waterfall
 
 - object: files/rel/RVL/Debug/d_a_tag_wljumpD.rel
   hash: 70b538f8c31ecb9eb171cb023c6d4c9034ef7b81
   symbols: config/ShieldD/rels/d_a_tag_wljumpD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_wljumpD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_wljumpD.map
+  name: d_a_tag_wljump
 
 - object: files/rel/RVL/Debug/d_a_tag_yamiD.rel
   hash: f2d7a3362a93ad9b974511f2cd6e707fc6531190
   symbols: config/ShieldD/rels/d_a_tag_yamiD/symbols.txt
   splits: config/ShieldD/rels/d_a_tag_yamiD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tag_yamiD.map
+  name: d_a_tag_yami
 
 - object: files/rel/RVL/Debug/d_a_talkD.rel
   hash: f31cd7f4f46cdf7ce80ccc3ea3351ed902c32efd
   symbols: config/ShieldD/rels/d_a_talkD/symbols.txt
   splits: config/ShieldD/rels/d_a_talkD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_talkD.map
+  name: d_a_talk
 
 - object: files/rel/RVL/Debug/d_a_tbox2D.rel
   hash: 9b8e48aad91b1f8fe9f39e584d5a7c014f8417cd
   symbols: config/ShieldD/rels/d_a_tbox2D/symbols.txt
   splits: config/ShieldD/rels/d_a_tbox2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tbox2D.map
+  name: d_a_tbox2
 
 - object: files/rel/RVL/Debug/d_a_tboxD.rel
   hash: 7749e6a5fc50bb7eb1847e3d1df43768d0af278b
   symbols: config/ShieldD/rels/d_a_tboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_tboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tboxD.map
+  name: d_a_tbox
 
 - object: files/rel/RVL/Debug/d_a_tboxSwD.rel
   hash: 75bf3dc6c8843522f14f81e853276f0155de9a97
   symbols: config/ShieldD/rels/d_a_tboxSwD/symbols.txt
   splits: config/ShieldD/rels/d_a_tboxSwD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_tboxSwD.map
+  name: d_a_tboxSw
 
 - object: files/rel/RVL/Debug/d_a_vrbox2D.rel
   hash: b534a1ef13ef0077559630ac87cfae1b36783c3a
   symbols: config/ShieldD/rels/d_a_vrbox2D/symbols.txt
   splits: config/ShieldD/rels/d_a_vrbox2D/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_vrbox2D.map
+  name: d_a_vrbox2
 
 - object: files/rel/RVL/Debug/d_a_vrboxD.rel
   hash: eb33c7ad0071d5b8e5535fcba666e6cc1f275898
   symbols: config/ShieldD/rels/d_a_vrboxD/symbols.txt
   splits: config/ShieldD/rels/d_a_vrboxD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_vrboxD.map
+  name: d_a_vrbox
 
 - object: files/rel/RVL/Debug/d_a_warp_bugD.rel
   hash: 5d8ef81a5eb8d29390f43fa190ab4e89fda5e9e9
   symbols: config/ShieldD/rels/d_a_warp_bugD/symbols.txt
   splits: config/ShieldD/rels/d_a_warp_bugD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_warp_bugD.map
+  name: d_a_warp_bug
 
 - object: files/rel/RVL/Debug/d_a_ykgrD.rel
   hash: 56d9192f3bc9b5049271f1f42cb9d96255230a7a
   symbols: config/ShieldD/rels/d_a_ykgrD/symbols.txt
   splits: config/ShieldD/rels/d_a_ykgrD/splits.txt
   # map: orig/ShieldD/fixed_maps/d_a_ykgrD.map
+  name: d_a_ykgr
 
 - object: files/rel/RVL/Debug/f_pc_profile_lstD.rel
   hash: 9bfd57980a11ce205659a49378fe55d9d1e6d20c
   symbols: config/ShieldD/rels/f_pc_profile_lstD/symbols.txt
   splits: config/ShieldD/rels/f_pc_profile_lstD/splits.txt
   # map: orig/ShieldD/fixed_maps/f_pc_profile_lstD.map
+  name: f_pc_profile_lst
 
 extract:
 - symbol: black_tex


### PR DESCRIPTION
Debug version has "D" suffixes on all REL filenames which makes them inconsistent with retail. This is annoying because if you have objdiff inside a REL and switch between retail/debug it kicks you out and you have to manually refind the TU with the other name which really slows down the workflow.

This PR switches REL names to use the object name instead of the filename, which is the same between debug/retail. This causes a one-time break in history tracking, but debug only got added to tracking today anyways.