### PR TITLE
Mark d_a_e_gm as matching again

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1721,7 +1721,7 @@ config.libs = [
     ActorRel(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d_a_e_gb"),
     ActorRel(NonMatching, "d_a_e_ge"),
     ActorRel(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d_a_e_gi"),
-    ActorRel(NonMatching, "d_a_e_gm"),
+    ActorRel(MatchingFor("GZ2E01", "GZ2J01"), "d_a_e_gm"),
     ActorRel(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d_a_e_gob"),
     ActorRel(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d_a_e_gs"),
     ActorRel(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d_a_e_hb_leaf"),


### PR DESCRIPTION
This marks `d_a_e_gm` as matching again after it was accidentally unmatched in #2676.