### PR TITLE
minor dol fixes for linkability

### DIFF
--- a/include/JSystem/J2DGraph/J2DPicture.h
+++ b/include/JSystem/J2DGraph/J2DPicture.h
@@ -90,7 +90,9 @@ public:
     /* 802FF320 */ virtual void prepend(JUTTexture* param_0, f32 param_1) {
         insert(param_0, 0, param_1);
     }
-    /* 801BDD70 */ virtual bool insert(ResTIMG const*, u8, f32);
+    /* 801BDD70 */ virtual bool insert(ResTIMG const*, u8, f32) {
+        // NONMATCHING
+    }
     /* 802FD168 */ virtual bool insert(ResTIMG const*, JUTPalette*, u8, f32);
     /* 80020368 */ virtual bool insert(char const* param_0, u8 param_1, f32 param_2) {
         return insert(param_0, NULL, param_1, param_2);

--- a/include/d/d_menu_dmap_map.h
+++ b/include/d/d_menu_dmap_map.h
@@ -74,7 +74,7 @@ public:
     virtual void getInitDispCenter(f32*, f32*) = 0;
     virtual void getZoomMinMaxCheck(f32*, f32*, f32*, f32*, bool*, bool*) = 0;
     virtual f32 getZoomCmPerPixel() = 0;
-    virtual void draw();
+    void draw() {}
 
     /* 801C0EE0 */ f32 getMapBlendPer() const;
     /* 801C0F24 */ f32 getPixelStageSizeX() const;

--- a/include/d/d_msg_scrn_base.h
+++ b/include/d/d_msg_scrn_base.h
@@ -19,24 +19,24 @@ public:
 
     /* 8023C274 */ virtual void draw();
     /* 8023C124 */ virtual ~dMsgScrnBase_c();
-    /* 80238C3C */ virtual void exec();
+    /* 80238C3C */ virtual void exec() {}
     /* 8023C234 */ virtual void multiDraw();
     /* 8023C300 */ virtual void drawSelf();
-    /* 80238C44 */ virtual void setSelectString(char*, char*, char*);
-    /* 80238C40 */ virtual void setSelectRubyString(char*, char*, char*);
-    /* 80238C58 */ virtual void arwAnimeInit();
-    /* 80238C54 */ virtual void arwAnimeMove();
-    /* 80238C74 */ virtual void dotAnimeInit();
-    /* 80238C70 */ virtual void dotAnimeMove();
-    /* 80238C60 */ virtual bool isSelect();
-    /* 80238C50 */ virtual void selectAnimeInit(u8, u8, f32, u8);
-    /* 80238C48 */ virtual bool selectAnimeMove(u8, u8, bool);
-    /* 80238C68 */ virtual bool selectAnimeEnd();
+    /* 80238C44 */ virtual void setSelectString(char*, char*, char*) {}
+    /* 80238C40 */ virtual void setSelectRubyString(char*, char*, char*) {}
+    /* 80238C58 */ virtual void arwAnimeInit() {}
+    /* 80238C54 */ virtual void arwAnimeMove() {}
+    /* 80238C74 */ virtual void dotAnimeInit() {}
+    /* 80238C70 */ virtual void dotAnimeMove() {}
+    /* 80238C60 */ virtual bool isSelect() { return true; }
+    /* 80238C50 */ virtual void selectAnimeInit(u8, u8, f32, u8) {}
+    /* 80238C48 */ virtual bool selectAnimeMove(u8, u8, bool) { return true; }
+    /* 80238C68 */ virtual bool selectAnimeEnd() { return true; }
     /* 8023C458 */ virtual void fukiScale(f32);
     /* 8023C480 */ virtual void fukiTrans(f32, f32);
     /* 8023C4A4 */ virtual void fukiAlpha(f32);
     /* 8023C4F4 */ virtual void fontAlpha(f32);
-    /* 80238C5C */ virtual void fukiPosCalc(u8);
+    /* 80238C5C */ virtual void fukiPosCalc(u8) {}
 
     f32 getSelTextBoxPosX(int idx) { return mSelTextBoxPosX[idx]; }
     f32 getSelTextBoxPosY(int idx) { return mSelTextBoxPosY[idx]; }


### PR DESCRIPTION
As noted in tp-mod-help-and-discussion, there were 2 DOL TUs that could not be marked as equivalent + linked into framework.dol:
1. d_menu_dmap
2. d_msg_object

Both complained about missing vtables and functions, so I cleaned up whatever the linker complained about, and now the TUs can link!

If you are curious, except for a handful of `d_a_npc_(etc)` TUs, all TUs can now be linked! We'd need to clean up the "stringbase" annoyance in said NPC files if we want them to link at the minimum.