### PR TITLE
Update objdiff

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -189,7 +189,7 @@ if not config.non_matching:
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20250812"
 config.dtk_tag = "v1.6.2"
-config.objdiff_tag = "v3.0.0-beta.14"
+config.objdiff_tag = "v3.0.1"
 config.sjiswrap_tag = "v1.2.2"
 config.wibo_tag = "0.7.0"
 


### PR DESCRIPTION
This improves automatic data pairing, so TUs that have their matched data % undercounted due to the weak data from the pch should go back up to the correct % now.