### PR TITLE
Use composition instead of inheritance for most f_op classes

### DIFF
--- a/include/JSystem/JKernel/JKRThread.h
+++ b/include/JSystem/JKernel/JKRThread.h
@@ -20,7 +20,7 @@ class JUTConsole;
  * @ingroup jsystem-jkernel
  * 
  */
-class JKRThread : JKRDisposer {
+class JKRThread : public JKRDisposer {
 public:
     class TLoad {
     public:

--- a/include/c/c_damagereaction.h
+++ b/include/c/c_damagereaction.h
@@ -3,7 +3,7 @@
 
 #include "JSystem/JParticle/JPAParticle.h"
 
-class JPTraceParticleCallBack4 : JPAParticleCallBack {
+class JPTraceParticleCallBack4 : public JPAParticleCallBack {
 public:
     /* 8001817C */ void execute(JPABaseEmitter*, JPABaseParticle*);
     /* 800182A4 */ void draw(JPABaseEmitter*, JPABaseParticle*);

--- a/include/f_op/f_op_actor.h
+++ b/include/f_op/f_op_actor.h
@@ -233,8 +233,9 @@ struct cull_box {
     /* 0xC */ Vec max;
 };
 
-class fopAc_ac_c : public leafdraw_class {
+class fopAc_ac_c {
 public:
+    /* 0x000 */ leafdraw_class base;
     /* 0x0C0 */ int actor_type;
     /* 0x0C4 */ create_tag_class actor_tag;
     /* 0x0D8 */ create_tag_class draw_tag;

--- a/include/f_op/f_op_actor_mng.h
+++ b/include/f_op/f_op_actor_mng.h
@@ -91,7 +91,7 @@ struct fOpAcm_HIO_entry_c : public mDoHIO_entry_c {
 
     #ifdef DEBUG
     void removeHIO(const fopAc_ac_c* i_this) { removeHIO(*i_this); }
-    void removeHIO(const fopAc_ac_c& i_this) { removeHIO(static_cast<const leafdraw_class&>(i_this)); }
+    void removeHIO(const fopAc_ac_c& i_this) { removeHIO(i_this.base); }
     void removeHIO(const leafdraw_class& i_this) { removeHIO(i_this.base); }
     void removeHIO(const base_process_class& i_this) { removeHIO(i_this.state); }
     void removeHIO(const state_class& state) {

--- a/include/f_op/f_op_kankyo.h
+++ b/include/f_op/f_op_kankyo.h
@@ -4,8 +4,8 @@
 #include "SSystem/SComponent/c_xyz.h"
 #include "f_pc/f_pc_leaf.h"
 
-class kankyo_class : public leafdraw_class {
-public:
+struct kankyo_class {
+    /* 0x00 */ leafdraw_class base;
     /* 0xC0 */ int type;
     /* 0xC4 */ create_tag_class draw_tag;
     /* 0xD8 */ leafdraw_method_class* sub_method;

--- a/include/f_op/f_op_msg.h
+++ b/include/f_op/f_op_msg.h
@@ -22,8 +22,8 @@ enum fopMsg_Mode_e {
 
 class fopAc_ac_c;
 
-class msg_class : public leafdraw_class {
-public:
+struct msg_class {
+    /* 0x00 */ leafdraw_class base;
     /* 0xC0 */ int type;
     /* 0xC4 */ create_tag_class draw_tag;
     /* 0xD8 */ leafdraw_method_class* sub_method;

--- a/include/f_op/f_op_overlap.h
+++ b/include/f_op/f_op_overlap.h
@@ -4,8 +4,8 @@
 #include "f_pc/f_pc_leaf.h"
 #include "SSystem/SComponent/c_request.h"
 
-class overlap_task_class : public leafdraw_class {
-public:
+struct overlap_task_class {
+    /* 0x00 */ leafdraw_class base;
     /* 0xC0 */ leafdraw_method_class* submethod;
     /* 0xC4 */ request_base_class request;
     /* 0xC8 */ fpc_ProcID scene_id;

--- a/include/f_op/f_op_view.h
+++ b/include/f_op/f_op_view.h
@@ -39,7 +39,8 @@ struct view_port_class {
     /* 0x18 */ scissor_class scissor;
 };
 
-struct view_class : public leafdraw_class {
+struct view_class {
+    /* 0x000 */ leafdraw_class base;
     /* 0x0C0 */ leafdraw_method_class* sub_method;
     /* 0x0C4 */ u8 field_0xc4;
     /* 0x0C8 */ f32 near;

--- a/src/d/actor/d_a_mg_fish.cpp
+++ b/src/d/actor/d_a_mg_fish.cpp
@@ -752,7 +752,7 @@ static f32 get_ground_y(mg_fish_class* i_this, cXyz* param_2) {
 static void mf_swim(mg_fish_class* i_this) {
     cXyz delta;
     switch (i_this->mActionPhase) {
-    case 0:
+    case 0: {
         i_this->mNextPos.x =  i_this->actor.home.pos.x + cM_rndFX(1000.0f);
         i_this->mNextPos.z =  i_this->actor.home.pos.z + cM_rndFX(1000.0f);
         if (i_this->field_0x624[2] == 0) {
@@ -775,6 +775,7 @@ static void mf_swim(mg_fish_class* i_this) {
             i_this->mActionPhase = 0;
             break;
         }
+    }
     case 1:
         delta = i_this->mNextPos - i_this->actor.current.pos;
         if ((i_this->mBobTimer & 3) == 0) {
@@ -875,7 +876,7 @@ static void mf_swim_p(mg_fish_class* i_this) {
         i_this->mNextPos.z = swim_path[i_this->mCurSwimStep].pos.z + cM_rndFX(200.0f);
 
         i_this->mActionPhase = 2;
-    case 2:
+    case 2: {
         cXyz delta = i_this->mNextPos - i_this->actor.current.pos;
         i_this->mMovementYaw = cM_atan2s(delta.x, delta.z);
         f32 latMoveDist = JMAFastSqrt(delta.x * delta.x + delta.z * delta.z);
@@ -893,6 +894,7 @@ static void mf_swim_p(mg_fish_class* i_this) {
             i_this->mActionPhase = 0;
         }
         break;
+    }
     case 10:
         targetSpeed = 0.0f;
         break;
@@ -997,7 +999,7 @@ static void mf_stay(mg_fish_class* i_this) {
         i_this->mActionPhase += 1;
         i_this->mMaxStep = 0;
         break;
-    case 1:
+    case 1: {
         f31 = 0.4f;
         f30 = 0.02f;
         cXyz delta = i_this->mNextPos - i_this->actor.current.pos;
@@ -1010,6 +1012,7 @@ static void mf_stay(mg_fish_class* i_this) {
         f32 mag = JMAFastSqrt(delta.x * delta.x + delta.z * delta.z);
         i_this->mMovementPitch = -cM_atan2s(delta.y, mag);
         break;
+    }
     case 2:
         cLib_addCalcAngleS2(&i_this->mMovementPitch, 0, 16, 0xa0);
         if (i_this->field_0x624[0] == 1 && i_this->field_0xc44 < 10) {
@@ -1118,7 +1121,7 @@ static void ri_swim(mg_fish_class* i_this) {
     f32 target = 0.0f;
     f32 maxStep = 0.01f;
     switch (i_this->mActionPhase) {
-    case 0:
+    case 0: {
         s16 foo = cM_rndFX(8000.0f);
         foo += i_this->actor.shape_angle.y + 0x8000;
         mDoMtx_YrotS(*calc_mtx, foo);
@@ -1138,6 +1141,7 @@ static void ri_swim(mg_fish_class* i_this) {
             break;
         }
         i_this->mMaxStep = 0;
+    }
     case 1:
         target = 0.25f;
         maxStep = 0.01f;
@@ -2611,7 +2615,7 @@ static void mf_aqua(mg_fish_class* i_this) {
         i_this->mActionPhase = 1;
         i_this->field_0x624[0] = cM_rndF(100.0f) + 100.0f;
         i_this->mMaxStep = 0;
-    case 1:
+    case 1: {
         targetSpeed = 0.4f;
         cXyz local_44 = i_this->mNextPos - i_this->actor.current.pos;
         i_this->mMovementYaw = cM_atan2s(local_44.x, local_44.z);
@@ -2631,6 +2635,7 @@ static void mf_aqua(mg_fish_class* i_this) {
             }
         }
         break;
+    }
     case 2:
         cLib_addCalcAngleS2(&i_this->mMovementPitch, 0, 0x10, 100);
         if (i_this->field_0x624[0] == 0) {
@@ -3860,7 +3865,7 @@ static int daMg_Fish_Create(fopAc_ac_c* i_this) {
 
     mg_fish_class* a_this = (mg_fish_class*)i_this;
 
-    a_this->mGedouKind = i_this->base.parameters;
+    a_this->mGedouKind = fopAcM_GetParam(i_this);
 
     bool flag1 = false;
     if (a_this->mGedouKind == 106) {
@@ -3926,7 +3931,7 @@ static int daMg_Fish_Create(fopAc_ac_c* i_this) {
     cPhs__Step retval = phase;
 
     if (phase == cPhs_COMPLEATE_e) {
-        s32 params_0 = i_this->base.parameters >> 24;
+        s32 params_0 = fopAcM_GetParam(i_this) >> 24;
         if (params_0 != 0 && params_0 != 0xff &&
             g_dComIfG_gameInfo.info.isSwitch(params_0, fopAcM_GetRoomNo(i_this)))
         {
@@ -3942,7 +3947,7 @@ static int daMg_Fish_Create(fopAc_ac_c* i_this) {
             a_this->mGedouKind == GEDOU_KIND_ED ||
             a_this->mGedouKind == GEDOU_KIND_SY)
         {
-            s32 params_2 = i_this->base.parameters >> 8 & 0xff;
+            s32 params_2 = fopAcM_GetParam(i_this) >> 8 & 0xff;
             if (params_2 == 0xff) {
                 params_2 = 0x1e;
             }
@@ -3987,7 +3992,7 @@ static int daMg_Fish_Create(fopAc_ac_c* i_this) {
         a_this->mAcch.Set(&i_this->current.pos, &i_this->old.pos, i_this, 1, &a_this->mAcchCir,
             &i_this->speed, NULL, NULL);
         a_this->field_0xc44 = dComIfGs_getEventReg(0xf11f);
-        a_this->mJointScale = 0.0001f + (i_this->base.parameters >> 8 & 0xff) * 0.01f;
+        a_this->mJointScale = 0.0001f + (fopAcM_GetParam(i_this) >> 8 & 0xff) * 0.01f;
         if (a_this->mGedouKind >= GEDOU_KIND_BG) {
             f32 fishMaxSize;
             if (lit_1008 == 1) {

--- a/src/d/actor/d_a_obj_bemos.cpp
+++ b/src/d/actor/d_a_obj_bemos.cpp
@@ -1197,7 +1197,7 @@ void daObjBm_c::Bgc_c::wall_pos(fopAc_ac_c const* i_actor, daObjBm_c::BgcSrc_c c
         sp54 = sp48 + sp6C;
 
         M_wall_work[i].Set(&sp48, &sp54, i_actor);
-        M_wall_work[i].SetActorPid(i_actor->base.id);
+        M_wall_work[i].SetActorPid(i_actor->base.base.id);
 
         if (dComIfG_Bgsp().LineCross(&M_wall_work[i])) {
             field_0x64[i] = M_wall_work[i].GetCross();

--- a/src/d/actor/d_a_obj_digsnow.cpp
+++ b/src/d/actor/d_a_obj_digsnow.cpp
@@ -117,7 +117,7 @@ void daObjDigSnow_c::mode_wait() {
 void daObjDigSnow_c::mode_init_dig() {
     dBgS_ObjGndChk obj_gnd_chk;
 
-    obj_gnd_chk.SetActorPid(base.id);
+    obj_gnd_chk.SetActorPid(base.base.id);
     obj_gnd_chk.SetPos(&current.pos);
 
     f32 gnd_height = dComIfG_Bgsp().GroundCross(&obj_gnd_chk);

--- a/src/d/actor/d_a_obj_gra2_soldier.inc
+++ b/src/d/actor/d_a_obj_gra2_soldier.inc
@@ -910,7 +910,7 @@ int daObj_GrA_c::rollAttack(void* param_1) {
                 cXyz sp54(current.pos);
                 sp54.y += 100.0f;
                 field_0x1f4c.Set(&sp54, &player->eyePos, this);
-                field_0x1f4c.SetActorPid(base.id);
+                field_0x1f4c.SetActorPid(base.base.id);
 
                 s16 sVar1 = cLib_targetAngleX(&sp54, &player->eyePos);
                 if (isFirstGra() || !dComIfG_Bgsp().LineCross(&field_0x1f4c)) {
@@ -935,7 +935,7 @@ int daObj_GrA_c::rollAttack(void* param_1) {
                 cXyz sp60(current.pos);
                 sp60.y += 100.0f;
                 field_0x1f4c.Set(&sp60, &player->eyePos, this);
-                field_0x1f4c.SetActorPid(base.id);
+                field_0x1f4c.SetActorPid(base.base.id);
 
                 if (player->checkPlayerFly() == 0 && (player->current.pos.y - current.pos.y) > 50.0f) {
                     player->offGoronSideMove();

--- a/src/d/actor/d_a_obj_iceblock.cpp
+++ b/src/d/actor/d_a_obj_iceblock.cpp
@@ -640,7 +640,7 @@ int daObjIceBlk_c::checkWallPre(s16 i_angle) {
 
     int var_r29 = -1;
 
-    linchk.SetActorPid(base.id);
+    linchk.SetActorPid(base.base.id);
 
     mDoMtx_stack_c::YrotS(i_angle);
     mDoMtx_stack_c::multVec(&cXyz::BaseZ, &spBC);
@@ -676,7 +676,7 @@ int daObjIceBlk_c::checkBgHit() {
 
     int var_r29 = -1;
 
-    mGndChk.SetActorPid(base.id);
+    mGndChk.SetActorPid(base.base.id);
 
     for (int i = 0; i < 5; i++) {
         static const Vec l_check_offsetXZ[] = {
@@ -743,7 +743,7 @@ BOOL daObjIceBlk_c::checkFall() {
     cXyz end;
 
     dBgS_ObjLinChk linchk;
-    linchk.SetActorPid(base.id);
+    linchk.SetActorPid(base.base.id);
 
     for (int i = 0; i < 5; i++) {
         static const Vec l_check_offsetXZ[] = {

--- a/src/d/actor/d_a_obj_ladder.cpp
+++ b/src/d/actor/d_a_obj_ladder.cpp
@@ -186,7 +186,7 @@ int daObjLadder::Act_c::Create() {
     mDoMtx_stack_c::multVecZero(&gndVec);
     mDoMtx_stack_c::pop();
     mGndChk.SetPos(&gndVec);
-    mGndChk.SetActorPid(base.id);
+    mGndChk.SetActorPid(base.base.id);
     mHeight = dComIfG_Bgsp().GroundCross(&mGndChk);
     mInDemo = false;
     mEventIdx = dComIfGp_getEventManager().getEventIdx(this, prm_get_evId());

--- a/src/d/actor/d_a_obj_lv4chandelier.cpp
+++ b/src/d/actor/d_a_obj_lv4chandelier.cpp
@@ -449,7 +449,7 @@ void daObjLv4Chan_c::chkGnd() {
     cStack_18 = field_0x23bc;
     cStack_18.y += 300.0f;
     mGndChk.SetPos(&cStack_18);
-    mGndChk.SetActorPid(base.id);
+    mGndChk.SetActorPid(base.base.id);
     field_0x247c = dComIfG_Bgsp().GroundCross(&mGndChk);
 }
 

--- a/src/d/actor/d_a_obj_lv4digsand.cpp
+++ b/src/d/actor/d_a_obj_lv4digsand.cpp
@@ -113,7 +113,7 @@ void daObjL4DigSand_c::mode_wait() {
  */
 void daObjL4DigSand_c::mode_init_dig() {
     dBgS_ObjGndChk gndchk;
-    gndchk.SetActorPid(base.id);
+    gndchk.SetActorPid(base.base.id);
     gndchk.SetPos(&current.pos);
 
     f32 gnd_y = dComIfG_Bgsp().GroundCross(&gndchk);

--- a/src/d/actor/d_a_obj_movebox.cpp
+++ b/src/d/actor/d_a_obj_movebox.cpp
@@ -68,7 +68,7 @@ void daObjMovebox::Bgc_c::gnd_pos(const daObjMovebox::Act_c* i_actor,
 
         mDoMtx_stack_c::multVec(&sp50, &sp5C);
         M_gnd_work[i].SetPos(&sp5C);
-        M_gnd_work[i].SetActorPid(i_actor->base.id);
+        M_gnd_work[i].SetActorPid(i_actor->base.base.id);
         field_0x0[i] = dComIfG_Bgsp().GroundCross(&M_gnd_work[i]);
 
         if (field_0x0[i] > var_f31) {
@@ -149,7 +149,7 @@ void daObjMovebox::Bgc_c::wall_pos(daObjMovebox::Act_c const* i_actor,
         sp54 = sp48 + sp6C;
 
         M_wall_work[i].Set(&sp48, &sp54, i_actor);
-        M_wall_work[i].SetActorPid(i_actor->base.id);
+        M_wall_work[i].SetActorPid(i_actor->base.base.id);
 
         if (dComIfG_Bgsp().LineCross(&M_wall_work[i])) {
             field_0x64[i] = M_wall_work[i].GetCross();
@@ -252,7 +252,7 @@ bool daObjMovebox::Bgc_c::chk_wall_touch(daObjMovebox::Act_c const* i_actor,
     sp38 += i_actor->current.pos;
     sp44 = sp38 + sp68;
 
-    touch_work.SetActorPid(i_actor->base.id);
+    touch_work.SetActorPid(i_actor->base.base.id);
     touch_work.Set(&sp38, &sp44, i_actor);
     return dComIfG_Bgsp().LineCross(&touch_work);
 }

--- a/src/d/actor/d_a_obj_pdtile.cpp
+++ b/src/d/actor/d_a_obj_pdtile.cpp
@@ -443,7 +443,7 @@ int daObjPDtile_c::Execute(Mtx** param_1) {
                                   -1.0f, 0);
         }
         dBgS_ObjGndChk adStack_e4;
-        adStack_e4.SetActorPid(base.id);
+        adStack_e4.SetActorPid(base.base.id);
         adStack_e4.SetPos(&current.pos);
         dComIfG_Bgsp().GroundCross(&adStack_e4);
         if (home.pos.y - current.pos.y < -3000.0f) {

--- a/src/d/actor/d_a_obj_tmoon.cpp
+++ b/src/d/actor/d_a_obj_tmoon.cpp
@@ -71,7 +71,7 @@ int daObjTMoon_c::execute() {
     } else if ((field_0x574 != 0x3ff) &&
                (dComIfGs_isEventBit(dSv_event_flag_c::saveBitLabels[field_0x574])))
     {
-        fopDwTg_ToDrawQ(&draw_tag, fpcLf_GetPriority(this));
+        fopDwTg_ToDrawQ(&draw_tag, fpcM_DrawPriority(this));
         return 1;
     }
     return 1;

--- a/src/d/actor/d_a_obj_udoor.cpp
+++ b/src/d/actor/d_a_obj_udoor.cpp
@@ -135,7 +135,7 @@ static cPhs__Step daObj_Udoor_Create(fopAc_ac_c* i_this) {
     
     cPhs__Step phase_state = (cPhs__Step)dComIfG_resLoad(&a_this->mPhase, "Obj_udoor");
     if (phase_state == cPhs_COMPLEATE_e) {
-        a_this->field_0x570 = a_this->base.parameters;
+        a_this->field_0x570 = fopAcM_GetParam(a_this);
         if (a_this->field_0x570 == 0xff) {
             a_this->field_0x570 = 0;
         }

--- a/src/d/actor/d_a_tag_push.cpp
+++ b/src/d/actor/d_a_tag_push.cpp
@@ -15,31 +15,31 @@ void* daTag_Push_c::srchActor(void* param_0, void* param_1) {
         if (fopAcM_IsExecuting(fopAcM_GetID(param_0))) {
             switch (((daTag_Push_c*)param_1)->getId()) {
             case 1:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_TARO;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_TARO;
                 break;
             case 2:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_JAGAR;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_JAGAR;
                 break;
             case 3:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_LEN;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_LEN;
                 break;
             case 4:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_TARO;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_TARO;
                 break;
             case 5:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_MARO;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_MARO;
                 break;
             case 6:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_BESU;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_BESU;
                 break;
             case 7:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_BOU;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_BOU;
                 break;
             case 8:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_GRS;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_GRS;
                 break;
             case 9:
-                bVar1 = ((daTag_Push_c*)param_0)->base.name == PROC_NPC_GRO;
+                bVar1 = fopAcM_GetName(param_0) == PROC_NPC_GRO;
                 break;
             }
         }

--- a/src/d/actor/d_a_tbox.cpp
+++ b/src/d/actor/d_a_tbox.cpp
@@ -810,7 +810,7 @@ void daTbox_c::dropProc() {
 
         dBgS_ObjGndChk gnd_chk;
         gnd_chk.SetPos(&chkpos);
-        gnd_chk.SetActorPid(base.id);
+        gnd_chk.SetActorPid(base.base.id);
         dComIfG_Bgsp().GroundCross(&gnd_chk);
 
         int bg_index = gnd_chk.GetBgIndex();

--- a/src/f_op/f_op_actor.cpp
+++ b/src/f_op/f_op_actor.cpp
@@ -209,7 +209,7 @@ static int fopAc_Create(void* i_this) {
 
     int ret = fpcMtd_Create((process_method_class*)a_this->sub_method, a_this);
     if (ret == cPhs_COMPLEATE_e) {
-        s32 priority = fpcLf_GetPriority(a_this);
+        s32 priority = fpcM_DrawPriority(a_this);
         fopDwTg_ToDrawQ(&a_this->draw_tag, priority);
     } else if (ret == cPhs_ERROR_e) {
         fopAcM_OnCondition(a_this, 0x10);

--- a/src/f_op/f_op_actor_mng.cpp
+++ b/src/f_op/f_op_actor_mng.cpp
@@ -1911,7 +1911,8 @@ void fopAcM_setEffectMtx(const fopAc_ac_c* i_actor, const J3DModelData* modelDat
 
 /* 8001D5A4-8001D5EC 017EE4 0048+00 1/1 0/0 0/0 .text fopAcM_getProcNameString__FPC10fopAc_ac_c */
 static const char* fopAcM_getProcNameString(const fopAc_ac_c* i_actor) {
-    const char* name = dStage_getName2(i_actor->base.profname, i_actor->argument);
+    s16 prof_name = fopAcM_GetProfName(i_actor);
+    const char* name = dStage_getName2(prof_name, i_actor->argument);
     return name != NULL ? name : "UNKOWN";
 }
 

--- a/src/f_op/f_op_camera.cpp
+++ b/src/f_op/f_op_camera.cpp
@@ -102,7 +102,7 @@ static int fopCam_Create(void* i_this) {
 
     int ret = fpcMtd_Create(&a_this->submethod->base, a_this);
     if (ret == cPhs_COMPLEATE_e) {
-        s32 priority = fpcLf_GetPriority(a_this);
+        s32 priority = fpcM_DrawPriority(a_this);
         fopDwTg_ToDrawQ(&a_this->create_tag, priority);
     }
 

--- a/src/f_op/f_op_camera_mng.cpp
+++ b/src/f_op/f_op_camera_mng.cpp
@@ -12,12 +12,12 @@ static fpc_ProcID l_fopCamM_id[4];
 
 /* 8001E308-8001E310 018C48 0008+00 0/0 12/12 2/2 .text fopCamM_GetParam__FP12camera_class */
 u32 fopCamM_GetParam(camera_class* i_this) {
-    return i_this->base.parameters;
+    return fpcM_GetParam(i_this);
 }
 
 /* 8001E310-8001E374 018C50 0064+00 0/0 1/1 0/0 .text            fopCamM_Create__FisPv */
 fpc_ProcID fopCamM_Create(int i_cameraIdx, s16 i_procName, void* i_append) {
-    l_fopCamM_id[i_cameraIdx] = fpcSCtRq_Request(fpcLy_CurrentLayer(), i_procName, NULL, NULL, i_append);
+    l_fopCamM_id[i_cameraIdx] = fpcM_Create(i_procName, NULL, i_append);
     return l_fopCamM_id[i_cameraIdx];
 }
 

--- a/src/f_op/f_op_kankyo.cpp
+++ b/src/f_op/f_op_kankyo.cpp
@@ -81,7 +81,7 @@ static int fopKy_Create(void* i_this) {
 
     int ret = fpcMtd_Create(&a_this->sub_method->base, a_this);
     if (ret == cPhs_COMPLEATE_e) {
-        s32 priority = fpcLf_GetPriority(a_this);
+        s32 priority = fpcM_DrawPriority(a_this);
         fopDwTg_ToDrawQ(&a_this->draw_tag, priority);
     }
 

--- a/src/f_op/f_op_msg.cpp
+++ b/src/f_op/f_op_msg.cpp
@@ -75,7 +75,7 @@ int fopMsg_Create(void* i_this) {
 
     int ret = fpcMtd_Create(&a_this->sub_method->base, a_this);
     if (ret == cPhs_COMPLEATE_e) {
-        s32 priority = fpcLf_GetPriority(a_this);
+        s32 priority = fpcM_DrawPriority(a_this);
         fopDwTg_ToDrawQ(&a_this->draw_tag, priority);
     }
 

--- a/src/f_op/f_op_msg_mng.cpp
+++ b/src/f_op/f_op_msg_mng.cpp
@@ -29,8 +29,7 @@ msg_class* fopMsgM_SearchByID(fpc_ProcID i_id) {
 
 /* 8001FA44-8001FA4C 01A384 0008+00 0/0 2/2 0/0 .text            fopMsgM_GetAppend__FPv */
 fopMsg_prm_class* fopMsgM_GetAppend(void* i_msg) {
-    msg_class* msg = (msg_class*)i_msg;
-    return (fopMsg_prm_class*)msg->base.append;
+    return (fopMsg_prm_class*)fpcM_GetAppend(i_msg);
 }
 
 /* 8001FA4C-8001FA6C 01A38C 0020+00 0/0 2/2 0/0 .text            fopMsgM_Delete__FPv */


### PR DESCRIPTION
Debug RTTI for `fopAc_ac_c` suggests it does not use inheritance. I also fixed most of the other f_op classes, but the camera-related ones seem to have other issues that need to be addressed before fixing their RTTI so I left those out for now.