### PR TITLE
Add PCH for JSystem

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -462,6 +462,11 @@ config.precompiled_headers = [
         "mw_version": MWVersion(config.version),
         "cflags": ["-lang=c++", *cflags_dolzel_rel],
     },
+    {
+        "source": "JSystem/JSystem.pch",
+        "mw_version": MWVersion(config.version),
+        "cflags": ["-lang=c++", *cflags_framework],
+    },
 ]
 config.libs = [
     {
@@ -832,7 +837,7 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JParticle/JPAKeyBlock.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01", "ShieldD"), "JSystem/JParticle/JPATexture.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JParticle/JPAResourceLoader.cpp"),
-            Object(Equivalent, "JSystem/JParticle/JPAEmitterManager.cpp"), # weak func order
+            Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/JParticle/JPAEmitterManager.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JParticle/JPAEmitter.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JParticle/JPAParticle.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JParticle/JPAMath.cpp"),
@@ -941,7 +946,7 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01", "ShieldD"), "JSystem/JAudio2/JAIAudible.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JAudio2/JAIAudience.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JAudio2/JAISe.cpp"),
-            Object(Equivalent, "JSystem/JAudio2/JAISeMgr.cpp"), # weak function order
+            Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/JAudio2/JAISeMgr.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/JAudio2/JAISeq.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JAudio2/JAISeqDataMgr.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/JAudio2/JAISeqMgr.cpp"),
@@ -1080,7 +1085,7 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTFont.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTResFont.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTDbPrint.cpp"),
-            Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTGamePad.cpp", extra_cflags=['-pragma "nosyminline on"']),
+            Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTGamePad.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTException.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTDirectPrint.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/JUtility/JUTAssert.cpp"),
@@ -1125,7 +1130,7 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/J3DGraphBase/J3DTransform.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/J3DGraphBase/J3DTexture.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/J3DGraphBase/J3DPacket.cpp"),
-            Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DShapeMtx.cpp", extra_cflags=['-pragma "nosyminline on"']),
+            Object(MatchingFor("GZ2E01", "GZ2J01"), "JSystem/J3DGraphBase/J3DShapeMtx.cpp"),
             Object(NonMatching, "JSystem/J3DGraphBase/J3DShapeDraw.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/J3DGraphBase/J3DShape.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "JSystem/J3DGraphBase/J3DMaterial.cpp"),

--- a/include/JSystem/JAudio2/JAISeMgr.h
+++ b/include/JSystem/JAudio2/JAISeMgr.h
@@ -56,7 +56,6 @@ public:
         field_0x4.field_0x0 = 0;
     }
 
-    /* 800078DC */ virtual ~JAISeCategoryMgr() {}
     /* 8029F8B0 */ virtual bool isUsingSeqData(JAISeqDataRegion const&);
     /* 8029F91C */ virtual int releaseSeqData(JAISeqDataRegion const&);
 
@@ -101,7 +100,6 @@ public:
     /* 802A0768 */ bool startSound(JAISoundID, JAISoundHandle*, JGeometry::TVec3<f32> const*);
     /* 802A08D0 */ int getNumActiveSe() const;
 
-    /* 802A08FC */ virtual ~JAISeMgr() {}
     /* 802A0168 */ virtual bool isUsingSeqData(JAISeqDataRegion const&);
     /* 802A01D8 */ virtual int releaseSeqData(JAISeqDataRegion const&);
 

--- a/include/JSystem/JSystem.h
+++ b/include/JSystem/JSystem.h
@@ -1,0 +1,10 @@
+#ifndef JSYSTEM_H
+#define JSYSTEM_H
+
+#ifdef __MWERKS__
+#include "JSystem/JSystem.mch" // IWYU pragma: export
+#else
+#include "JSystem/JSystem.pch" // IWYU pragma: export
+#endif
+
+#endif // DOLZEL_PCH

--- a/include/JSystem/JSystem.pch
+++ b/include/JSystem/JSystem.pch
@@ -1,0 +1,7 @@
+#ifndef JSYSTEM_PCH
+#define JSYSTEM_PCH
+
+#include "JSystem/JSupport/JSUList.h"
+#include "JSystem/J3DGraphBase/J3DShape.h"
+
+#endif // JSYSTEM_PCH

--- a/src/JSystem/J2DGraph/J2DAnimation.cpp
+++ b/src/JSystem/J2DGraph/J2DAnimation.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DAnimation.h"
 #include "JSystem/J2DGraph/J2DScreen.h"
 #include "JSystem/J3DGraphBase/J3DTexture.h"

--- a/src/JSystem/J2DGraph/J2DAnmLoader.cpp
+++ b/src/JSystem/J2DGraph/J2DAnmLoader.cpp
@@ -2,6 +2,8 @@
 // J2DAnmLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DAnmLoader.h"
 #include "JSystem/JSupport/JSupport.h"
 

--- a/src/JSystem/J2DGraph/J2DGrafContext.cpp
+++ b/src/JSystem/J2DGraph/J2DGrafContext.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DGrafContext.h"
 #include "dolphin/gx.h"
 

--- a/src/JSystem/J2DGraph/J2DManage.cpp
+++ b/src/JSystem/J2DGraph/J2DManage.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DManage.h"
 #include "JSystem/JSupport/JSUInputStream.h"
 #include "string.h"

--- a/src/JSystem/J2DGraph/J2DMatBlock.cpp
+++ b/src/JSystem/J2DGraph/J2DMatBlock.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J2DMatBlock
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DMatBlock.h"
 #include "JSystem/JUtility/JUTPalette.h"
 #include "JSystem/JUtility/JUTResFont.h"

--- a/src/JSystem/J2DGraph/J2DMaterial.cpp
+++ b/src/JSystem/J2DGraph/J2DMaterial.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J2DMaterial
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DMaterial.h"
 #include "JSystem/J3DGraphBase/J3DStruct.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/J2DGraph/J2DMaterialFactory.cpp
+++ b/src/JSystem/J2DGraph/J2DMaterialFactory.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J2DMaterialFactory
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DMaterialFactory.h"
 #include "JSystem/J2DGraph/J2DMaterial.h"
 #include "JSystem/J2DGraph/J2DScreen.h"

--- a/src/JSystem/J2DGraph/J2DOrthoGraph.cpp
+++ b/src/JSystem/J2DGraph/J2DOrthoGraph.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 #include "dolphin/gx.h"
 

--- a/src/JSystem/J2DGraph/J2DPane.cpp
+++ b/src/JSystem/J2DGraph/J2DPane.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DPane.h"
 #include "JSystem/J2DGraph/J2DAnimation.h"
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"

--- a/src/JSystem/J2DGraph/J2DPicture.cpp
+++ b/src/JSystem/J2DGraph/J2DPicture.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J2DPicture
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DPicture.h"
 #include "JSystem/J2DGraph/J2DScreen.h"
 #include "JSystem/J2DGraph/J2DMaterial.h"

--- a/src/JSystem/J2DGraph/J2DPictureEx.cpp
+++ b/src/JSystem/J2DGraph/J2DPictureEx.cpp
@@ -3,12 +3,13 @@
 // Translation Unit: J2DPictureEx
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DPictureEx.h"
 #include "JSystem/J2DGraph/J2DMaterial.h"
 #include "JSystem/J2DGraph/J2DScreen.h"
 #include "JSystem/JSupport/JSURandomInputStream.h"
 #include "JSystem/JUtility/JUTTexture.h"
-#include "dol2asm.h"
 #include "dolphin/types.h"
 
 /* 80303640-803036EC 2FDF80 00AC+00 1/0 0/0 0/0 .text

--- a/src/JSystem/J2DGraph/J2DPrint.cpp
+++ b/src/JSystem/J2DGraph/J2DPrint.cpp
@@ -1,9 +1,10 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DPrint.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JUtility/JUTFont.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include "global.h"
 
 /* 80451580-80451584 000A80 0004+00 3/3 0/0 0/0 .sbss            mStrBuff__8J2DPrint */
 char* J2DPrint::mStrBuff;

--- a/src/JSystem/J2DGraph/J2DScreen.cpp
+++ b/src/JSystem/J2DGraph/J2DScreen.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J2DScreen
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DScreen.h"
 #include "JSystem/J2DGraph/J2DMaterialFactory.h"
 #include "JSystem/J2DGraph/J2DPictureEx.h"

--- a/src/JSystem/J2DGraph/J2DTevs.cpp
+++ b/src/JSystem/J2DGraph/J2DTevs.cpp
@@ -2,6 +2,8 @@
 // J2DTevs
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DTevs.h"
 #include "JSystem/J2DGraph/J2DMatBlock.h"
 #include "math.h"

--- a/src/JSystem/J2DGraph/J2DTextBox.cpp
+++ b/src/JSystem/J2DGraph/J2DTextBox.cpp
@@ -3,11 +3,12 @@
 // Translation Unit: J2DTextBox
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DTextBox.h"
 #include "JSystem/J2DGraph/J2DPrint.h"
 #include "JSystem/JSupport/JSURandomInputStream.h"
 #include "JSystem/JUtility/JUTResFont.h"
-#include "dol2asm.h"
 
 /* 802FF660-802FF6D8 2F9FA0 0078+00 0/0 1/1 0/0 .text            __ct__10J2DTextBoxFv */
 J2DTextBox::J2DTextBox()

--- a/src/JSystem/J2DGraph/J2DTextBoxEx.cpp
+++ b/src/JSystem/J2DGraph/J2DTextBoxEx.cpp
@@ -2,6 +2,8 @@
 // J2DTextBoxEx
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DTextBoxEx.h"
 #include "JSystem/J2DGraph/J2DPrint.h"
 #include "JSystem/JSupport/JSURandomInputStream.h"

--- a/src/JSystem/J2DGraph/J2DWindow.cpp
+++ b/src/JSystem/J2DGraph/J2DWindow.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DWindow.h"
 #include "JSystem/JSupport/JSURandomInputStream.h"
 #include "JSystem/JUtility/JUTPalette.h"

--- a/src/JSystem/J2DGraph/J2DWindowEx.cpp
+++ b/src/JSystem/J2DGraph/J2DWindowEx.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J2DWindowEx
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J2DGraph/J2DWindowEx.h"
 #include "JSystem/JUtility/JUTTexture.h"
 #include "JSystem/JSupport/JSURandomInputStream.h"

--- a/src/JSystem/J3DGraphAnimator/J3DAnimation.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DAnimation.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DAnimation.h"
 #include "JSystem/J3DGraphBase/J3DStruct.h"
 #include "JSystem/JMath/JMath.h"

--- a/src/JSystem/J3DGraphAnimator/J3DCluster.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DCluster.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DCluster.h"
 #include "JSystem/J3DGraphAnimator/J3DAnimation.h"
 #include "JSystem/J3DGraphAnimator/J3DModel.h"

--- a/src/JSystem/J3DGraphAnimator/J3DJoint.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DJoint.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DJoint.h"
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
 #include "JSystem/J3DGraphAnimator/J3DModel.h"

--- a/src/JSystem/J3DGraphAnimator/J3DJointTree.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DJointTree.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DJointTree.h"
 #include "JSystem/J3DGraphAnimator/J3DMaterialAttach.h"
 #include "JSystem/J3DGraphAnimator/J3DShapeTable.h"

--- a/src/JSystem/J3DGraphAnimator/J3DMaterialAnm.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DMaterialAnm.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 

--- a/src/JSystem/J3DGraphAnimator/J3DMaterialAttach.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DMaterialAttach.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DMaterialAttach.h"
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"

--- a/src/JSystem/J3DGraphAnimator/J3DModel.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DModel.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"

--- a/src/JSystem/J3DGraphAnimator/J3DModelData.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DModelData.cpp
@@ -2,6 +2,8 @@
 // J3DModelData
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DModelData.h"
 #include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"

--- a/src/JSystem/J3DGraphAnimator/J3DMtxBuffer.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DMtxBuffer.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DMtxBuffer.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 #include "JSystem/J3DGraphLoader/J3DModelLoader.h"

--- a/src/JSystem/J3DGraphAnimator/J3DShapeTable.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DShapeTable.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DShapeTable.h"
 
 void J3DShapeTable::hide() {

--- a/src/JSystem/J3DGraphAnimator/J3DSkinDeform.cpp
+++ b/src/JSystem/J3DGraphAnimator/J3DSkinDeform.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphAnimator/J3DSkinDeform.h"
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/J3DGraphBase/J3DDrawBuffer.cpp
+++ b/src/JSystem/J3DGraphBase/J3DDrawBuffer.cpp
@@ -3,6 +3,8 @@
  *
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DDrawBuffer.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/J3DGraphBase/J3DGD.cpp
+++ b/src/JSystem/J3DGraphBase/J3DGD.cpp
@@ -2,6 +2,8 @@
 // J3DGD
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DGD.h"
 #include "JSystem/J3DGraphBase/J3DFifo.h"
 

--- a/src/JSystem/J3DGraphBase/J3DMatBlock.cpp
+++ b/src/JSystem/J3DGraphBase/J3DMatBlock.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DMatBlock.h"
 #include "JSystem/J3DGraphBase/J3DPacket.h"
 #include "JSystem/J3DGraphBase/J3DSys.h"

--- a/src/JSystem/J3DGraphBase/J3DMaterial.cpp
+++ b/src/JSystem/J3DGraphBase/J3DMaterial.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 #include "JSystem/J3DGraphBase/J3DGD.h"
 

--- a/src/JSystem/J3DGraphBase/J3DPacket.cpp
+++ b/src/JSystem/J3DGraphBase/J3DPacket.cpp
@@ -1,10 +1,11 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DPacket.h"
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/J3DGraphBase/J3DDrawBuffer.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 #include "JSystem/J3DGraphBase/J3DShapeMtx.h"
 #include "JSystem/JKernel/JKRHeap.h"
-#include <dolphin/os.h>
 #include <dolphin/os.h>
 #include "string.h"
 #include "global.h"

--- a/src/JSystem/J3DGraphBase/J3DShape.cpp
+++ b/src/JSystem/J3DGraphBase/J3DShape.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DShape.h"
 #include "JSystem/J3DGraphBase/J3DPacket.h"
 #include "JSystem/J3DGraphBase/J3DVertex.h"

--- a/src/JSystem/J3DGraphBase/J3DShapeDraw.cpp
+++ b/src/JSystem/J3DGraphBase/J3DShapeDraw.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DShapeDraw.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include <string.h>

--- a/src/JSystem/J3DGraphBase/J3DShapeMtx.cpp
+++ b/src/JSystem/J3DGraphBase/J3DShapeMtx.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DShapeMtx.h"
 #include "JSystem/J3DGraphAnimator/J3DModel.h"
 #include "JSystem/J3DGraphBase/J3DFifo.h"

--- a/src/JSystem/J3DGraphBase/J3DStruct.cpp
+++ b/src/JSystem/J3DGraphBase/J3DStruct.cpp
@@ -2,6 +2,8 @@
 // J3DStruct
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DStruct.h"
 #include "JSystem/JMath/JMath.h"
 

--- a/src/JSystem/J3DGraphBase/J3DSys.cpp
+++ b/src/JSystem/J3DGraphBase/J3DSys.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DSys.h"
 #include "JSystem/J3DGraphBase/J3DTevs.h"
 #include "JSystem/J3DGraphBase/J3DTexture.h"

--- a/src/JSystem/J3DGraphBase/J3DTevs.cpp
+++ b/src/JSystem/J3DGraphBase/J3DTevs.cpp
@@ -2,6 +2,8 @@
 // J3DTevs
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DTevs.h"
 #include "JSystem/J3DGraphBase/J3DGD.h"
 #include "JSystem/J3DGraphBase/J3DMatBlock.h"

--- a/src/JSystem/J3DGraphBase/J3DTexture.cpp
+++ b/src/JSystem/J3DGraphBase/J3DTexture.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DTexture.h"
 #include "JSystem/J3DAssert.h"
 

--- a/src/JSystem/J3DGraphBase/J3DTransform.cpp
+++ b/src/JSystem/J3DGraphBase/J3DTransform.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DTransform.h"
 #include "JSystem/J3DGraphBase/J3DStruct.h"
 #include "JSystem/JMath/JMATrigonometric.h"

--- a/src/JSystem/J3DGraphBase/J3DVertex.cpp
+++ b/src/JSystem/J3DGraphBase/J3DVertex.cpp
@@ -1,9 +1,10 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphBase/J3DVertex.h"
 #include "JSystem/J3DGraphAnimator/J3DJointTree.h"
 #include "JSystem/J3DGraphBase/J3DSys.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include <string.h>
-#include "global.h"
 
 /* 80310EF8-80310F78 30B838 0080+00 0/0 1/1 0/0 .text            __ct__13J3DVertexDataFv */
 J3DVertexData::J3DVertexData() {

--- a/src/JSystem/J3DGraphLoader/J3DAnmLoader.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DAnmLoader.cpp
@@ -2,6 +2,8 @@
 // J3DAnmLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DAnmLoader.h"
 #include "JSystem/JSupport/JSupport.h"
 #include "dolphin/os.h"

--- a/src/JSystem/J3DGraphLoader/J3DClusterLoader.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DClusterLoader.cpp
@@ -2,6 +2,8 @@
 // J3DClusterLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DClusterLoader.h"
 #include "JSystem/J3DGraphAnimator/J3DSkinDeform.h"
 #include "JSystem/JSupport/JSupport.h"

--- a/src/JSystem/J3DGraphLoader/J3DJointFactory.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DJointFactory.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DJointFactory
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DJointFactory.h"
 #include "JSystem/J3DGraphLoader/J3DModelLoader.h"
 #include "JSystem/J3DGraphAnimator/J3DJoint.h"

--- a/src/JSystem/J3DGraphLoader/J3DMaterialFactory.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DMaterialFactory.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DMaterialFactory
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DMaterialFactory.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 #include "JSystem/JMath/JMath.h"

--- a/src/JSystem/J3DGraphLoader/J3DMaterialFactory_v21.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DMaterialFactory_v21.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DMaterialFactory_v21
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DMaterialFactory_v21.h"
 #include "JSystem/J3DGraphLoader/J3DMaterialFactory.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"

--- a/src/JSystem/J3DGraphLoader/J3DModelLoader.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DModelLoader.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DModelLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DModelLoader.h"
 #include "JSystem/J3DGraphLoader/J3DJointFactory.h"
 #include "JSystem/J3DGraphLoader/J3DMaterialFactory.h"

--- a/src/JSystem/J3DGraphLoader/J3DModelLoaderCalcSize.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DModelLoaderCalcSize.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DModelLoaderCalcSize
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DModelLoaderCalcSize.h"
 #include "JSystem/J3DGraphLoader/J3DModelLoader.h"
 #include "JSystem/J3DGraphLoader/J3DShapeFactory.h"

--- a/src/JSystem/J3DGraphLoader/J3DShapeFactory.cpp
+++ b/src/JSystem/J3DGraphLoader/J3DShapeFactory.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DShapeFactory
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DGraphLoader/J3DShapeFactory.h"
 #include "JSystem/J3DGraphBase/J3DShape.h"
 #include "JSystem/J3DGraphBase/J3DShapeMtx.h"

--- a/src/JSystem/J3DU/J3DUClipper.cpp
+++ b/src/JSystem/J3DU/J3DUClipper.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DUClipper
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DU/J3DUClipper.h"
 #include "math.h"
 

--- a/src/JSystem/J3DU/J3DUDL.cpp
+++ b/src/JSystem/J3DU/J3DUDL.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: J3DUDL
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/J3DU/J3DUDL.h"
 #include "JSystem/J3DGraphBase/J3DShapeMtx.h"
 

--- a/src/JSystem/JAudio2/JAIAudible.cpp
+++ b/src/JSystem/JAudio2/JAIAudible.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAIAudible.h"
 
 JAIAudible::~JAIAudible() {}

--- a/src/JSystem/JAudio2/JAIAudience.cpp
+++ b/src/JSystem/JAudio2/JAIAudience.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAIAudience.h"
 
 JAIAudience::~JAIAudience() {}

--- a/src/JSystem/JAudio2/JAISe.cpp
+++ b/src/JSystem/JAudio2/JAISe.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISe
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISe.h"
 #include "JSystem/JAudio2/JAIAudience.h"
 #include "JSystem/JAudio2/JAISeMgr.h"

--- a/src/JSystem/JAudio2/JAISeMgr.cpp
+++ b/src/JSystem/JAudio2/JAISeMgr.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISeMgr
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISeMgr.h"
 #include "JSystem/JAudio2/JAISoundHandles.h"
 #include "JSystem/JAudio2/JAISoundInfo.h"

--- a/src/JSystem/JAudio2/JAISeq.cpp
+++ b/src/JSystem/JAudio2/JAISeq.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISeq
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISeq.h"
 #include "JSystem/JAudio2/JAISeqMgr.h"
 #include "JSystem/JAudio2/JAISoundChild.h"

--- a/src/JSystem/JAudio2/JAISeqDataMgr.cpp
+++ b/src/JSystem/JAudio2/JAISeqDataMgr.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISeqDataMgr.h"
 
 JAISeqDataUser::~JAISeqDataUser() {}

--- a/src/JSystem/JAudio2/JAISeqMgr.cpp
+++ b/src/JSystem/JAudio2/JAISeqMgr.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISeqMgr
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISeqMgr.h"
 #include "JSystem/JAudio2/JAISeq.h"
 #include "JSystem/JAudio2/JAISoundHandles.h"

--- a/src/JSystem/JAudio2/JAISound.cpp
+++ b/src/JSystem/JAudio2/JAISound.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISound
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISound.h"
 #include "JSystem/JAudio2/JAIAudience.h"
 #include "JSystem/JAudio2/JAISoundHandles.h"

--- a/src/JSystem/JAudio2/JAISoundChild.cpp
+++ b/src/JSystem/JAudio2/JAISoundChild.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISoundChild.h"
 #include "JSystem/JAudio2/JASTrack.h"
 

--- a/src/JSystem/JAudio2/JAISoundHandles.cpp
+++ b/src/JSystem/JAudio2/JAISoundHandles.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISoundHandles
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISoundHandles.h"
 
 //

--- a/src/JSystem/JAudio2/JAISoundInfo.cpp
+++ b/src/JSystem/JAudio2/JAISoundInfo.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAISoundInfo
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISoundInfo.h"
 
 //

--- a/src/JSystem/JAudio2/JAISoundParams.cpp
+++ b/src/JSystem/JAudio2/JAISoundParams.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISoundParams.h"
 
 void JAISoundParamsMove::moveVolume(f32 newValue, u32 count) {

--- a/src/JSystem/JAudio2/JAISoundStarter.cpp
+++ b/src/JSystem/JAudio2/JAISoundStarter.cpp
@@ -2,6 +2,8 @@
 // JAISoundStarter
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAISoundStarter.h"
 #include "JSystem/JAudio2/JAISoundHandles.h"
 

--- a/src/JSystem/JAudio2/JAIStream.cpp
+++ b/src/JSystem/JAudio2/JAIStream.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAIStream
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAIStream.h"
 #include "JSystem/JAudio2/JAIStreamMgr.h"
 #include "JSystem/JAudio2/JAISoundChild.h"

--- a/src/JSystem/JAudio2/JAIStreamDataMgr.cpp
+++ b/src/JSystem/JAudio2/JAIStreamDataMgr.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAIStreamDataMgr.h"
 
 JAIStreamDataMgr::~JAIStreamDataMgr() {}

--- a/src/JSystem/JAudio2/JAIStreamMgr.cpp
+++ b/src/JSystem/JAudio2/JAIStreamMgr.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAIStreamMgr
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAIStreamMgr.h"
 #include "JSystem/JAudio2/JAISoundHandles.h"
 #include "JSystem/JAudio2/JAIStreamDataMgr.h"

--- a/src/JSystem/JAudio2/JASAiCtrl.cpp
+++ b/src/JSystem/JAudio2/JASAiCtrl.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASAiCtrl
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASAudioThread.h"
 #include "JSystem/JAudio2/JASCalc.h"

--- a/src/JSystem/JAudio2/JASAramStream.cpp
+++ b/src/JSystem/JAudio2/JASAramStream.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASAramStream
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASAramStream.h"
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASChannel.h"

--- a/src/JSystem/JAudio2/JASAudioReseter.cpp
+++ b/src/JSystem/JAudio2/JASAudioReseter.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASAudioReseter
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASAudioReseter.h"
 #include "JSystem/JAudio2/JASAudioThread.h"
 #include "JSystem/JAudio2/JASCriticalSection.h"

--- a/src/JSystem/JAudio2/JASAudioThread.cpp
+++ b/src/JSystem/JAudio2/JASAudioThread.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASAudioThread
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASAudioThread.h"
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASDriverIF.h"

--- a/src/JSystem/JAudio2/JASBNKParser.cpp
+++ b/src/JSystem/JAudio2/JASBNKParser.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASBNKParser
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASBNKParser.h"
 #include "JSystem/JAudio2/JASBasicBank.h"
 #include "JSystem/JAudio2/JASCalc.h"

--- a/src/JSystem/JAudio2/JASBank.cpp
+++ b/src/JSystem/JAudio2/JASBank.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASBank
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASBank.h"
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASBasicInst.h"

--- a/src/JSystem/JAudio2/JASBasicBank.cpp
+++ b/src/JSystem/JAudio2/JASBasicBank.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASBasicBank
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASBasicBank.h"
 #include "JSystem/JAudio2/JASCalc.h"
 

--- a/src/JSystem/JAudio2/JASBasicInst.cpp
+++ b/src/JSystem/JAudio2/JASBasicInst.cpp
@@ -2,6 +2,8 @@
 // JASBasicInst
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASBasicInst.h"
 #include "JSystem/JAudio2/JASCalc.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JAudio2/JASBasicWaveBank.cpp
+++ b/src/JSystem/JAudio2/JASBasicWaveBank.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASBasicWaveBank
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASBasicWaveBank.h"
 #include "JSystem/JAudio2/JASMutex.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JAudio2/JASCalc.cpp
+++ b/src/JSystem/JAudio2/JASCalc.cpp
@@ -2,6 +2,8 @@
 // JASCalc
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASCalc.h"
 #include <dolphin/os.h>
 #include "math.h"

--- a/src/JSystem/JAudio2/JASCallback.cpp
+++ b/src/JSystem/JAudio2/JASCallback.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASCallback
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASCallback.h"
 #include "JSystem/JAudio2/JASCriticalSection.h"
 

--- a/src/JSystem/JAudio2/JASChannel.cpp
+++ b/src/JSystem/JAudio2/JASChannel.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASChannel
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASChannel.h"
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASCalc.h"

--- a/src/JSystem/JAudio2/JASCmdStack.cpp
+++ b/src/JSystem/JAudio2/JASCmdStack.cpp
@@ -2,6 +2,8 @@
 // JASCmdStack
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASCmdStack.h"
 #include "dolphin/os.h"
 

--- a/src/JSystem/JAudio2/JASDSPChannel.cpp
+++ b/src/JSystem/JAudio2/JASDSPChannel.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASDSPChannel
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASDSPChannel.h"
 #include "JSystem/JAudio2/JASHeapCtrl.h"
 #include "JSystem/JKernel/JKRSolidHeap.h"

--- a/src/JSystem/JAudio2/JASDSPInterface.cpp
+++ b/src/JSystem/JAudio2/JASDSPInterface.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASDSPInterface
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASDSPInterface.h"
 #include "JSystem/JAudio2/JASCalc.h"
 #include "JSystem/JAudio2/JASHeapCtrl.h"

--- a/src/JSystem/JAudio2/JASDriverIF.cpp
+++ b/src/JSystem/JAudio2/JASDriverIF.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASDriverIF
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASDriverIF.h"
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASDSPInterface.h"

--- a/src/JSystem/JAudio2/JASDrumSet.cpp
+++ b/src/JSystem/JAudio2/JASDrumSet.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASDrumSet
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASDrumSet.h"
 #include "JSystem/JAudio2/JASCalc.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JAudio2/JASDvdThread.cpp
+++ b/src/JSystem/JAudio2/JASDvdThread.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASDvdThread
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASDvdThread.h"
 #include "JSystem/JAudio2/JASTaskThread.h"
 #include "JSystem/JKernel/JKRSolidHeap.h"

--- a/src/JSystem/JAudio2/JASHeapCtrl.cpp
+++ b/src/JSystem/JAudio2/JASHeapCtrl.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASHeapCtrl
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASHeapCtrl.h"
 #include "JSystem/JAudio2/JASMutex.h"
 #include "JSystem/JAudio2/JASWaveArcLoader.h"

--- a/src/JSystem/JAudio2/JASLfo.cpp
+++ b/src/JSystem/JAudio2/JASLfo.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASLfo
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASLfo.h"
 #include "SSystem/SComponent/c_math.h"
 

--- a/src/JSystem/JAudio2/JASOscillator.cpp
+++ b/src/JSystem/JAudio2/JASOscillator.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASOscillator
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASOscillator.h"
 
 //

--- a/src/JSystem/JAudio2/JASProbe.cpp
+++ b/src/JSystem/JAudio2/JASProbe.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASProbe
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASProbe.h"
 #include "dolphin/os.h"
 

--- a/src/JSystem/JAudio2/JASRegisterParam.cpp
+++ b/src/JSystem/JAudio2/JASRegisterParam.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASRegisterParam
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASRegisterParam.h"
 
 //

--- a/src/JSystem/JAudio2/JASReport.cpp
+++ b/src/JSystem/JAudio2/JASReport.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASReport
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASReport.h"
 #include "JSystem/JAudio2/JASMutex.h"
 #include "stdio.h"

--- a/src/JSystem/JAudio2/JASResArcLoader.cpp
+++ b/src/JSystem/JAudio2/JASResArcLoader.cpp
@@ -3,6 +3,8 @@
  * JAS - Resource Archive Loader
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASResArcLoader.h"
 #include "JSystem/JAudio2/JASDvdThread.h"
 #include "JSystem/JAudio2/JASTaskThread.h"

--- a/src/JSystem/JAudio2/JASSeqCtrl.cpp
+++ b/src/JSystem/JAudio2/JASSeqCtrl.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASSeqCtrl
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASSeqCtrl.h"
 #include "JSystem/JAudio2/JASSeqParser.h"
 #include "JSystem/JAudio2/JASTrack.h"

--- a/src/JSystem/JAudio2/JASSeqParser.cpp
+++ b/src/JSystem/JAudio2/JASSeqParser.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASSeqParser
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASSeqParser.h"
 #include "JSystem/JAudio2/JASCalc.h"
 #include "JSystem/JAudio2/JASReport.h"

--- a/src/JSystem/JAudio2/JASSeqReader.cpp
+++ b/src/JSystem/JAudio2/JASSeqReader.cpp
@@ -3,6 +3,8 @@
  * 
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASSeqReader.h"
 
 /* 80296108-80296148 290A48 0040+00 0/0 2/2 0/0 .text            init__12JASSeqReaderFv */

--- a/src/JSystem/JAudio2/JASSimpleWaveBank.cpp
+++ b/src/JSystem/JAudio2/JASSimpleWaveBank.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASSimpleWaveBank
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASSimpleWaveBank.h"
 
 /* 80298C94-80298CF4 2935D4 0060+00 0/0 1/1 0/0 .text            __ct__17JASSimpleWaveBankFv */

--- a/src/JSystem/JAudio2/JASSoundParams.cpp
+++ b/src/JSystem/JAudio2/JASSoundParams.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASSoundParams
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASSoundParams.h"
 
 /* 8029E3B0-8029E47C 298CF0 00CC+00 0/0 2/2 0/0 .text            clamp__14JASSoundParamsFv */

--- a/src/JSystem/JAudio2/JASTaskThread.cpp
+++ b/src/JSystem/JAudio2/JASTaskThread.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASTaskThread
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASTaskThread.h"
 #include "JSystem/JAudio2/JASCalc.h"
 #include "JSystem/JAudio2/JASCriticalSection.h"

--- a/src/JSystem/JAudio2/JASTrack.cpp
+++ b/src/JSystem/JAudio2/JASTrack.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASTrack
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASTrack.h"
 #include "JSystem/JAudio2/JASCriticalSection.h"
 #include "JSystem/JAudio2/JASDriverIF.h"

--- a/src/JSystem/JAudio2/JASTrackPort.cpp
+++ b/src/JSystem/JAudio2/JASTrackPort.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASTrackPort
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASTrackPort.h"
 
 /* 8029354C-8029357C 28DE8C 0030+00 0/0 1/1 0/0 .text            init__12JASTrackPortFv */

--- a/src/JSystem/JAudio2/JASVoiceBank.cpp
+++ b/src/JSystem/JAudio2/JASVoiceBank.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASVoiceBank
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASVoiceBank.h"
 #include "JSystem/JAudio2/JASBasicInst.h"
 

--- a/src/JSystem/JAudio2/JASWSParser.cpp
+++ b/src/JSystem/JAudio2/JASWSParser.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASWSParser
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASWSParser.h"
 #include "JSystem/JAudio2/JASBasicWaveBank.h"
 #include "JSystem/JAudio2/JASSimpleWaveBank.h"

--- a/src/JSystem/JAudio2/JASWaveArcLoader.cpp
+++ b/src/JSystem/JAudio2/JASWaveArcLoader.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JASWaveArcLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JASWaveArcLoader.h"
 #include "JSystem/JAudio2/JASDvdThread.h"
 #include "JSystem/JAudio2/JASTaskThread.h"

--- a/src/JSystem/JAudio2/JAUAudioArcInterpreter.cpp
+++ b/src/JSystem/JAudio2/JAUAudioArcInterpreter.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAUAudioArcInterpreter
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUAudioArcInterpreter.h"
 #include "JSystem/JUtility/JUTAssert.h"
 

--- a/src/JSystem/JAudio2/JAUAudioArcLoader.cpp
+++ b/src/JSystem/JAudio2/JAUAudioArcLoader.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAUAudioArcLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUAudioArcLoader.h"
 #include "JSystem/JAudio2/JAISeMgr.h"
 #include "JSystem/JAudio2/JAUSectionHeap.h"

--- a/src/JSystem/JAudio2/JAUAudioMgr.cpp
+++ b/src/JSystem/JAudio2/JAUAudioMgr.cpp
@@ -2,6 +2,8 @@
 // JAUAudioMgr
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUAudioMgr.h"
 #include "JSystem/JAudio2/JASHeapCtrl.h"
 

--- a/src/JSystem/JAudio2/JAUBankTable.cpp
+++ b/src/JSystem/JAudio2/JAUBankTable.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAUBankTable
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUBankTable.h"
 
 /* 802A4A80-802A4AA0 29F3C0 0020+00 0/0 1/1 0/0 .text

--- a/src/JSystem/JAudio2/JAUClusterSound.cpp
+++ b/src/JSystem/JAudio2/JAUClusterSound.cpp
@@ -2,6 +2,8 @@
 // JAUClusterSound
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUClusterSound.h"
 #include "JSystem/JAudio2/JAISoundHandles.h"
 

--- a/src/JSystem/JAudio2/JAUInitializer.cpp
+++ b/src/JSystem/JAudio2/JAUInitializer.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAUInitializer
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUInitializer.h"
 #include "JSystem/JAudio2/JAISe.h"
 #include "JSystem/JAudio2/JAISeq.h"

--- a/src/JSystem/JAudio2/JAUSectionHeap.cpp
+++ b/src/JSystem/JAudio2/JAUSectionHeap.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAUSectionHeap
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUSectionHeap.h"
 #include "JSystem/JAudio2/JASBNKParser.h"
 #include "JSystem/JAudio2/JASBankTable.h"
@@ -17,7 +19,6 @@
 #include "JSystem/JAudio2/JAUSoundTable.h"
 #include "JSystem/JAudio2/JAUStreamFileTable.h"
 #include "JSystem/JKernel/JKRSolidHeap.h"
-#include "stdlib.h"
 #include "dolphin/dvd.h"
 
 namespace {

--- a/src/JSystem/JAudio2/JAUSeqCollection.cpp
+++ b/src/JSystem/JAudio2/JAUSeqCollection.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JAUSeqCollection
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUSeqCollection.h"
 #include "JSystem/JUtility/JUTAssert.h"
 

--- a/src/JSystem/JAudio2/JAUSeqDataBlockMgr.cpp
+++ b/src/JSystem/JAudio2/JAUSeqDataBlockMgr.cpp
@@ -2,6 +2,8 @@
 // JAUSeqDataBlockMgr
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUSeqDataBlockMgr.h"
 #include "JSystem/JAudio2/JAUSoundInfo.h"
 #include "JSystem/JAudio2/JASResArcLoader.h"

--- a/src/JSystem/JAudio2/JAUSoundAnimator.cpp
+++ b/src/JSystem/JAudio2/JAUSoundAnimator.cpp
@@ -2,6 +2,8 @@
 // Translation Unit: JAUSoundAnimator
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUSoundAnimator.h"
 
 /* 802A6F70-802A7044 2A18B0 00D4+00 0/0 1/1 0/0 .text getStartSoundIndex__17JAUSoundAnimationCFf

--- a/src/JSystem/JAudio2/JAUSoundTable.cpp
+++ b/src/JSystem/JAudio2/JAUSoundTable.cpp
@@ -2,6 +2,8 @@
 // JAUSoundTable
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUSoundTable.h"
 
 /* 802A7114-802A7160 2A1A54 004C+00 0/0 1/1 0/0 .text            init__13JAUSoundTableFPCv */

--- a/src/JSystem/JAudio2/JAUStreamFileTable.cpp
+++ b/src/JSystem/JAudio2/JAUStreamFileTable.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/JAUStreamFileTable.h"
 #include "dolphin/os.h"
 

--- a/src/JSystem/JAudio2/dspproc.cpp
+++ b/src/JSystem/JAudio2/dspproc.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: dspproc
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/dspproc.h"
 #include "JSystem/JAudio2/dsptask.h"
 #include "JSystem/JAudio2/JASDSPInterface.h"

--- a/src/JSystem/JAudio2/dsptask.cpp
+++ b/src/JSystem/JAudio2/dsptask.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: dsptask
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/dsptask.h"
 #include "JSystem/JAudio2/osdsp.h"
 #include "global.h"

--- a/src/JSystem/JAudio2/osdsp.cpp
+++ b/src/JSystem/JAudio2/osdsp.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: osdsp
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/osdsp.h"
 #include "JSystem/JAudio2/osdsp_task.h"
 #include "dolphin/os.h"

--- a/src/JSystem/JAudio2/osdsp_task.cpp
+++ b/src/JSystem/JAudio2/osdsp_task.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: osdsp_task
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JAudio2/osdsp_task.h"
 #include "JSystem/JAudio2/dspproc.h"
 #include <dolphin/dsp.h>

--- a/src/JSystem/JFramework/JFWDisplay.cpp
+++ b/src/JSystem/JFramework/JFWDisplay.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JFramework/JFWDisplay.h"
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 #include "JSystem/JUtility/JUTAssert.h"

--- a/src/JSystem/JFramework/JFWSystem.cpp
+++ b/src/JSystem/JFramework/JFWSystem.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JFWSystem
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JFramework/JFWSystem.h"
 #include "JSystem/JKernel/JKRExpHeap.h"
 #include "JSystem/JUtility/JUTConsole.h"

--- a/src/JSystem/JGadget/binary.cpp
+++ b/src/JSystem/JGadget/binary.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: binary
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JGadget/binary.h"
 
 /* 802DC864-802DC8C8 2D71A4 0064+00 0/0 2/2 0/0 .text

--- a/src/JSystem/JGadget/linklist.cpp
+++ b/src/JSystem/JGadget/linklist.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: linklist
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JGadget/linklist.h"
 
 template <typename T>

--- a/src/JSystem/JGadget/std-vector.cpp
+++ b/src/JSystem/JGadget/std-vector.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: std-vector
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JGadget/std-vector.h"
 
 /* 802DCCC8-802DCCD0 2D7608 0008+00 1/1 0/0 0/0 .text extend_default__Q27JGadget6vectorFUlUlUl */

--- a/src/JSystem/JHostIO/JHIComm.cpp
+++ b/src/JSystem/JHostIO/JHIComm.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JHIComm.h"
 
 static int min(int a, int b);

--- a/src/JSystem/JHostIO/JHICommonMem.cpp
+++ b/src/JSystem/JHostIO/JHICommonMem.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JHICommonMem.h"
 
 JHIMemBuf* JHICommonMem::instance;

--- a/src/JSystem/JHostIO/JHIMccBuf.cpp
+++ b/src/JSystem/JHostIO/JHIMccBuf.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JHIMccBuf.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JHostIO/JHIRMcc.h"

--- a/src/JSystem/JHostIO/JHIMemBuf.cpp
+++ b/src/JSystem/JHostIO/JHIMemBuf.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JHICommonMem.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include <dolphin.h>

--- a/src/JSystem/JHostIO/JHIRMcc.cpp
+++ b/src/JSystem/JHostIO/JHIRMcc.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JHIMccBuf.h"
 
 enum HIO2DeviceType {

--- a/src/JSystem/JHostIO/JHIhioASync.cpp
+++ b/src/JSystem/JHostIO/JHIhioASync.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JHIMccBuf.h"
 #include "JSystem/JHostIO/JHIRMcc.h"
 #include <dolphin.h>

--- a/src/JSystem/JHostIO/JOREntry.cpp
+++ b/src/JSystem/JHostIO/JOREntry.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JORServer.h"
 #include "JSystem/JHostIO/JOREntry.h"
 #include "JSystem/JHostIO/JHIhioASync.h"

--- a/src/JSystem/JHostIO/JORFile.cpp
+++ b/src/JSystem/JHostIO/JORFile.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JORFile.h"
 #include "JSystem/JHostIO/JORServer.h"
 #include <dolphin.h>

--- a/src/JSystem/JHostIO/JORHostInfo.cpp
+++ b/src/JSystem/JHostIO/JORHostInfo.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JORHostInfo.h"
 #include "JSystem/JHostIO/JORServer.h"
 

--- a/src/JSystem/JHostIO/JORMessageBox.cpp
+++ b/src/JSystem/JHostIO/JORMessageBox.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JORServer.h"
 
 u32 JORMessageBox(const char* message, const char* title, u32 style) {

--- a/src/JSystem/JHostIO/JORServer.cpp
+++ b/src/JSystem/JHostIO/JORServer.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JORServer.h"
 #include "JSystem/JHostIO/JORReflexible.h"
 #include "JSystem/JHostIO/JORFile.h"

--- a/src/JSystem/JHostIO/JORShellExecute.cpp
+++ b/src/JSystem/JHostIO/JORShellExecute.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JHostIO/JORServer.h"
 
 int JORShellExecute(const char* param_0, const char* param_1, const char* param_2, const char* param_3, int param_4) {

--- a/src/JSystem/JKernel/JKRAram.cpp
+++ b/src/JSystem/JKernel/JKRAram.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAram.h"
 #include "JSystem/JKernel/JKRAramPiece.h"
 #include "JSystem/JKernel/JKRAramStream.h"
@@ -5,7 +7,6 @@
 #include "JSystem/JKernel/JKRExpHeap.h"
 #include "JSystem/JUtility/JUTException.h"
 #include "dolphin/ar.h"
-#include <dolphin/os.h>
 #include <dolphin/os.h>
 #include "string.h"
 

--- a/src/JSystem/JKernel/JKRAramArchive.cpp
+++ b/src/JSystem/JKernel/JKRAramArchive.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JKRAramArchive
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAramArchive.h"
 #include "JSystem/JKernel/JKRAram.h"
 #include "JSystem/JKernel/JKRDecomp.h"

--- a/src/JSystem/JKernel/JKRAramBlock.cpp
+++ b/src/JSystem/JKernel/JKRAramBlock.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAramBlock.h"
 #include "JSystem/JKernel/JKRAramHeap.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JKernel/JKRAramHeap.cpp
+++ b/src/JSystem/JKernel/JKRAramHeap.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAramHeap.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "global.h"

--- a/src/JSystem/JKernel/JKRAramPiece.cpp
+++ b/src/JSystem/JKernel/JKRAramPiece.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAramPiece.h"
 #include "JSystem/JKernel/JKRAram.h"
 #include "JSystem/JKernel/JKRDecomp.h"

--- a/src/JSystem/JKernel/JKRAramStream.cpp
+++ b/src/JSystem/JKernel/JKRAramStream.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAramStream.h"
 #include "JSystem/JKernel/JKRAramPiece.h"
 #include "JSystem/JSupport/JSUFileStream.h"

--- a/src/JSystem/JKernel/JKRArchivePri.cpp
+++ b/src/JSystem/JKernel/JKRArchivePri.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRArchive.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "ctype.h"

--- a/src/JSystem/JKernel/JKRArchivePub.cpp
+++ b/src/JSystem/JKernel/JKRArchivePub.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAramArchive.h"
 #include "JSystem/JKernel/JKRArchive.h"
 #include "JSystem/JKernel/JKRCompArchive.h"

--- a/src/JSystem/JKernel/JKRAssertHeap.cpp
+++ b/src/JSystem/JKernel/JKRAssertHeap.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRAssertHeap.h"
 
 /* 802D12C4-802D1300 2CBC04 003C+00 1/1 0/0 0/0 .text __ct__13JKRAssertHeapFPvUlP7JKRHeapb */

--- a/src/JSystem/JKernel/JKRCompArchive.cpp
+++ b/src/JSystem/JKernel/JKRCompArchive.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRCompArchive.h"
 #include "JSystem/JKernel/JKRAram.h"
 #include "JSystem/JKernel/JKRAramArchive.h"

--- a/src/JSystem/JKernel/JKRDecomp.cpp
+++ b/src/JSystem/JKernel/JKRDecomp.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRDecomp.h"
 #include "JSystem/JKernel/JKRAramPiece.h"
 #include "global.h"

--- a/src/JSystem/JKernel/JKRDisposer.cpp
+++ b/src/JSystem/JKernel/JKRDisposer.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRDisposer.h"
 #include "JSystem/JKernel/JKRHeap.h"
 

--- a/src/JSystem/JKernel/JKRDvdAramRipper.cpp
+++ b/src/JSystem/JKernel/JKRDvdAramRipper.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRDvdAramRipper.h"
 #include "JSystem/JKernel/JKRAram.h"
 #include "JSystem/JKernel/JKRAramPiece.h"

--- a/src/JSystem/JKernel/JKRDvdArchive.cpp
+++ b/src/JSystem/JKernel/JKRDvdArchive.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRDvdArchive.h"
 #include "JSystem/JKernel/JKRDecomp.h"
 #include "JSystem/JKernel/JKRDvdFile.h"

--- a/src/JSystem/JKernel/JKRDvdFile.cpp
+++ b/src/JSystem/JKernel/JKRDvdFile.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRDvdFile.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "JSystem/JUtility/JUTException.h"

--- a/src/JSystem/JKernel/JKRDvdRipper.cpp
+++ b/src/JSystem/JKernel/JKRDvdRipper.cpp
@@ -2,12 +2,13 @@
 // JKRDvdRipper
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRDvdRipper.h"
 #include "JSystem/JKernel/JKRDvdFile.h"
 #include "JSystem/JKernel/JKRDecomp.h"
 #include "JSystem/JUtility/JUTException.h"
 #include "string.h"
-#include <dolphin/os.h>
 #include <dolphin/os.h>
 #include "dolphin/vi.h"
 #include <stdint.h>

--- a/src/JSystem/JKernel/JKRExpHeap.cpp
+++ b/src/JSystem/JKernel/JKRExpHeap.cpp
@@ -2,6 +2,8 @@
 // JKRExpHeap
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRExpHeap.h"
 #include "JSystem/JSupport/JSupport.h"
 #include "JSystem/JUtility/JUTConsole.h"

--- a/src/JSystem/JKernel/JKRFile.cpp
+++ b/src/JSystem/JKernel/JKRFile.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRFile.h"
 #include "dolphin/vi.h"
 

--- a/src/JSystem/JKernel/JKRFileCache.cpp
+++ b/src/JSystem/JKernel/JKRFileCache.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRFileCache.h"
 #include "JSystem/JKernel/JKRDvdFile.h"
 #include "JSystem/JKernel/JKRFileFinder.h"

--- a/src/JSystem/JKernel/JKRFileFinder.cpp
+++ b/src/JSystem/JKernel/JKRFileFinder.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRFileFinder.h"
 #include "JSystem/JKernel/JKRArchive.h"
 

--- a/src/JSystem/JKernel/JKRFileLoader.cpp
+++ b/src/JSystem/JKernel/JKRFileLoader.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRFileLoader.h"
 #include "string.h"
 #include "ctype.h"

--- a/src/JSystem/JKernel/JKRHeap.cpp
+++ b/src/JSystem/JKernel/JKRHeap.cpp
@@ -3,6 +3,8 @@
  * JSystem Heap Framework
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "JSystem/JUtility/JUTException.h"

--- a/src/JSystem/JKernel/JKRMemArchive.cpp
+++ b/src/JSystem/JKernel/JKRMemArchive.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRMemArchive.h"
 #include "JSystem/JKernel/JKRDecomp.h"
 #include "JSystem/JKernel/JKRDvdRipper.h"

--- a/src/JSystem/JKernel/JKRSolidHeap.cpp
+++ b/src/JSystem/JKernel/JKRSolidHeap.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRSolidHeap.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "JSystem/JUtility/JUTConsole.h"

--- a/src/JSystem/JKernel/JKRThread.cpp
+++ b/src/JSystem/JKernel/JKRThread.cpp
@@ -1,8 +1,9 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JKernel/JKRThread.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "JSystem/JUtility/JUTConsole.h"
 #include "stdio.h"
-#include "dol2asm.h"
 #include "global.h"
 #include <stdint.h>
 

--- a/src/JSystem/JMath/JMATrigonometric.cpp
+++ b/src/JSystem/JMath/JMATrigonometric.cpp
@@ -3,10 +3,11 @@
 // Translation Unit: JMATrigonometric
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 // don't include header until this "zero" mess is figured out
 // #include "JSystem/JMath/JMATrigonometric.h"
 #include "math.h"
-#include "dol2asm.h"
 #include "global.h"
 
 static f32 dummy() {

--- a/src/JSystem/JMath/JMath.cpp
+++ b/src/JSystem/JMath/JMath.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JMath
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMath/JMath.h"
 #include "JSystem/JMath/JMATrigonometric.h"
 

--- a/src/JSystem/JMath/random.cpp
+++ b/src/JSystem/JMath/random.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: random
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMath/random.h"
 
 /* 80339AE4-80339AEC -00001 0008+00 0/0 0/0 0/0 .text            __ct__Q25JMath13TRandom_fast_FUl */

--- a/src/JSystem/JMessage/control.cpp
+++ b/src/JSystem/JMessage/control.cpp
@@ -3,6 +3,8 @@
  * JMessage Controller
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMessage/control.h"
 
 /* 802A7548-802A758C 2A1E88 0044+00 0/0 2/2 0/0 .text            __ct__Q28JMessage8TControlFv */

--- a/src/JSystem/JMessage/data.cpp
+++ b/src/JSystem/JMessage/data.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMessage/data.h"
 
 /* 80455818-80455820 003E18 0004+04 0/0 1/1 0/0 .sdata2          ga4cSignature__Q28JMessage4data */

--- a/src/JSystem/JMessage/locale.cpp
+++ b/src/JSystem/JMessage/locale.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMessage/locale.h"
 
 /* 802A9528-802A958C 2A3E68 0064+00 0/0 1/0 0/0 .text

--- a/src/JSystem/JMessage/processor.cpp
+++ b/src/JSystem/JMessage/processor.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMessage/processor.h"
 #include "JSystem/JMessage/control.h"
 #include "JSystem/JUtility/JUTAssert.h"

--- a/src/JSystem/JMessage/resource.cpp
+++ b/src/JSystem/JMessage/resource.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JMessage/resource.h"
 #include "JSystem/JGadget/search.h"
 #include "JSystem/JGadget/define.h"

--- a/src/JSystem/JParticle/JPABaseShape.cpp
+++ b/src/JSystem/JParticle/JPABaseShape.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPABaseShape
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPABaseShape.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JParticle/JPAParticle.h"

--- a/src/JSystem/JParticle/JPAChildShape.cpp
+++ b/src/JSystem/JParticle/JPAChildShape.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAChildShape
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAChildShape.h"
 #include "JSystem/JParticle/JPAParticle.h"
 #include "JSystem/JParticle/JPAEmitter.h"

--- a/src/JSystem/JParticle/JPADynamicsBlock.cpp
+++ b/src/JSystem/JParticle/JPADynamicsBlock.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPADynamicsBlock
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPADynamicsBlock.h"
 #include "JSystem/JMath/JMATrigonometric.h"
 #include "JSystem/JParticle/JPAEmitter.h"

--- a/src/JSystem/JParticle/JPAEmitter.cpp
+++ b/src/JSystem/JParticle/JPAEmitter.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAEmitter
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAEmitter.h"
 #include "JSystem/JParticle/JPAEmitterManager.h"
 #include "JSystem/JParticle/JPAParticle.h"

--- a/src/JSystem/JParticle/JPAEmitterManager.cpp
+++ b/src/JSystem/JParticle/JPAEmitterManager.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAEmitterManager
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAEmitterManager.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JParticle/JPAEmitter.h"

--- a/src/JSystem/JParticle/JPAExTexShape.cpp
+++ b/src/JSystem/JParticle/JPAExTexShape.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAExTexShape
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAExTexShape.h"
 #include "JSystem/JParticle/JPAResourceManager.h"
 #include "JSystem/JParticle/JPAEmitter.h"

--- a/src/JSystem/JParticle/JPAExtraShape.cpp
+++ b/src/JSystem/JParticle/JPAExtraShape.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAExtraShape
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAExtraShape.h"
 #include "JSystem/JMath/JMATrigonometric.h"
 #include "JSystem/JParticle/JPAParticle.h"

--- a/src/JSystem/JParticle/JPAFieldBlock.cpp
+++ b/src/JSystem/JParticle/JPAFieldBlock.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAFieldBlock
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAFieldBlock.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JParticle/JPAEmitter.h"

--- a/src/JSystem/JParticle/JPAKeyBlock.cpp
+++ b/src/JSystem/JParticle/JPAKeyBlock.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAKeyBlock
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAKeyBlock.h"
 #include "JSystem/JParticle/JPAMath.h"
 

--- a/src/JSystem/JParticle/JPAMath.cpp
+++ b/src/JSystem/JParticle/JPAMath.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAMath
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAMath.h"
 #include "JSystem/JMath/JMATrigonometric.h"
 #include "JSystem/J2DGraph/J2DAnimation.h"

--- a/src/JSystem/JParticle/JPAParticle.cpp
+++ b/src/JSystem/JParticle/JPAParticle.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAParticle
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAParticle.h"
 #include "JSystem/JParticle/JPABaseShape.h"
 #include "JSystem/JParticle/JPAChildShape.h"

--- a/src/JSystem/JParticle/JPAResource.cpp
+++ b/src/JSystem/JParticle/JPAResource.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAResource
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAResource.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JParticle/JPABaseShape.h"

--- a/src/JSystem/JParticle/JPAResourceLoader.cpp
+++ b/src/JSystem/JParticle/JPAResourceLoader.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAResourceLoader
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAResourceLoader.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JParticle/JPABaseShape.h"

--- a/src/JSystem/JParticle/JPAResourceManager.cpp
+++ b/src/JSystem/JParticle/JPAResourceManager.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPAResourceManager
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPAResourceManager.h"
 #include "JSystem/JParticle/JPADynamicsBlock.h"
 #include "JSystem/JParticle/JPAResource.h"

--- a/src/JSystem/JParticle/JPATexture.cpp
+++ b/src/JSystem/JParticle/JPATexture.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JPATexture
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JParticle/JPATexture.h"
 
 /* 8027D7D4-8027D83C 278114 0068+00 0/0 1/1 0/0 .text            __ct__10JPATextureFPCUc */

--- a/src/JSystem/JStage/JSGActor.cpp
+++ b/src/JSystem/JStage/JSGActor.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGActor.h"
 
 /* 80280A48-80280AA8 27B388 0060+00 0/0 1/1 0/0 .text            __dt__Q26JStage6TActorFv */

--- a/src/JSystem/JStage/JSGAmbientLight.cpp
+++ b/src/JSystem/JStage/JSGAmbientLight.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGAmbientLight.h"
 
 /* 80280B20-80280B80 27B460 0060+00 0/0 1/1 0/0 .text            __dt__Q26JStage13TAmbientLightFv */

--- a/src/JSystem/JStage/JSGCamera.cpp
+++ b/src/JSystem/JStage/JSGCamera.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGCamera.h"
 #include "math.h"
 #include "limits.h"

--- a/src/JSystem/JStage/JSGFog.cpp
+++ b/src/JSystem/JStage/JSGFog.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGFog.h"
 #include "math.h"
 

--- a/src/JSystem/JStage/JSGLight.cpp
+++ b/src/JSystem/JStage/JSGLight.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGLight.h"
 
 /* 80280D28-80280D88 27B668 0060+00 0/0 1/1 0/0 .text            __dt__Q26JStage6TLightFv */

--- a/src/JSystem/JStage/JSGObject.cpp
+++ b/src/JSystem/JStage/JSGObject.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGObject.h"
 
 /* 80280DD4-80280E1C 27B714 0048+00 0/0 6/6 0/0 .text            __dt__Q26JStage7TObjectFv */

--- a/src/JSystem/JStage/JSGSystem.cpp
+++ b/src/JSystem/JStage/JSGSystem.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStage/JSGSystem.h"
 
 /* 80280E90-80280EF0 27B7D0 0060+00 0/0 1/1 0/0 .text            __dt__Q26JStage7TSystemFv */

--- a/src/JSystem/JStudio/JStudio/ctb-data.cpp
+++ b/src/JSystem/JStudio/JStudio/ctb-data.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/ctb.h"
 
 /* ############################################################################################## */

--- a/src/JSystem/JStudio/JStudio/ctb.cpp
+++ b/src/JSystem/JStudio/JStudio/ctb.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: ctb
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/ctb.h"
 #include "iterator.h"
 #include "string.h"

--- a/src/JSystem/JStudio/JStudio/functionvalue.cpp
+++ b/src/JSystem/JStudio/JStudio/functionvalue.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: functionvalue
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/functionvalue.h"
 #include "JSystem/JGadget/search.h"
 #include "JSystem/JUtility/JUTException.h"

--- a/src/JSystem/JStudio/JStudio/fvb-data-parse.cpp
+++ b/src/JSystem/JStudio/JStudio/fvb-data-parse.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: fvb-data-parse
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/fvb-data-parse.h"
 
 //

--- a/src/JSystem/JStudio/JStudio/fvb-data.cpp
+++ b/src/JSystem/JStudio/JStudio/fvb-data.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/fvb-data.h"
 
 extern const char JStudio::fvb::data::ga4cSignature[4] = "FVB";

--- a/src/JSystem/JStudio/JStudio/fvb.cpp
+++ b/src/JSystem/JStudio/JStudio/fvb.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: fvb
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/fvb.h"
 #include "JSystem/JUtility/JUTException.h"
 #include <string.h>

--- a/src/JSystem/JStudio/JStudio/jstudio-control.cpp
+++ b/src/JSystem/JStudio/JStudio/jstudio-control.cpp
@@ -2,6 +2,8 @@
 // jstudio-control
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/jstudio-control.h"
 #include "JSystem/JStudio/JStudio/jstudio-math.h"
 #include "JSystem/JStudio/JStudio/jstudio-data.h"

--- a/src/JSystem/JStudio/JStudio/jstudio-data.cpp
+++ b/src/JSystem/JStudio/JStudio/jstudio-data.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/jstudio-data.h"
 
 extern const char JStudio::data::ga8cSignature[8] = "jstudio";

--- a/src/JSystem/JStudio/JStudio/jstudio-math.cpp
+++ b/src/JSystem/JStudio/JStudio/jstudio-math.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: jstudio-math
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/jstudio-math.h"
 #include "JSystem/JGeometry.h"
 #include "JSystem/TPosition3.h"

--- a/src/JSystem/JStudio/JStudio/jstudio-object.cpp
+++ b/src/JSystem/JStudio/JStudio/jstudio-object.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: jstudio-object
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/jstudio-object.h"
 
 namespace JStudio {

--- a/src/JSystem/JStudio/JStudio/object-id.cpp
+++ b/src/JSystem/JStudio/JStudio/object-id.cpp
@@ -2,6 +2,8 @@
 // object-id
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/object-id.h"
 #include "JSystem/JUtility/JUTAssert.h"
 

--- a/src/JSystem/JStudio/JStudio/stb-data-parse.cpp
+++ b/src/JSystem/JStudio/JStudio/stb-data-parse.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: stb-data-parse
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/stb-data-parse.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include "dolphin/os.h"

--- a/src/JSystem/JStudio/JStudio/stb-data.cpp
+++ b/src/JSystem/JStudio/JStudio/stb-data.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/stb-data.h"
 #include "dol2asm.h"
 

--- a/src/JSystem/JStudio/JStudio/stb.cpp
+++ b/src/JSystem/JStudio/JStudio/stb.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio/stb.h"
 #include "JSystem/JStudio/JStudio/jstudio-object.h"
 #include "JSystem/JUtility/JUTException.h"

--- a/src/JSystem/JStudio/JStudio_JAudio2/control.cpp
+++ b/src/JSystem/JStudio/JStudio_JAudio2/control.cpp
@@ -2,6 +2,8 @@
 // control
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JAudio2/control.h"
 #include "JSystem/JGadget/pointer.h"
 

--- a/src/JSystem/JStudio/JStudio_JAudio2/object-sound.cpp
+++ b/src/JSystem/JStudio/JStudio_JAudio2/object-sound.cpp
@@ -2,6 +2,8 @@
 // object-sound
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JAudio2/object-sound.h"
 #include "JSystem/JStudio/JStudio_JAudio2/control.h"
 #include "JSystem/JStudio/JStudio_JStage/control.h"

--- a/src/JSystem/JStudio/JStudio_JParticle/control.cpp
+++ b/src/JSystem/JStudio/JStudio_JParticle/control.cpp
@@ -2,6 +2,8 @@
 // control
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JParticle/control.h"
 #include "JSystem/JParticle/JPAEmitterManager.h"
 #include "JSystem/JGadget/pointer.h"

--- a/src/JSystem/JStudio/JStudio_JParticle/object-particle.cpp
+++ b/src/JSystem/JStudio/JStudio_JParticle/object-particle.cpp
@@ -2,6 +2,8 @@
 // object-particle
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JParticle/object-particle.h"
 #include "JSystem/JStudio/JStudio_JStage/control.h"
 

--- a/src/JSystem/JStudio/JStudio_JStage/control.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/control.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: control
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/control.h"
 #include "JSystem/JStage/JSGActor.h"
 #include "JSystem/JStage/JSGLight.h"

--- a/src/JSystem/JStudio/JStudio_JStage/object-actor.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/object-actor.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: object-actor
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/object-actor.h"
 
 /* 8028A5F0-8028A6B4 284F30 00C4+00 0/0 1/1 0/0 .text

--- a/src/JSystem/JStudio/JStudio_JStage/object-ambientlight.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/object-ambientlight.cpp
@@ -2,6 +2,8 @@
 // object-ambientlight
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/object-ambientlight.h"
 
 /* 8028B610-8028B6AC 285F50 009C+00 0/0 1/1 0/0 .text

--- a/src/JSystem/JStudio/JStudio_JStage/object-camera.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/object-camera.cpp
@@ -2,6 +2,8 @@
 // object-camera
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/object-camera.h"
 
 /* 8028B8A0-8028B960 2861E0 00C0+00 0/0 1/1 0/0 .text

--- a/src/JSystem/JStudio/JStudio_JStage/object-fog.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/object-fog.cpp
@@ -2,6 +2,8 @@
 // object-fog
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/object-fog.h"
 
 /* 8028C574-8028C610 286EB4 009C+00 0/0 1/1 0/0 .text

--- a/src/JSystem/JStudio/JStudio_JStage/object-light.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/object-light.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: object-light
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/object-light.h"
 
 /* 8028CB50-8028CBF4 287490 00A4+00 0/0 1/1 0/0 .text

--- a/src/JSystem/JStudio/JStudio_JStage/object.cpp
+++ b/src/JSystem/JStudio/JStudio_JStage/object.cpp
@@ -2,6 +2,8 @@
 // object
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JStudio/JStudio_JStage/object.h"
 
 /* 8028A1F8-8028A290 284B38 0098+00 0/0 2/2 0/0 .text

--- a/src/JSystem/JSupport/JSUFileStream.cpp
+++ b/src/JSystem/JSupport/JSUFileStream.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JSUFileStream
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JSupport/JSUFileStream.h"
 #include "JSystem/JKernel/JKRFile.h"
 

--- a/src/JSystem/JSupport/JSUInputStream.cpp
+++ b/src/JSystem/JSupport/JSUInputStream.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JSUInputStream
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JSupport/JSUInputStream.h"
 #include "JSystem/JSupport/JSURandomInputStream.h"
 #include <dolphin.h>

--- a/src/JSystem/JSupport/JSUList.cpp
+++ b/src/JSystem/JSupport/JSUList.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JSUList
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JSupport/JSUList.h"
 
 JSUPtrLink::JSUPtrLink(void* object) {

--- a/src/JSystem/JSupport/JSUMemoryStream.cpp
+++ b/src/JSystem/JSupport/JSUMemoryStream.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JSUMemoryStream
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JSupport/JSUMemoryStream.h"
 #include "string.h"
 

--- a/src/JSystem/JSupport/JSUOutputStream.cpp
+++ b/src/JSystem/JSupport/JSUOutputStream.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JSupport/JSUOutputStream.h"
 #include "JSystem/JSupport/JSURandomOutputStream.h"
 #include <dolphin.h>

--- a/src/JSystem/JUtility/JUTAssert.cpp
+++ b/src/JSystem/JUtility/JUTAssert.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTAssert
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTAssert.h"
 #include "JSystem/JUtility/JUTConsole.h"
 #include "JSystem/JUtility/JUTDbPrint.h"

--- a/src/JSystem/JUtility/JUTCacheFont.cpp
+++ b/src/JSystem/JUtility/JUTCacheFont.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTCacheFont
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTCacheFont.h"
 #include "JSystem/JUtility/JUTException.h"
 #include "JSystem/JUtility/JUTAssert.h"

--- a/src/JSystem/JUtility/JUTConsole.cpp
+++ b/src/JSystem/JUtility/JUTConsole.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTConsole.h"
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JUtility/JUTDbPrint.cpp
+++ b/src/JSystem/JUtility/JUTDbPrint.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTDbPrint
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTDbPrint.h"
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JUtility/JUTDirectFile.cpp
+++ b/src/JSystem/JUtility/JUTDirectFile.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTDirectFile
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTDirectFile.h"
 #include <dolphin/os.h>
 #include "global.h"

--- a/src/JSystem/JUtility/JUTDirectPrint.cpp
+++ b/src/JSystem/JUtility/JUTDirectPrint.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTDirectPrint
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTDirectPrint.h"
 #include "stdio.h"
 #include <dolphin/os.h>

--- a/src/JSystem/JUtility/JUTException.cpp
+++ b/src/JSystem/JUtility/JUTException.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTException
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTException.h"
 #include "JSystem/JUtility/JUTConsole.h"
 #include "JSystem/JUtility/JUTDirectPrint.h"

--- a/src/JSystem/JUtility/JUTFader.cpp
+++ b/src/JSystem/JUtility/JUTFader.cpp
@@ -3,6 +3,8 @@
  * JUtility - Color Fader
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTFader.h"
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 

--- a/src/JSystem/JUtility/JUTFont.cpp
+++ b/src/JSystem/JUtility/JUTFont.cpp
@@ -3,6 +3,8 @@
  * JUtility - Font Management
  */
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTFont.h"
 
 /* 802DECF8-802DED24 2D9638 002C+00 0/0 2/2 0/0 .text            __ct__7JUTFontFv */

--- a/src/JSystem/JUtility/JUTFontData_Ascfont_fix12.cpp
+++ b/src/JSystem/JUtility/JUTFontData_Ascfont_fix12.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include <dolphin.h>
 #include "global.h"
 

--- a/src/JSystem/JUtility/JUTGamePad.cpp
+++ b/src/JSystem/JUtility/JUTGamePad.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTGamePad.h"
 #include <math.h>
 

--- a/src/JSystem/JUtility/JUTGraphFifo.cpp
+++ b/src/JSystem/JUtility/JUTGraphFifo.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTGraphFifo
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTGraphFifo.h"
 #include "JSystem/JKernel/JKRHeap.h"
 

--- a/src/JSystem/JUtility/JUTNameTab.cpp
+++ b/src/JSystem/JUtility/JUTNameTab.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTNameTab
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTNameTab.h"
 #include "string.h"
 

--- a/src/JSystem/JUtility/JUTPalette.cpp
+++ b/src/JSystem/JUtility/JUTPalette.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTPalette.h"
 #include "dolphin/gx.h"
 #include "dolphin/os.h"

--- a/src/JSystem/JUtility/JUTProcBar.cpp
+++ b/src/JSystem/JUtility/JUTProcBar.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTProcBar.h"
 #include "JSystem/J2DGraph/J2DOrthoGraph.h"
 #include "JSystem/JKernel/JKRHeap.h"

--- a/src/JSystem/JUtility/JUTResFont.cpp
+++ b/src/JSystem/JUtility/JUTResFont.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTResFont
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTResFont.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "JSystem/JSupport/JSupport.h"

--- a/src/JSystem/JUtility/JUTResource.cpp
+++ b/src/JSystem/JUtility/JUTResource.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTResource.h"
 #include "JSystem/JKernel/JKRArchive.h"
 #include "JSystem/JSupport/JSUInputStream.h"

--- a/src/JSystem/JUtility/JUTTexture.cpp
+++ b/src/JSystem/JUtility/JUTTexture.cpp
@@ -1,3 +1,5 @@
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTTexture.h"
 #include "JSystem/JUtility/JUTPalette.h"
 #include "dolphin/gx.h"

--- a/src/JSystem/JUtility/JUTVideo.cpp
+++ b/src/JSystem/JUtility/JUTVideo.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTVideo
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTVideo.h"
 #include "JSystem/JUtility/JUTDirectPrint.h"
 #include "JSystem/JUtility/JUTXfb.h"

--- a/src/JSystem/JUtility/JUTXfb.cpp
+++ b/src/JSystem/JUtility/JUTXfb.cpp
@@ -3,6 +3,8 @@
 // Translation Unit: JUTXfb
 //
 
+#include "JSystem/JSystem.h" // IWYU pragma: keep
+
 #include "JSystem/JUtility/JUTXfb.h"
 #include "JSystem/JKernel/JKRHeap.h"
 #include "dolphin/gx.h"


### PR DESCRIPTION
This PR adds `JSystem.pch` which fixes weak function order/removes the need for `nosyminline` in several JSystem TUs. These changes are deliberately conservative and both the PCH ~~and the files that include it~~ are as narrowly scoped as possible to fix existing function order issues.

This approach admittedly feels a little ad hoc, so I'm very open to feedback if it seems like this is just being treated as a nail for the PCH hammer when it shouldn't.