### PR TITLE
NPC str cleanup and misc for 100% linkability

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -712,7 +712,7 @@ config.libs = [
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d/d_meter2.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d/d_msg_out_font.cpp"),
             Object(NonMatching, "d/d_msg_class.cpp"),
-            Object(NonMatching, "d/d_msg_object.cpp"),
+            Object(Equivalent, "d/d_msg_object.cpp"),  # weak func order
             Object(NonMatching, "d/d_msg_unit.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d/d_msg_scrn_3select.cpp"),
             Object(MatchingFor("GZ2E01", "GZ2P01", "GZ2J01"), "d/d_msg_scrn_arrow.cpp"),

--- a/include/d/actor/d_a_npc_bans.h
+++ b/include/d/actor/d_a_npc_bans.h
@@ -63,7 +63,7 @@ public:
     /* 80967C04 */ void checkChangeJoint(int);
     /* 80967C14 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[4];
+    static char* mCutNameList[4];
     static u8 mCutList[48];
 private:
     /* 0x568 */ u8 field_0x568[0x1270 - 0x568];

--- a/include/d/actor/d_a_npc_clerka.h
+++ b/include/d/actor/d_a_npc_clerka.h
@@ -54,7 +54,7 @@ public:
     /* 809956B4 */ void checkChangeJoint(int);
     /* 809956C4 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/include/d/actor/d_a_npc_clerkb.h
+++ b/include/d/actor/d_a_npc_clerkb.h
@@ -58,7 +58,7 @@ public:
     /* 809997CC */ void checkChangeJoint(int);
     /* 809997DC */ void checkRemoveJoint(int);
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/include/d/actor/d_a_npc_clerkt.h
+++ b/include/d/actor/d_a_npc_clerkt.h
@@ -52,7 +52,7 @@ public:
     /* 8099D098 */ s32 getNeckJointNo();
     /* 8099D0A0 */ s32 getHeadJointNo();
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/include/d/actor/d_a_npc_doc.h
+++ b/include/d/actor/d_a_npc_doc.h
@@ -56,7 +56,7 @@ public:
     /* 809AA294 */ s32 getFootRJointNo();
     /* 809AA29C */ void chkXYItems();
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/include/d/actor/d_a_npc_fairy.h
+++ b/include/d/actor/d_a_npc_fairy.h
@@ -114,7 +114,7 @@ public:
     /* 809B9258 */ void checkChangeJoint(int);
     /* 809B9268 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[18];
+    static char* mCutNameList[18];
     static u8 mCutList[216];
 private:
     /* 0x568 */ u8 field_0x568[0x10c8 - 0x568];

--- a/include/d/actor/d_a_npc_gra.h
+++ b/include/d/actor/d_a_npc_gra.h
@@ -97,7 +97,7 @@ public:
 
     int getType() { return mType; }
 
-    static void* mEvtCutNameList[12];
+    static char* mEvtCutNameList[12];
     static u8 mEvtCutList[144];
 
 private:

--- a/include/d/actor/d_a_npc_grd.h
+++ b/include/d/actor/d_a_npc_grd.h
@@ -53,7 +53,7 @@ public:
     /* 809D2C9C */ void ECut_nodToGrz(int);
     /* 809D3994 */ void adjustShapeAngle();
 
-    static void* mEvtCutNameList[2];
+    static char* mEvtCutNameList[2];
     static u8 mEvtCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_grm.h
+++ b/include/d/actor/d_a_npc_grm.h
@@ -57,7 +57,7 @@ public:
     /* 809D5FB8 */ void checkChangeJoint(int);
     /* 809D5FC8 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[2];
+    static char* mCutNameList[2];
     static u8 mCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_gro.h
+++ b/include/d/actor/d_a_npc_gro.h
@@ -56,7 +56,7 @@ public:
     /* 809DE4EC */ void test(void*);
     /* 809DEF0C */ void adjustShapeAngle();
 
-    static void* mEvtCutNameList[3];
+    static char* mEvtCutNameList[3];
     static u8 mEvtCutList[36];
 
 private:

--- a/include/d/actor/d_a_npc_grs.h
+++ b/include/d/actor/d_a_npc_grs.h
@@ -54,7 +54,7 @@ public:
     /* 809E7300 */ void setPrtcl();
     /* 809E7D5C */ void adjustShapeAngle();
 
-    static void* mEvtCutNameList[2];
+    static char* mEvtCutNameList[2];
     static u8 mEvtCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_hoz.h
+++ b/include/d/actor/d_a_npc_hoz.h
@@ -81,7 +81,7 @@ public:
     bool getGameStartFlag() { return mGameStartFlag; }
     void setPotBreakFlag() { mPotBreakFlag = true; }
 
-    static void* mCutNameList[8];
+    static char* mCutNameList[8];
     static u8 mCutList[96];
 
 private:

--- a/include/d/actor/d_a_npc_kn.h
+++ b/include/d/actor/d_a_npc_kn.h
@@ -363,8 +363,12 @@ public:
     /* 80A3B708 */ virtual void decTmr();
     /* 80A3A504 */ virtual void clrParam();
     /* 80A3B7C4 */ virtual bool afterSetFaceMotionAnm(int, int, f32, int) { return true; }
-    /* 80A3B7CC */ virtual daNpcT_faceMotionAnmData_c getFaceMotionAnm(daNpcT_faceMotionAnmData_c);
-    /* 80A3B7FC */ virtual daNpcT_motionAnmData_c getMotionAnm(daNpcT_motionAnmData_c);
+    /* 80A3B7CC */ virtual daNpcT_faceMotionAnmData_c getFaceMotionAnm(daNpcT_faceMotionAnmData_c arg0) {
+        return arg0;
+    }
+    /* 80A3B7FC */ virtual daNpcT_motionAnmData_c getMotionAnm(daNpcT_motionAnmData_c arg0) {
+        return arg0;
+    }
     /* 80A2AA0C */ virtual ~daNpc_Kn_c();
     /* 80A2D060 */ virtual bool afterSetMotionAnm(int, int, f32, int);
     

--- a/include/d/actor/d_a_npc_knj.h
+++ b/include/d/actor/d_a_npc_knj.h
@@ -44,7 +44,7 @@ public:
                                daNpcT_MotionSeqMngr_c::sequenceStepData_c const*, int,
                                daNpcT_evtData_c const*, char**);
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/include/d/actor/d_a_npc_kyury.h
+++ b/include/d/actor/d_a_npc_kyury.h
@@ -54,7 +54,7 @@ public:
     /* 80A63820 */ void checkChangeJoint(int);
     /* 80A63830 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[2];
+    static char* mCutNameList[2];
     static u8 mCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_len.h
+++ b/include/d/actor/d_a_npc_len.h
@@ -60,7 +60,7 @@ public:
     /* 80A68E28 */ s32 getFootRJointNo();
     /* 80A68E30 */ bool chkXYItems();
 
-    static void* mCutNameList[4];
+    static char* mCutNameList[4];
     static u8 mCutList[48];
 
 private:

--- a/include/d/actor/d_a_npc_myna2.h
+++ b/include/d/actor/d_a_npc_myna2.h
@@ -51,7 +51,7 @@ public:
     /* 80A86BEC */ void ECut_gameGoalSuccess(int);
     /* 80A86E8C */ void calcHovering(int, int);
 
-    static void* mEvtCutNameList[5];
+    static char* mEvtCutNameList[5];
     static u8 mEvtCutList[60];
 
 private:

--- a/include/d/actor/d_a_npc_pachi_maro.h
+++ b/include/d/actor/d_a_npc_pachi_maro.h
@@ -89,7 +89,7 @@ public:
     /* 80A9B800 */ void checkChangeJoint(int);
     /* 80A9B810 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[11];
+    static char* mCutNameList[11];
     static u8 mCutList[132];
 
 private:

--- a/include/d/actor/d_a_npc_pachi_taro.h
+++ b/include/d/actor/d_a_npc_pachi_taro.h
@@ -107,7 +107,7 @@ public:
 
     void clrMesPat() { mMesPat = -1; }
 
-    static void* mCutNameList[11];
+    static char* mCutNameList[11];
     static u8 mCutList[132];
 
 private:

--- a/include/d/actor/d_a_npc_post.h
+++ b/include/d/actor/d_a_npc_post.h
@@ -62,7 +62,7 @@ public:
     /* 80AAD110 */ s32 getFootLJointNo();
     /* 80AAD118 */ s32 getFootRJointNo();
 
-    static void* mCutNameList[2];
+    static char* mCutNameList[2];
     static u8 mCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_pouya.h
+++ b/include/d/actor/d_a_npc_pouya.h
@@ -59,7 +59,7 @@ public:
 
     MtxP getHeadMtx() { return mpMorf->getModel()->getAnmMtx(4); }
 
-    static void* mCutNameList[3];
+    static char* mCutNameList[3];
     static u8 mCutList[36];
 
 private:

--- a/include/d/actor/d_a_npc_shaman.h
+++ b/include/d/actor/d_a_npc_shaman.h
@@ -66,7 +66,7 @@ public:
     /* 80AE6B3C */ void checkChangeJoint(int);
     /* 80AE6B4C */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[2];
+    static char* mCutNameList[2];
     static u8 mCutList[24];
     static u8 mEvtBitLabels[12];
     static u8 mTmpBitLabels[12];

--- a/include/d/actor/d_a_npc_sola.h
+++ b/include/d/actor/d_a_npc_sola.h
@@ -49,7 +49,7 @@ public:
     /* 80AEF084 */ s32 getNeckJointNo();
     /* 80AEF08C */ bool getBackboneJointNo();
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/include/d/actor/d_a_npc_soldierA.h
+++ b/include/d/actor/d_a_npc_soldierA.h
@@ -48,7 +48,7 @@ public:
     /* 80AF1B8C */ void ECut_listenLake(int);
     /* 80AF1CA4 */ void test(void*);
 
-    static void* mEvtCutNameList[3];
+    static char* mEvtCutNameList[3];
     static u8 mEvtCutList[36];
 
 private:

--- a/include/d/actor/d_a_npc_soldierB.h
+++ b/include/d/actor/d_a_npc_soldierB.h
@@ -47,7 +47,7 @@ public:
     /* 80AF4F54 */ void ECut_listenLake(int);
     /* 80AF50AC */ void test(void*);
 
-    static void* mEvtCutNameList[2];
+    static char* mEvtCutNameList[2];
     static u8 mEvtCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_the.h
+++ b/include/d/actor/d_a_npc_the.h
@@ -113,7 +113,7 @@ public:
     /* 80AFAEC8 */ void setAttnPos();
     /* 80AFB1C4 */ void lookat();
     /* 80AFB488 */ BOOL drawDbgInfo();
-    /* 80AFBD9C */ void adjustShapeAngle();
+    /* 80AFBD9C */ void adjustShapeAngle() {}
 
     u8 getTypeFromParam() {
         switch (fopAcM_GetParam(this) & 0xff) {

--- a/include/d/actor/d_a_npc_toby.h
+++ b/include/d/actor/d_a_npc_toby.h
@@ -70,7 +70,7 @@ public:
     /* 80B24968 */ s32 getFootRJointNo();
     /* 80B24970 */ bool chkXYItems();
 
-    static void* mCutNameList[7];
+    static char* mCutNameList[7];
     static u8 mCutList[84];
 
 private:

--- a/include/d/actor/d_a_npc_yamis.h
+++ b/include/d/actor/d_a_npc_yamis.h
@@ -57,7 +57,7 @@ public:
     /* 80B495C8 */ void checkRemoveJoint(int);
     /* 80B495D8 */ void evtEndProc();
 
-    static void* mCutNameList[2];
+    static char* mCutNameList[2];
     static u8 mCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_yamit.h
+++ b/include/d/actor/d_a_npc_yamit.h
@@ -59,7 +59,7 @@ public:
     /* 80B4CD18 */ void checkChangeJoint(int);
     /* 80B4CD28 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList[2];
+    static char* mCutNameList[2];
     static u8 mCutList[24];
 
 private:

--- a/include/d/actor/d_a_npc_zanb.h
+++ b/include/d/actor/d_a_npc_zanb.h
@@ -53,7 +53,7 @@ public:
     /* 80B6BC38 */ void checkChangeJoint(int);
     /* 80B6BC48 */ void checkRemoveJoint(int);
 
-    static void* mCutNameList;
+    static char* mCutNameList[1];
     static u8 mCutList[12];
 
 private:

--- a/src/d/actor/d_a_npc_bans.cpp
+++ b/src/d/actor/d_a_npc_bans.cpp
@@ -346,38 +346,26 @@ SECTION_DATA static u8 l_bmdData[32] = {
 };
 
 /* 80968040-80968088 -00001 0048+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[18] = {
-    (void*)&d_a_npc_bans__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x11),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x1D),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x28),
-    (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x2E),
-    (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x35),
-    (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x40),
-    (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x4C),
-    (void*)0x00000003,
+static daNpcT_evtData_c l_evtList[9] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
+    {"NO_RESPONSE", 0},
+    {"DEMO13_STB", 0},
+    {"ANGER", 3},
+    {"ANGER2", 4},
+    {"ANGER_NEAR", 3},
+    {"ANGER_NEAR2", 4},
+    {"GOBACK", 3},
 };
-#pragma pop
 
 /* 80968088-809680A0 -00001 0018+00 3/4 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[6] = {
-    (void*)&d_a_npc_bans__stringBase0,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x53),
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x58),
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x60),
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x66),
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x6C),
+static char* l_resNameList[6] = {
+    "",
+    "Bans",
+    "Bans_TW",
+    "Bans1",
+    "Bans2",
+    "Len1",
 };
 
 /* 809680A0-809680A4 0000A0 0003+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -526,11 +514,11 @@ SECTION_DATA static u8 l_motionSequenceData[336] = {
 #pragma pop
 
 /* 8096852C-8096853C -00001 0010+00 1/1 0/0 0/0 .data            mCutNameList__12daNpc_Bans_c */
-SECTION_DATA void* daNpc_Bans_c::mCutNameList[4] = {
-    (void*)&d_a_npc_bans__stringBase0,
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x28),
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x71),
-    (void*)(((char*)&d_a_npc_bans__stringBase0) + 0x7A),
+char* daNpc_Bans_c::mCutNameList[4] = {
+    "",
+    "ANGER",
+    "PURCHASE",
+    "GO_BACK",
 };
 
 /* 8096853C-80968548 -00001 000C+00 0/1 0/0 0/0 .data            @3870 */

--- a/src/d/actor/d_a_npc_blue_ns.cpp
+++ b/src/d/actor/d_a_npc_blue_ns.cpp
@@ -263,27 +263,21 @@ SECTION_DATA static u8 l_bckGetParamList[108] = {
 };
 
 /* 8096CC2C-8096CC30 -00001 0004+00 4/5 0/0 0/0 .data            l_arcNames */
-SECTION_DATA static void* l_arcNames = (void*)&d_a_npc_blue_ns__stringBase0;
+static char* l_arcNames[1] = {"Blue_NS"};
 
 /* 8096CC30-8096CC4C -00001 001C+00 0/1 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[7] = {
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_blue_ns__stringBase0) + 0x8),
-    (void*)(((char*)&d_a_npc_blue_ns__stringBase0) + 0x17),
-    (void*)(((char*)&d_a_npc_blue_ns__stringBase0) + 0x25),
-    (void*)(((char*)&d_a_npc_blue_ns__stringBase0) + 0x34),
-    (void*)(((char*)&d_a_npc_blue_ns__stringBase0) + 0x34),
-    (void*)(((char*)&d_a_npc_blue_ns__stringBase0) + 0x34),
+static char* l_evtNames[7] = {
+    NULL,
+    "CHG_YAMI_CHIBI",
+    "CHG_YAMI_DEBU",
+    "CHG_YAMI_NOPPO",
+    "CHG_YAMI_NOPPO_STOPPER",
+    "CHG_YAMI_NOPPO_STOPPER",
+    "CHG_YAMI_NOPPO_STOPPER",
 };
-#pragma pop
 
 /* 8096CC4C-8096CC50 -00001 0004+00 0/2 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)&d_a_npc_blue_ns__stringBase0;
-#pragma pop
+static char* l_myName = "Blue_NS";
 
 /* 8096CC50-8096CC5C -00001 000C+00 0/1 0/0 0/0 .data            @3890 */
 #pragma push

--- a/src/d/actor/d_a_npc_bouS.cpp
+++ b/src/d/actor/d_a_npc_bouS.cpp
@@ -295,24 +295,21 @@ SECTION_DATA static u8 l_btkGetParamList[12] = {
 };
 
 /* 80978920-80978928 -00001 0008+00 6/7 0/0 0/0 .data            l_arcNames */
-SECTION_DATA static void* l_arcNames[2] = {
-    (void*)&d_a_npc_bouS__stringBase0,
-    (void*)(((char*)&d_a_npc_bouS__stringBase0) + 0x4),
+static char* l_arcNames[2] = {
+    "Bou",
+    "Bou4",
 };
 
 /* 80978928-80978938 -00001 0010+00 3/4 0/0 0/0 .data            l_evtNames */
-SECTION_DATA static void* l_evtNames[4] = {
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_bouS__stringBase0) + 0x9),
-    (void*)(((char*)&d_a_npc_bouS__stringBase0) + 0x1A),
-    (void*)(((char*)&d_a_npc_bouS__stringBase0) + 0x2B),
+static char* l_evtNames[4] = {
+    NULL,
+    "BOUS_INTRO_SUMO1",
+    "BOUS_INTRO_SUMO2",
+    "BOUS_INTRO_SUMO3",
 };
 
 /* 80978938-8097893C -00001 0004+00 0/2 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_bouS__stringBase0) + 0x3C);
-#pragma pop
+static char* l_myName = "BouS";
 
 /* 8097893C-80978948 -00001 000C+00 0/1 0/0 0/0 .data            @4036 */
 #pragma push

--- a/src/d/actor/d_a_npc_chat.cpp
+++ b/src/d/actor/d_a_npc_chat.cpp
@@ -431,334 +431,304 @@ extern "C" char const* const stringBase_80987943;
 extern "C" char const* const stringBase_8098794A;
 
 /* 8098699C-809869B4 -00001 0018+00 8/7 0/0 0/0 .rodata          l_resMANa */
-SECTION_RODATA static void* const l_resMANa[6] = {
-    (void*)&d_a_npc_chat__stringBase0,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x6),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMANa[6] = {
+    "MAN_a",
+    "MAN_a_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x8098699C, &l_resMANa);
 
 /* 809869B4-809869CC -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMADa */
-SECTION_RODATA static void* const l_resMADa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x31),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x37),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMADa[6] = {
+    "MAD_a",
+    "MAD_a_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x809869B4, &l_resMADa);
 
 /* 809869CC-809869E4 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMCNa */
-SECTION_RODATA static void* const l_resMCNa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x40),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x46),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMCNa[6] = {
+    "MCN_a",
+    "MCN_a_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x809869CC, &l_resMCNa);
 
 /* 809869E4-809869FC -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMONa */
-SECTION_RODATA static void* const l_resMONa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x4F),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x55),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMONa[6] = {
+    "MON_a",
+    "MON_a_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x809869E4, &l_resMONa);
 
 /* 809869FC-80986A14 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMANb */
-SECTION_RODATA static void* const l_resMANb[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x5E),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x64),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMANb[6] = {
+    "MAN_b",
+    "MAN_b_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x809869FC, &l_resMANb);
 
 /* 80986A14-80986A2C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMANc */
-SECTION_RODATA static void* const l_resMANc[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x6D),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x73),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMANc[6] = {
+    "MAN_c",
+    "MAN_c_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986A14, &l_resMANc);
 
 /* 80986A2C-80986A44 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMASa */
-SECTION_RODATA static void* const l_resMASa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x7C),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x82),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMASa[6] = {
+    "MAS_a",
+    "MAS_a_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986A2C, &l_resMASa);
 
 /* 80986A44-80986A5C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMBNa */
-SECTION_RODATA static void* const l_resMBNa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x8B),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x91),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMBNa[6] = {
+    "MBN_a",
+    "MBN_a_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986A44, &l_resMBNa);
 
 /* 80986A5C-80986A74 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMANa2 */
-SECTION_RODATA static void* const l_resMANa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x9A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xA1),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMANa2[6] = {
+    "MAN_a2",
+    "MAN_a2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986A5C, &l_resMANa2);
 
 /* 80986A74-80986A8C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMADa2 */
-SECTION_RODATA static void* const l_resMADa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xAB),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xB2),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMADa2[6] = {
+    "MAD_a2",
+    "MAD_a2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986A74, &l_resMADa2);
 
 /* 80986A8C-80986AA4 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMCNa2 */
-SECTION_RODATA static void* const l_resMCNa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xBC),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xC3),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMCNa2[6] = {
+    "MCN_a2",
+    "MCN_a2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986A8C, &l_resMCNa2);
 
 /* 80986AA4-80986ABC -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMONa2 */
-SECTION_RODATA static void* const l_resMONa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xCD),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xD4),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMONa2[6] = {
+    "MON_a2",
+    "MON_a2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986AA4, &l_resMONa2);
 
 /* 80986ABC-80986AD4 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMANb2 */
-SECTION_RODATA static void* const l_resMANb2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xDE),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xE5),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMANb2[6] = {
+    "MAN_b2",
+    "MAN_b2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986ABC, &l_resMANb2);
 
 /* 80986AD4-80986AEC -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMANc2 */
-SECTION_RODATA static void* const l_resMANc2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xEF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF6),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMANc2[6] = {
+    "MAN_c2",
+    "MAN_c2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986AD4, &l_resMANc2);
 
 /* 80986AEC-80986B04 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMASa2 */
-SECTION_RODATA static void* const l_resMASa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x100),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x107),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMASa2[6] = {
+    "MAS_a2",
+    "MAS_a2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986AEC, &l_resMASa2);
 
 /* 80986B04-80986B1C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMBNa2 */
-SECTION_RODATA static void* const l_resMBNa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x111),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x118),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMBNa2[6] = {
+    "MBN_a2",
+    "MBN_a2_TW",
+    "Mgeneral",
+    "Mspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B04, &l_resMBNa2);
 
 /* 80986B1C-80986B34 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWANa */
-SECTION_RODATA static void* const l_resWANa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x122),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x128),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWANa[6] = {
+    "WAN_a",
+    "WAN_a_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B1C, &l_resWANa);
 
 /* 80986B34-80986B4C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWADa */
-SECTION_RODATA static void* const l_resWADa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x143),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x149),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWADa[6] = {
+    "WAD_a",
+    "WAD_a_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B34, &l_resWADa);
 
 /* 80986B4C-80986B64 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMATa */
-SECTION_RODATA static void* const l_resMATa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x152),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x158),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMATa[6] = {
+    "MAT_a",
+    "MAT_a_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B4C, &l_resMATa);
 
 /* 80986B64-80986B7C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWCNa */
-SECTION_RODATA static void* const l_resWCNa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x161),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x167),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWCNa[6] = {
+    "WCN_a",
+    "WCN_a_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B64, &l_resWCNa);
 
 /* 80986B7C-80986B94 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWONa */
-SECTION_RODATA static void* const l_resWONa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x170),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x176),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWONa[6] = {
+    "WON_a",
+    "WON_a_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B7C, &l_resWONa);
 
 /* 80986B94-80986BAC -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWGNa */
-SECTION_RODATA static void* const l_resWGNa[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x17F),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x185),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWGNa[6] = {
+    "WGN_a",
+    "WGN_a_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986B94, &l_resWGNa);
 
 /* 80986BAC-80986BC4 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWANb */
-SECTION_RODATA static void* const l_resWANb[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18E),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x194),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWANb[6] = {
+    "WAN_b",
+    "WAN_b_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986BAC, &l_resWANb);
 
 /* 80986BC4-80986BDC -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWANa2 */
-SECTION_RODATA static void* const l_resWANa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x19D),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1A4),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWANa2[6] = {
+    "WAN_a2",
+    "WAN_a2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986BC4, &l_resWANa2);
 
 /* 80986BDC-80986BF4 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWADa2 */
-SECTION_RODATA static void* const l_resWADa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1AE),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1B5),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWADa2[6] = {
+    "WAD_a2",
+    "WAD_a2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986BDC, &l_resWADa2);
 
 /* 80986BF4-80986C0C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resMATa2 */
-SECTION_RODATA static void* const l_resMATa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1BF),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1C6),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resMATa2[6] = {
+    "MAT_a2",
+    "MAT_a2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986BF4, &l_resMATa2);
 
 /* 80986C0C-80986C24 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWCNa2 */
-SECTION_RODATA static void* const l_resWCNa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1D0),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1D7),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWCNa2[6] = {
+    "WCN_a2",
+    "WCN_a2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986C0C, &l_resWCNa2);
 
 /* 80986C24-80986C3C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWONa2 */
-SECTION_RODATA static void* const l_resWONa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1E1),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1E8),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWONa2[6] = {
+    "WON_a2",
+    "WON_a2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986C24, &l_resWONa2);
 
 /* 80986C3C-80986C54 -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWGNa2 */
-SECTION_RODATA static void* const l_resWGNa2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1F2),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x1F9),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWGNa2[6] = {
+    "WGN_a2",
+    "WGN_a2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986C3C, &l_resWGNa2);
 
 /* 80986C54-80986C6C -00001 0018+00 1/1 0/0 0/0 .rodata          l_resWANb2 */
-SECTION_RODATA static void* const l_resWANb2[6] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x203),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x20A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28),
+static char* const l_resWANb2[6] = {
+    "WAN_b2",
+    "WAN_b2_TW",
+    "Wgeneral",
+    "Wspecial",
+    "object",
+    "objectTW",
 };
-COMPILER_STRIP_GATE(0x80986C54, &l_resWANb2);
 
 /* 80987740-80987740 000DA4 0000+00 0/0 0/0 0/0 .rodata          @stringBase0 */
 #pragma push
@@ -844,6 +814,11 @@ SECTION_DATA static void* l_resNameTbl[30] = {
     (void*)&l_resWGNa2, (void*)&l_resWANb2,
 };
 
+struct anmTblPrm {
+    char* arc_name;
+    int resource_index;
+};
+
 /* 809879F4-80987AE4 000098 00F0+00 1/2 0/0 0/0 .data            l_bmdTbl */
 SECTION_DATA static u8 l_bmdTbl[240] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
@@ -921,119 +896,119 @@ SECTION_DATA static u8 l_btpTWTbl[240] = {
 };
 
 /* 80987DB4-80987F64 -00001 01B0+00 1/1 0/0 0/0 .data            l_bckTbl_M */
-SECTION_DATA static void* l_bckTbl_M[108] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000001A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000001B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000001D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000001E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000008,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000014,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000015,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000017,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000005,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000006,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000001C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000018,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000016,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000011,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000000D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000000E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000012,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000000F,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000010,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000012,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x0000000F,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x0000000C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000015,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000013,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000010,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x0000000D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000016,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000014,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000011,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x0000000E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000017,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000007,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000008,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x0000000A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000019,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000000C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000013,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000006,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000005,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x18), (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x00000007,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0xF),  (void*)0x0000000A,
+static anmTblPrm l_bckTbl_M[54] = {
+    {"Mgeneral",  0x1A},
+    {"Mgeneral",  0x1B},
+    {"Mgeneral",  0x1D},
+    {"Mgeneral",  0x1E},
+    {"Mgeneral",  8},
+    {"Mgeneral",  9},
+    {"Mgeneral",  0x14},
+    {"Mgeneral",  0x15},
+    {"Mgeneral",  0x17},
+    {"Mgeneral",  5},
+    {"Mgeneral",  6},
+    {"Mgeneral",  0x1C},
+    {"Mgeneral",  0x18},
+    {"Mgeneral",  0x16},
+    {"Mgeneral",  0x11},
+    {"Mgeneral",  0xD},
+    {"Mgeneral",  0xE},
+    {"Mgeneral",  0x12},
+    {"Mgeneral",  0xF},
+    {"Mgeneral",  0x10},
+    {"Mgeneral",  3},
+    {"Mgeneral",  4},
+    {"Mspecial", 0x12},
+    {"Mspecial", 0xF},
+    {"Mspecial", 0xC},
+    {"Mspecial", 0x15},
+    {"Mspecial", 0x13},
+    {"Mspecial", 0x10},
+    {"Mspecial", 0xD},
+    {"Mspecial", 0x16},
+    {"Mspecial", 0x14},
+    {"Mspecial", 0x11},
+    {"Mspecial", 0xE},
+    {"Mspecial", 0x17},
+    {"Mspecial", 7},
+    {"Mspecial", 8},
+    {"Mspecial", 0xA},
+    {"Mspecial", 0xB},
+    {"Mgeneral",  0x19},
+    {"Mgeneral",  0xB},
+    {"Mgeneral",  0xC},
+    {"Mgeneral",  0x13},
+    {"Mspecial", 3},
+    {"Mspecial", 6},
+    {"Mspecial", 5},
+    {"Mspecial", 9},
+    {"Mspecial", 4},
+    {"Mgeneral",  7},
+    {"Mgeneral",  -1},
+    {"Mgeneral",  -1},
+    {"Mgeneral",  -1},
+    {"Mgeneral",  -1},
+    {"Mgeneral",  -1},
+    {"Mgeneral",  0xA},
 };
 
 /* 80987F64-80988114 -00001 01B0+00 1/1 0/0 0/0 .data            l_bckTbl_W */
-SECTION_DATA static void* l_bckTbl_W[108] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000001F,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000020,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000022,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000023,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000000D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000000E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000019,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000001A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000001C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000000A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000021,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000001D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000001B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000016,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000012,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000013,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000017,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000014,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000015,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000007,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000008,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x0000000D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x0000000A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000007,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000010,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x0000000E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000008,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000011,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x0000000F,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x0000000C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000012,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000005,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0x00000006,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000001E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000010,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000011,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000018,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x13A), (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000000C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000005,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000006,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x131), (void*)0x0000000F,
+static anmTblPrm l_bckTbl_W[54] = {
+    {"Wgeneral", 0x1F},
+    {"Wgeneral", 0x20},
+    {"Wgeneral", 0x22},
+    {"Wgeneral", 0x23},
+    {"Wgeneral", 0xD},
+    {"Wgeneral", 0xE},
+    {"Wgeneral", 0x19},
+    {"Wgeneral", 0x1A},
+    {"Wgeneral", 0x1C},
+    {"Wgeneral", 0xA},
+    {"Wgeneral", 0xB},
+    {"Wgeneral", 0x21},
+    {"Wgeneral", 0x1D},
+    {"Wgeneral", 0x1B},
+    {"Wgeneral", 0x16},
+    {"Wgeneral", 0x12},
+    {"Wgeneral", 0x13},
+    {"Wgeneral", 0x17},
+    {"Wgeneral", 0x14},
+    {"Wgeneral", 0x15},
+    {"Wgeneral", 7},
+    {"Wgeneral", 8},
+    {"Wspecial", 0xD},
+    {"Wspecial", 0xA},
+    {"Wspecial", 7},
+    {"Wspecial", 0x10},
+    {"Wspecial", 0xE},
+    {"Wspecial", 0xB},
+    {"Wspecial", 8},
+    {"Wspecial", 0x11},
+    {"Wspecial", 0xF},
+    {"Wspecial", 0xC},
+    {"Wspecial", 9},
+    {"Wspecial", 0x12},
+    {"Wspecial", 3},
+    {"Wspecial", 4},
+    {"Wspecial", 5},
+    {"Wspecial", 6},
+    {"Wgeneral", 0x1E},
+    {"Wgeneral", 0x10},
+    {"Wgeneral", 0x11},
+    {"Wgeneral", 0x18},
+    {"Wspecial", -1},
+    {"Wspecial", -1},
+    {"Wspecial", -1},
+    {"Wspecial", -1},
+    {"Wspecial", -1},
+    {"Wgeneral", 0xC},
+    {"Wgeneral", 3},
+    {"Wgeneral", 4},
+    {"Wgeneral", 5},
+    {"Wgeneral", 6},
+    {"Wgeneral", 9},
+    {"Wgeneral", 0xF},
 };
 
 /* 80988114-809898D4 0007B8 17C0+00 1/1 0/0 0/0 .data            a_jntTbl_M */
@@ -1932,10 +1907,7 @@ SECTION_DATA static u8 l_evtNames[4] = {
 #pragma pop
 
 /* 8098B750-8098B754 -00001 0004+00 0/2 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x214);
-#pragma pop
+static char* l_myName = "Chat";
 
 /* 8098B754-8098B760 003DF8 000C+00 0/2 0/0 0/0 .data            mEvtSeqList__11daNpcChat_c */
 #pragma push
@@ -2275,42 +2247,39 @@ daNpcChat_c::~daNpcChat_c() {
     // NONMATCHING
 }
 
-/* ############################################################################################## */
 /* 80986C6C-80986CD4 -00001 0068+00 1/1 0/0 0/0 .rodata          l_objTbl */
-SECTION_RODATA static void* const l_objTbl[26] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000008,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x0000000D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x0000000E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x0000000C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000006,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000007,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x0000000A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x0000000F,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x21), (void*)0x00000010,
+static anmTblPrm const l_objTbl[13] = {
+    {"object", 9},
+    {"object", 9},
+    {"object", 8},
+    {"object", 3},
+    {"object", 0xD},
+    {"object", 0xE},
+    {"object", 0xC},
+    {"object", 6},
+    {"object", 7},
+    {"object", 0xA},
+    {"object", 0xB},
+    {"object", 0xF},
+    {"object", 0x10},
 };
-COMPILER_STRIP_GATE(0x80986C6C, &l_objTbl);
 
 /* 80986CD4-80986D3C -00001 0068+00 1/1 0/0 0/0 .rodata          l_objTWTbl */
-SECTION_RODATA static void* const l_objTWTbl[26] = {
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x00000009,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x00000008,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x0000000D,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x0000000E,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x0000000C,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x00000006,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x00000007,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x0000000A,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0xFFFFFFFF,
-    (void*)(((char*)&d_a_npc_chat__stringBase0) + 0x28), (void*)0xFFFFFFFF,
+static anmTblPrm const l_objTWTbl[13] = {
+    {"objectTW", 9},
+    {"objectTW", 9},
+    {"objectTW", 8},
+    {"objectTW", 3},
+    {"objectTW", 0xD},
+    {"objectTW", 0xE},
+    {"objectTW", 0xC},
+    {"objectTW", 6},
+    {"objectTW", 7},
+    {"objectTW", 0xA},
+    {"objectTW", 0xB},
+    {"objectTW", -1},
+    {"objectTW", -1},
 };
-COMPILER_STRIP_GATE(0x80986CD4, &l_objTWTbl);
 
 /* 80986D3C-80986DA8 0003A0 006C+00 1/3 0/0 0/0 .rodata          m__17daNpcChat_Param_c */
 SECTION_RODATA u8 const daNpcChat_Param_c::m[108] = {

--- a/src/d/actor/d_a_npc_chin.cpp
+++ b/src/d/actor/d_a_npc_chin.cpp
@@ -403,13 +403,13 @@ SECTION_DATA static u8 l_btkGetParamList[108] = {
 };
 
 /* 809920A8-809920C0 -00001 0018+00 7/11 0/0 0/0 .data            l_arcNames */
-SECTION_DATA static void* l_arcNames[6] = {
-    (void*)&d_a_npc_chin__stringBase0,
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x5),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0xB),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x14),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x1E),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x28),
+static char* l_arcNames[6] = {
+    "Chin",
+    "chin1",
+    "chin_mdl",
+    "chin_tmdl",
+    "chin1_evt",
+    "SpotLight",
 };
 
 /* 8098BF0C-8098C000 0000EC 00F4+00 1/1 0/0 0/0 .text loadModel__Q211daNpcChin_c12_SpotLight_cFv
@@ -450,19 +450,16 @@ SECTION_DATA static void* sLoadResInfo[2] = {
 };
 
 /* 809920C8-809920E8 -00001 0020+00 0/2 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[8] = {
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x32),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x3D),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x49),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x56),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x69),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x75),
-    (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x81),
+static char* l_evtNames[8] = {
+    NULL,
+    "GAME_START",
+    "GAME_FAILED",
+    "GAME_SUCCEED",
+    "SELECT_GAME_GIVEUP",
+    "GAME_GIVEUP",
+    "CHIN_APPEAR",
+    "SPOTLIGHT_OFF",
 };
-#pragma pop
 
 /* 809920E8-809920F4 -00001 000C+00 0/1 0/0 0/0 .data            @3854 */
 #pragma push
@@ -545,7 +542,7 @@ SECTION_DATA u8 daNpcChin_c::mEvtSeqList[96] = {
 };
 
 /* 8099219C-809921A0 -00001 0004+00 1/2 0/0 0/0 .data            l_myName */
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_chin__stringBase0) + 0x8F);
+static char* l_myName = "chin";
 
 /* 809921A0-809921DC -00001 003C+00 1/1 0/0 0/0 .data            @4745 */
 SECTION_DATA static void* lit_4745[15] = {

--- a/src/d/actor/d_a_npc_clerka.cpp
+++ b/src/d/actor/d_a_npc_clerka.cpp
@@ -282,22 +282,16 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 809959BC-809959D4 -00001 0018+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[6] = {
-    (void*)&d_a_npc_clerka__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_clerka__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_clerka__stringBase0) + 0x11),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[3] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
+    {"NO_RESPONSE", 0},
 };
-#pragma pop
 
 /* 809959D4-809959DC -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_clerka__stringBase0,
-    (void*)(((char*)&d_a_npc_clerka__stringBase0) + 0x1D),
+static char* l_resNameList[2] = {
+    "",
+    "clerkA",
 };
 
 /* 809959DC-809959E0 000048 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -376,7 +370,7 @@ SECTION_DATA static u8 l_motionSequenceData[112] = {
 #pragma pop
 
 /* 80995BF8-80995BFC -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__14daNpc_clerkA_c */
-SECTION_DATA void* daNpc_clerkA_c::mCutNameList = (void*)&d_a_npc_clerka__stringBase0;
+char* daNpc_clerkA_c::mCutNameList[1] = {""};
 
 /* 80995BFC-80995C08 000268 000C+00 2/2 0/0 0/0 .data            mCutList__14daNpc_clerkA_c */
 SECTION_DATA u8 daNpc_clerkA_c::mCutList[12] = {

--- a/src/d/actor/d_a_npc_clerkb.cpp
+++ b/src/d/actor/d_a_npc_clerkb.cpp
@@ -293,22 +293,16 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80999AD8-80999AF0 -00001 0018+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[6] = {
-    (void*)&d_a_npc_clerkb__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_clerkb__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_clerkb__stringBase0) + 0x11),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[3] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
+    {"NO_RESPONSE", 0},
 };
-#pragma pop
 
 /* 80999AF0-80999AF8 -00001 0008+00 3/4 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_clerkb__stringBase0,
-    (void*)(((char*)&d_a_npc_clerkb__stringBase0) + 0x1D),
+static char* l_resNameList[2] = {
+    "",
+    "clerkB",
 };
 
 /* 80999AF8-80999AFC 000048 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -400,7 +394,7 @@ SECTION_DATA static u8 l_motionSequenceData[144] = {
 #pragma pop
 
 /* 80999E1C-80999E20 -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__14daNpc_clerkB_c */
-SECTION_DATA void* daNpc_clerkB_c::mCutNameList = (void*)&d_a_npc_clerkb__stringBase0;
+char* daNpc_clerkB_c::mCutNameList[1] = {""};
 
 /* 80999E20-80999E2C 000370 000C+00 2/2 0/0 0/0 .data            mCutList__14daNpc_clerkB_c */
 SECTION_DATA u8 daNpc_clerkB_c::mCutList[12] = {

--- a/src/d/actor/d_a_npc_clerkt.cpp
+++ b/src/d/actor/d_a_npc_clerkt.cpp
@@ -275,20 +275,15 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 8099D380-8099D390 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_clerkt__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_clerkt__stringBase0) + 0x1),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
 };
-#pragma pop
 
 /* 8099D390-8099D398 -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_clerkt__stringBase0,
-    (void*)(((char*)&d_a_npc_clerkt__stringBase0) + 0x11),
+static char* l_resNameList[2] = {
+    "",
+    "Tkj",
 };
 
 /* 8099D398-8099D39C 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -342,7 +337,7 @@ SECTION_DATA static u8 l_motionSequenceData[16] = {
 #pragma pop
 
 /* 8099D428-8099D42C -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__13daNpcClerkT_c */
-SECTION_DATA void* daNpcClerkT_c::mCutNameList = (void*)&d_a_npc_clerkt__stringBase0;
+char* daNpcClerkT_c::mCutNameList[1] = {""};
 
 /* 8099D42C-8099D438 0000D4 000C+00 2/2 0/0 0/0 .data            mCutList__13daNpcClerkT_c */
 SECTION_DATA u8 daNpcClerkT_c::mCutList[12] = {

--- a/src/d/actor/d_a_npc_doc.cpp
+++ b/src/d/actor/d_a_npc_doc.cpp
@@ -272,21 +272,16 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 809AA468-809AA478 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_doc__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_doc__stringBase0) + 0x1),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
 };
-#pragma pop
 
 /* 809AA478-809AA484 -00001 000C+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[3] = {
-    (void*)&d_a_npc_doc__stringBase0,
-    (void*)(((char*)&d_a_npc_doc__stringBase0) + 0xD),
-    (void*)(((char*)&d_a_npc_doc__stringBase0) + 0x11),
+static char* l_resNameList[3] = {
+    "",
+    "Doc",
+    "Doc1",
 };
 
 /* 809AA484-809AA488 000044 0003+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -400,7 +395,7 @@ SECTION_DATA static u8 l_motionSequenceData[208] = {
 #pragma pop
 
 /* 809AA8A4-809AA8A8 -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__11daNpc_Doc_c */
-SECTION_DATA void* daNpc_Doc_c::mCutNameList = (void*)&d_a_npc_doc__stringBase0;
+char* daNpc_Doc_c::mCutNameList[1] = {""};
 
 /* 809AA8A8-809AA8B4 000468 000C+00 2/2 0/0 0/0 .data            mCutList__11daNpc_Doc_c */
 SECTION_DATA u8 daNpc_Doc_c::mCutList[12] = {

--- a/src/d/actor/d_a_npc_fairy.cpp
+++ b/src/d/actor/d_a_npc_fairy.cpp
@@ -379,9 +379,9 @@ SECTION_DEAD static char const* const stringBase_809B94CD = "fairy";
 #pragma pop
 
 /* 809B95F8-809B9600 -00001 0008+00 7/8 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_fairy__stringBase0,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x1),
+static char* l_resNameList[2] = {
+    "",
+    "fairy",
 };
 
 /* 809B1BC0-809B1CE4 0001A0 0124+00 1/1 0/0 0/0 .text            loadModel__16_Fairy_Feather_cFv */
@@ -591,68 +591,47 @@ SECTION_DATA static u8 l_motionSequenceData[176] = {
 #pragma pop
 
 /* 809B98FC-809B998C -00001 0090+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[36] = {
-    (void*)&d_a_npc_fairy__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x7),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x15),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x23),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x31),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x3F),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x4D),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x5B),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x69),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x77),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x85),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x93),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xA1),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xAF),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xBD),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xCC),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xDB),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xEA),
-    (void*)0x00000001,
+static daNpcT_evtData_c l_evtList[18] = {
+    {"", 0},
+    {"APPEAR_10F_01", 1},
+    {"APPEAR_10F_02", 1},
+    {"APPEAR_20F_01", 1},
+    {"APPEAR_20F_02", 1},
+    {"APPEAR_30F_01", 1},
+    {"APPEAR_30F_02", 1},
+    {"APPEAR_40F_01", 1},
+    {"APPEAR_40F_02", 1},
+    {"APPEAR_50F_01", 1},
+    {"APPEAR_50F_02", 1},
+    {"APPEAR_50F_03", 1},
+    {"APPEAR_50F_04", 1},
+    {"APPEAR_50F_05", 1},
+    {"SELECT_RETURN1", 1},
+    {"SELECT_RETURN2", 1},
+    {"SELECT_RETURN3", 1},
+    {"RETURN_CANCEL", 1},
 };
-#pragma pop
 
 /* 809B998C-809B99D4 -00001 0048+00 1/1 0/0 0/0 .data            mCutNameList__13daNpc_Fairy_c */
-SECTION_DATA void* daNpc_Fairy_c::mCutNameList[18] = {
-    (void*)&d_a_npc_fairy__stringBase0,
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x7),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x15),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x23),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x31),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x3F),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x4D),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x5B),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x69),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x77),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x85),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0x93),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xA1),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xAF),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xBD),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xCC),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xDB),
-    (void*)(((char*)&d_a_npc_fairy__stringBase0) + 0xEA),
+char* daNpc_Fairy_c::mCutNameList[18] = {
+    "",
+    "APPEAR_10F_01",
+    "APPEAR_10F_02",
+    "APPEAR_20F_01",
+    "APPEAR_20F_02",
+    "APPEAR_30F_01",
+    "APPEAR_30F_02",
+    "APPEAR_40F_01",
+    "APPEAR_40F_02",
+    "APPEAR_50F_01",
+    "APPEAR_50F_02",
+    "APPEAR_50F_03",
+    "APPEAR_50F_04",
+    "APPEAR_50F_05",
+    "SELECT_RETURN1",
+    "SELECT_RETURN2",
+    "SELECT_RETURN3",
+    "RETURN_CANCEL",
 };
 
 /* 809B99D4-809B99E0 -00001 000C+00 0/1 0/0 0/0 .data            @3851 */

--- a/src/d/actor/d_a_npc_gra.cpp
+++ b/src/d/actor/d_a_npc_gra.cpp
@@ -442,22 +442,19 @@ SECTION_DATA static u8 l_evtGetParamList[88] = {
 #pragma pop
 
 /* 809CA8D4-809CA900 -00001 002C+00 0/3 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[11] = {
-    (void*)NULL,
-    (void*)&d_a_npc_gra__stringBase0,
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x9),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x13),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x1C),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x2B),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x35),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x41),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x51),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x69),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x78),
+static char* l_evtNames[11] = {
+    NULL,
+    "TALK_SPA",
+    "TEACH_ELV",
+    "KICK_OUT",
+    "KICK_OUT_BREAK",
+    "NONE_LOOK",
+    "RESCUE_ROCK",
+    "CARRY_SPA_WATER",
+    "CARRY_SPA_WATER_FAILURE",
+    "TALK_SPA_WATER",
+    "ROLL_ROCK_CRASH",
 };
-#pragma pop
 
 /* 809CA900-809CA920 0002EC 0020+00 1/0 0/0 0/0 .data            l_loadRes_GRAa */
 SECTION_DATA static u8 l_loadRes_GRAa[32] = {
@@ -555,50 +552,47 @@ SECTION_DATA static void* l_loadRes_list[13] = {
 };
 
 /* 809CAAD4-809CAB14 -00001 0040+00 5/9 0/0 0/0 .data            l_resNames */
-SECTION_DATA static void* l_resNames[16] = {
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x88),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x91),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x99),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xA0),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xA8),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xB2),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xBA),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xC3),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xCC),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xD6),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xDE),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xE8),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xF2),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xFB),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x103),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x10C),
+static char* l_resNames[16] = {
+    "grA_base",
+    "grA_mdl",
+    "grA_TW",
+    "grA_SPA",
+    "grA_Sdemo",
+    "grA_Elv",
+    "grA_Kick",
+    "grA_Rock",
+    "grA_RockD",
+    "grA_SWD",
+    "grA_onsen",
+    "grA_onsn2",
+    "maroTaru",
+    "grA_RCD",
+    "grA_gate",
+    "grA_town",
 };
 
 /* 809CAB14-809CAB20 -00001 000C+00 1/1 0/0 0/0 .data            l_myName */
-SECTION_DATA static void* l_myName[3] = {
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x115),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x119),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0xB2),
+static char* l_myName[3] = {
+    "grA",
+    "grA_spa",
+    "grA_Elv",
 };
 
 /* 809CAB20-809CAB50 -00001 0030+00 0/1 0/0 0/0 .data            mEvtCutNameList__11daNpc_grA_c */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_grA_c::mEvtCutNameList[12] = {
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x121),
-    (void*)&d_a_npc_gra__stringBase0,
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x122),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x12C),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x9),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x13),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x2B),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x35),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x41),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x51),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x69),
-    (void*)(((char*)&d_a_npc_gra__stringBase0) + 0x78),
+char* daNpc_grA_c::mEvtCutNameList[12] = {
+    "",
+    "TALK_SPA",
+    "GRDS_ROLL",
+    "GRDS_GATE",
+    "TEACH_ELV",
+    "KICK_OUT",
+    "NONE_LOOK",
+    "RESCUE_ROCK",
+    "CARRY_SPA_WATER",
+    "CARRY_SPA_WATER_FAILURE",
+    "TALK_SPA_WATER",
+    "ROLL_ROCK_CRASH",
 };
-#pragma pop
 
 /* 809CAB50-809CAB5C -00001 000C+00 0/1 0/0 0/0 .data            @4084 */
 #pragma push

--- a/src/d/actor/d_a_npc_grd.cpp
+++ b/src/d/actor/d_a_npc_grd.cpp
@@ -309,9 +309,9 @@ SECTION_DATA static void* l_loadRes_list[3] = {
 };
 
 /* 809D3CFC-809D3D04 -00001 0008+00 6/8 0/0 0/0 .data            l_resNames */
-SECTION_DATA static void* l_resNames[2] = {
-    (void*)&d_a_npc_grd__stringBase0,
-    (void*)(((char*)&d_a_npc_grd__stringBase0) + 0x4),
+static char* l_resNames[2] = {
+    "grD",
+    "grD1",
 };
 
 /* 809D3D04-809D3D08 0000F0 0004+00 0/1 0/0 0/0 .data            l_evtNames */
@@ -326,19 +326,13 @@ SECTION_DATA static u8 l_evtNames[4] = {
 #pragma pop
 
 /* 809D3D08-809D3D0C -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)&d_a_npc_grd__stringBase0;
-#pragma pop
+static char* l_myName = "grD";
 
 /* 809D3D0C-809D3D14 -00001 0008+00 0/1 0/0 0/0 .data            mEvtCutNameList__11daNpc_Grd_c */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_Grd_c::mEvtCutNameList[2] = {
-    (void*)(((char*)&d_a_npc_grd__stringBase0) + 0x9),
-    (void*)(((char*)&d_a_npc_grd__stringBase0) + 0xA),
+char* daNpc_Grd_c::mEvtCutNameList[2] = {
+    "",
+    "NOD_TO_GRZ",
 };
-#pragma pop
 
 /* 809D3D14-809D3D20 -00001 000C+00 1/1 0/0 0/0 .data            @4018 */
 SECTION_DATA static void* lit_4018[3] = {

--- a/src/d/actor/d_a_npc_grm.cpp
+++ b/src/d/actor/d_a_npc_grm.cpp
@@ -267,23 +267,17 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 809D6EBC-809D6ED4 -00001 0018+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[6] = {
-    (void*)&d_a_npc_grm__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_grm__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)NULL,
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[3] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
+    {NULL, 0},
 };
-#pragma pop
 
 /* 809D6ED4-809D6EE0 -00001 000C+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[3] = {
-    (void*)&d_a_npc_grm__stringBase0,
-    (void*)(((char*)&d_a_npc_grm__stringBase0) + 0x11),
-    (void*)(((char*)&d_a_npc_grm__stringBase0) + 0x1A),
+static char* l_resNameList[3] = {
+    "",
+    "grA_base",
+    "grA_mdl",
 };
 
 /* 809D6EE0-809D6EE4 00004C 0003+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -357,9 +351,9 @@ SECTION_DATA static u8 l_motionSequenceData[80] = {
 #pragma pop
 
 /* 809D70BC-809D70C4 -00001 0008+00 1/1 0/0 0/0 .data            mCutNameList__11daNpc_grM_c */
-SECTION_DATA void* daNpc_grM_c::mCutNameList[2] = {
-    (void*)&d_a_npc_grm__stringBase0,
-    (void*)(((char*)&d_a_npc_grm__stringBase0) + 0x22),
+char* daNpc_grM_c::mCutNameList[2] = {
+    "",
+    "TALK_SPA",
 };
 
 /* 809D70C4-809D70D0 -00001 000C+00 1/1 0/0 0/0 .data            @3831 */

--- a/src/d/actor/d_a_npc_gro.cpp
+++ b/src/d/actor/d_a_npc_gro.cpp
@@ -364,37 +364,28 @@ SECTION_DATA static u8 l_loadObj_list[16] = {
 #pragma pop
 
 /* 809DF4A4-809DF4B0 -00001 000C+00 5/9 0/0 0/0 .data            l_resNames */
-SECTION_DATA static void* l_resNames[3] = {
-    (void*)&d_a_npc_gro__stringBase0,
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0x4),
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0x9),
+static char* l_resNames[3] = {
+    "grO",
+    "grO1",
+    "grO1D",
 };
 
 /* 809DF4B0-809DF4BC -00001 000C+00 0/2 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[3] = {
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0x1C),
+static char* l_evtNames[3] = {
+    NULL,
+    "BOKIN_FINISH",
+    "PUSHOUT",
 };
-#pragma pop
 
 /* 809DF4BC-809DF4C0 -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)&d_a_npc_gro__stringBase0;
-#pragma pop
+static char* l_myName = "grO";
 
 /* 809DF4C0-809DF4CC -00001 000C+00 0/1 0/0 0/0 .data            mEvtCutNameList__11daNpc_grO_c */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_grO_c::mEvtCutNameList[3] = {
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0x24),
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_gro__stringBase0) + 0x1C),
+char* daNpc_grO_c::mEvtCutNameList[3] = {
+    "",
+    "BOKIN_FINISH",
+    "PUSHOUT",
 };
-#pragma pop
 
 /* 809DF4CC-809DF4D8 -00001 000C+00 0/1 0/0 0/0 .data            @4096 */
 #pragma push

--- a/src/d/actor/d_a_npc_grs.cpp
+++ b/src/d/actor/d_a_npc_grs.cpp
@@ -314,31 +314,22 @@ SECTION_DATA static void* l_loadRes_list[2] = {
 };
 
 /* 809E8084-809E8088 -00001 0004+00 6/8 0/0 0/0 .data            l_resNames */
-SECTION_DATA static void* l_resNames = (void*)&d_a_npc_grs__stringBase0;
+static char* l_resNames[1] = {"grS"};
 
 /* 809E8088-809E8090 -00001 0008+00 0/1 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[2] = {
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_grs__stringBase0) + 0x4),
+static char* l_evtNames[2] = {
+    NULL,
+    "PUSHOUT",
 };
-#pragma pop
 
 /* 809E8090-809E8094 -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)&d_a_npc_grs__stringBase0;
-#pragma pop
+static char* l_myName = "grS";
 
 /* 809E8094-809E809C -00001 0008+00 0/1 0/0 0/0 .data            mEvtCutNameList__11daNpc_grS_c */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_grS_c::mEvtCutNameList[2] = {
-    (void*)(((char*)&d_a_npc_grs__stringBase0) + 0xC),
-    (void*)(((char*)&d_a_npc_grs__stringBase0) + 0x4),
+char* daNpc_grS_c::mEvtCutNameList[2] = {
+    "",
+    "PUSHOUT",
 };
-#pragma pop
 
 /* 809E809C-809E80A8 -00001 000C+00 1/1 0/0 0/0 .data            @4051 */
 SECTION_DATA static void* lit_4051[3] = {

--- a/src/d/actor/d_a_npc_hoz.cpp
+++ b/src/d/actor/d_a_npc_hoz.cpp
@@ -309,39 +309,27 @@ SECTION_DATA static u8 l_bmdData[16] = {
 };
 
 /* 80A06834-80A0687C -00001 0048+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[18] = {
-    (void*)&d_a_npc_hoz__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x1),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0xB),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x1C),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x2A),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x37),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x44),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x50),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x58),
-    (void*)0x00000001,
+static daNpcT_evtData_c l_evtList[9] = {
+    {"", 0},
+    {"BOAT_RACE", 1},
+    {"BOAT_RACE_RETURN", 1},
+    {"BEFORE_BATTLE", 1},
+    {"AFTER_BATTLE", 1},
+    {"BEFORE_BLAST", 1},
+    {"AFTER_BLAST", 1},
+    {"Y_MUSHI", 1},
+    {"TALK_BREAK", 1},
 };
-#pragma pop
 
 /* 80A0687C-80A06898 -00001 001C+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[7] = {
-    (void*)&d_a_npc_hoz__stringBase0,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x63),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x67),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x6E),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x73),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x78),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x7D),
+static char* l_resNameList[7] = {
+    "",
+    "Hoz",
+    "Hoz_TW",
+    "Hoz1",
+    "Hoz2",
+    "Hoz3",
+    "Hoz2_3",
 };
 
 /* 80A06898-80A0689C 000094 0003+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -617,15 +605,15 @@ SECTION_DATA static u8 l_motionSequenceData[576] = {
 #pragma pop
 
 /* 80A075C0-80A075E0 -00001 0020+00 1/1 0/0 0/0 .data            mCutNameList__11daNpc_Hoz_c */
-SECTION_DATA void* daNpc_Hoz_c::mCutNameList[8] = {
-    (void*)&d_a_npc_hoz__stringBase0,
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x1),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x1C),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x2A),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x37),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x44),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x50),
-    (void*)(((char*)&d_a_npc_hoz__stringBase0) + 0x58),
+char* daNpc_Hoz_c::mCutNameList[8] = {
+    "",
+    "BOAT_RACE",
+    "BEFORE_BATTLE",
+    "AFTER_BATTLE",
+    "BEFORE_BLAST",
+    "AFTER_BLAST",
+    "Y_MUSHI",
+    "TALK_BREAK",
 };
 
 /* 80A075E0-80A075EC -00001 000C+00 0/1 0/0 0/0 .data            @3957 */

--- a/src/d/actor/d_a_npc_knj.cpp
+++ b/src/d/actor/d_a_npc_knj.cpp
@@ -214,20 +214,15 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80A455F8-80A45608 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_knj__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_knj__stringBase0) + 0x1),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
 };
-#pragma pop
 
 /* 80A45608-80A45610 -00001 0008+00 2/4 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_knj__stringBase0,
-    (void*)(((char*)&d_a_npc_knj__stringBase0) + 0xD),
+static char* l_resNameList[2] = {
+    "",
+    "Knj",
 };
 
 /* 80A45610-80A45614 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -278,7 +273,7 @@ SECTION_DATA static u8 l_motionSequenceData[16] = {
 #pragma pop
 
 /* 80A45684-80A45688 -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__11daNpc_Knj_c */
-SECTION_DATA void* daNpc_Knj_c::mCutNameList = (void*)&d_a_npc_knj__stringBase0;
+char* daNpc_Knj_c::mCutNameList[1] = {""};
 
 /* 80A45688-80A45694 0000B8 000C+00 2/2 0/0 0/0 .data            mCutList__11daNpc_Knj_c */
 SECTION_DATA u8 daNpc_Knj_c::mCutList[12] = {

--- a/src/d/actor/d_a_npc_kyury.cpp
+++ b/src/d/actor/d_a_npc_kyury.cpp
@@ -275,23 +275,17 @@ SECTION_DATA static u8 l_bmdData[24] = {
 };
 
 /* 80A63A4C-80A63A64 -00001 0018+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[6] = {
-    (void*)&d_a_npc_kyury__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_kyury__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_kyury__stringBase0) + 0xD),
-    (void*)0x00000002,
+static daNpcT_evtData_c l_evtList[3] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
+    {"FIRST_CONVERSATION", 2},
 };
-#pragma pop
 
 /* 80A63A64-80A63A70 -00001 000C+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[3] = {
-    (void*)&d_a_npc_kyury__stringBase0,
-    (void*)(((char*)&d_a_npc_kyury__stringBase0) + 0x20),
-    (void*)(((char*)&d_a_npc_kyury__stringBase0) + 0x26),
+static char* l_resNameList[3] = {
+    "",
+    "Kyury",
+    "Kyury1",
 };
 
 /* 80A63A70-80A63A74 00005C 0002+02 0/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -437,9 +431,9 @@ SECTION_DATA static u8 l_motionSequenceData[208] = {
 #pragma pop
 
 /* 80A63FF4-80A63FFC -00001 0008+00 1/1 0/0 0/0 .data            mCutNameList__13daNpc_Kyury_c */
-SECTION_DATA void* daNpc_Kyury_c::mCutNameList[2] = {
-    (void*)&d_a_npc_kyury__stringBase0,
-    (void*)(((char*)&d_a_npc_kyury__stringBase0) + 0x2D),
+char* daNpc_Kyury_c::mCutNameList[2] = {
+    "",
+    "CONVERSATION",
 };
 
 /* 80A63FFC-80A64008 -00001 000C+00 1/1 0/0 0/0 .data            @3813 */

--- a/src/d/actor/d_a_npc_len.cpp
+++ b/src/d/actor/d_a_npc_len.cpp
@@ -304,32 +304,22 @@ SECTION_DATA static u8 l_bmdData[16] = {
 };
 
 /* 80A690B8-80A690F0 -00001 0038+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[14] = {
-    (void*)&d_a_npc_len__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x11),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x1D),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x28),
-    (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x2E),
-    (void*)0x00000003,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x45),
-    (void*)0x00000003,
+static daNpcT_evtData_c l_evtList[7] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
+    {"NO_RESPONSE", 0},
+    {"DEMO13_STB", 0},
+    {"HURRY", 3},
+    {"CONVERSATION_IN_HOTEL1", 3},
+    {"CONVERSATION_IN_HOTEL2", 3},
 };
-#pragma pop
 
 /* 80A690F0-80A69100 -00001 0010+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[4] = {
-    (void*)&d_a_npc_len__stringBase0,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x5C),
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x60),
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x67),
+static char* l_resNameList[4] = {
+    "",
+    "Len",
+    "Len_TW",
+    "Len1",
 };
 
 /* 80A69100-80A69104 000078 0003+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -481,11 +471,11 @@ SECTION_DATA static u8 l_motionSequenceData[224] = {
 #pragma pop
 
 /* 80A69774-80A69784 -00001 0010+00 1/1 0/0 0/0 .data            mCutNameList__11daNpc_Len_c */
-SECTION_DATA void* daNpc_Len_c::mCutNameList[4] = {
-    (void*)&d_a_npc_len__stringBase0,
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x28),
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x6C),
-    (void*)(((char*)&d_a_npc_len__stringBase0) + 0x82),
+char* daNpc_Len_c::mCutNameList[4] = {
+    "",
+    "HURRY",
+    "CONVERSATION_IN_HOTEL",
+    "TAKE_WOODSTATUE",
 };
 
 /* 80A69784-80A69790 -00001 000C+00 0/1 0/0 0/0 .data            @3845 */

--- a/src/d/actor/d_a_npc_myna2.cpp
+++ b/src/d/actor/d_a_npc_myna2.cpp
@@ -277,16 +277,13 @@ SECTION_DATA static u8 l_evtGetParamList[40] = {
 #pragma pop
 
 /* 80A88784-80A88798 -00001 0014+00 0/1 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[5] = {
-    (void*)NULL,
-    (void*)&d_a_npc_myna2__stringBase0,
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0xB),
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x22),
+static char* l_evtNames[5] = {
+    NULL,
+    "FIRST_TALK",
+    "GAME_FAILURE",
+    "GAME_GOAL",
+    "GAME_GOAL_SUCCESS",
 };
-#pragma pop
 
 /* 80A88798-80A887A4 0000E4 000C+00 1/0 0/0 0/0 .data            l_loadRes_MYNA2a */
 SECTION_DATA static u8 l_loadRes_MYNA2a[12] = {
@@ -318,29 +315,23 @@ SECTION_DATA static void* l_loadRes_list[5] = {
 };
 
 /* 80A887DC-80A887E8 -00001 000C+00 5/6 0/0 0/0 .data            l_resNames */
-SECTION_DATA static void* l_resNames[3] = {
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x34),
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x3B),
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x44),
+static char* l_resNames[3] = {
+    "MYNA_b",
+    "MYNA_b_f",
+    "MYNA_b_g",
 };
 
 /* 80A887E8-80A887EC -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x4D);
-#pragma pop
+static char* l_myName = "myna2";
 
 /* 80A887EC-80A88800 -00001 0014+00 0/1 0/0 0/0 .data            mEvtCutNameList__13daNpc_myna2_c */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_myna2_c::mEvtCutNameList[5] = {
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x53),
-    (void*)&d_a_npc_myna2__stringBase0,
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0xB),
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x18),
-    (void*)(((char*)&d_a_npc_myna2__stringBase0) + 0x22),
+char* daNpc_myna2_c::mEvtCutNameList[5] = {
+    "",
+    "FIRST_TALK",
+    "GAME_FAILURE",
+    "GAME_GOAL",
+    "GAME_GOAL_SUCCESS",
 };
-#pragma pop
 
 /* 80A88800-80A8880C -00001 000C+00 0/1 0/0 0/0 .data            @4033 */
 #pragma push

--- a/src/d/actor/d_a_npc_pachi_maro.cpp
+++ b/src/d/actor/d_a_npc_pachi_maro.cpp
@@ -309,29 +309,24 @@ SECTION_DATA static u8 l_bmdData[16] = {
 };
 
 /* 80A9BAA8-80A9BAB8 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_pachi_maro__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x1),
-    (void*)0x0000000A,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"TUTRIAL_TALK", 10},
 };
-#pragma pop
 
 /* 80A9BAB8-80A9BAE4 -00001 002C+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[11] = {
-    (void*)&d_a_npc_pachi_maro__stringBase0,
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0xE),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x13),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x1B),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x21),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x27),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x2D),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x33),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x39),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x3E),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x44),
+static char* l_resNameList[11] = {
+    "",
+    "Maro",
+    "Maro_TW",
+    "Maro1",
+    "Maro2",
+    "Maro3",
+    "Taro1",
+    "Taro2",
+    "Len1",
+    "Besu1",
+    "evt_pachi",
 };
 
 /* 80A9BAE4-80A9BAE8 00006C 0003+01 0/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -475,18 +470,18 @@ SECTION_DATA static u8 l_motionSequenceData[144] = {
 
 /* 80A9BE64-80A9BE90 -00001 002C+00 1/1 0/0 0/0 .data            mCutNameList__18daNpc_Pachi_Maro_c
  */
-SECTION_DATA void* daNpc_Pachi_Maro_c::mCutNameList[11] = {
-    (void*)&d_a_npc_pachi_maro__stringBase0,
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x4E),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x5C),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x6F),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x1),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x7D),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x8B),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0x9B),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0xB1),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0xC0),
-    (void*)(((char*)&d_a_npc_pachi_maro__stringBase0) + 0xD1),
+char* daNpc_Pachi_Maro_c::mCutNameList[11] = {
+    "",
+    "TUTRIAL_BEGIN",
+    "TUTRIAL_BEGIN_SKIP",
+    "TUTRIAL_CLEAR",
+    "TUTRIAL_TALK",
+    "TUTRIAL_TALK2",
+    "HIT_KAKASI_BODY",
+    "TUTRIAL_SELECT_GIVEUP",
+    "TUTRIAL_GIVEUP",
+    "TUTRIAL_CONTINUE",
+    "TUTRIAL_CAUTION",
 };
 
 /* 80A9BE90-80A9BE9C -00001 000C+00 0/1 0/0 0/0 .data            @3952 */

--- a/src/d/actor/d_a_npc_pachi_taro.cpp
+++ b/src/d/actor/d_a_npc_pachi_taro.cpp
@@ -352,48 +352,34 @@ SECTION_DATA static u8 l_bmdData[40] = {
 };
 
 /* 80AA1974-80AA19CC -00001 0058+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[22] = {
-    (void*)&d_a_npc_pachi_taro__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x1),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xF),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x22),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x30),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x3D),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x4B),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x5B),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x71),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x82),
-    (void*)0x0000000B,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x91),
-    (void*)0x0000000B,
+static daNpcT_evtData_c l_evtList[11] = {
+    {"", 0},
+    {"TUTRIAL_BEGIN", 11},
+    {"TUTRIAL_BEGIN_SKIP", 11},
+    {"TUTRIAL_CLEAR", 11},
+    {"TUTRIAL_TALK", 11},
+    {"TUTRIAL_TALK2", 11},
+    {"HIT_KAKASI_BODY", 11},
+    {"TUTRIAL_SELECT_GIVEUP", 11},
+    {"TUTRIAL_CONTINUE", 11},
+    {"TUTRIAL_GIVEUP", 11},
+    {"TUTRIAL_CAUTION", 11},
 };
-#pragma pop
 
 /* 80AA19CC-80AA19FC -00001 0030+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[12] = {
-    (void*)&d_a_npc_pachi_taro__stringBase0,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xA1),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xA6),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xAE),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xB4),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xBA),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xC0),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xC6),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xCC),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xD2),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xD8),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xDD),
+static char* l_resNameList[12] = {
+    "",
+    "Taro",
+    "Taro_TW",
+    "Taro0",
+    "Taro1",
+    "Taro2",
+    "Taro3",
+    "Taro4",
+    "Taro5",
+    "TaroB",
+    "Len1",
+    "evt_pachi",
 };
 
 /* 80AA19FC-80AA1A04 0000D0 0007+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -648,18 +634,18 @@ SECTION_DATA static u8 l_motionSequenceData[656] = {
 
 /* 80AA2668-80AA2694 -00001 002C+00 1/1 0/0 0/0 .data            mCutNameList__18daNpc_Pachi_Taro_c
  */
-SECTION_DATA void* daNpc_Pachi_Taro_c::mCutNameList[11] = {
-    (void*)&d_a_npc_pachi_taro__stringBase0,
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x1),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0xF),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x22),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x30),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x3D),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x4B),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x5B),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x71),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x82),
-    (void*)(((char*)&d_a_npc_pachi_taro__stringBase0) + 0x91),
+char* daNpc_Pachi_Taro_c::mCutNameList[11] = {
+    "",
+    "TUTRIAL_BEGIN",
+    "TUTRIAL_BEGIN_SKIP",
+    "TUTRIAL_CLEAR",
+    "TUTRIAL_TALK",
+    "TUTRIAL_TALK2",
+    "HIT_KAKASI_BODY",
+    "TUTRIAL_SELECT_GIVEUP",
+    "TUTRIAL_CONTINUE",
+    "TUTRIAL_GIVEUP",
+    "TUTRIAL_CAUTION",
 };
 
 /* 80AA2694-80AA26A0 -00001 000C+00 0/1 0/0 0/0 .data            @3979 */

--- a/src/d/actor/d_a_npc_post.cpp
+++ b/src/d/actor/d_a_npc_post.cpp
@@ -311,28 +311,20 @@ SECTION_DATA static u8 l_bmdData[32] = {
 };
 
 /* 80AAD3EC-80AAD414 -00001 0028+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[10] = {
-    (void*)&d_a_npc_post__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0xD),
-    (void*)0x00000002,
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0x15),
-    (void*)0x00000002,
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0x2F),
-    (void*)0x00000002,
+static daNpcT_evtData_c l_evtList[5] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
+    {"DELIVER", 2},
+    {"DELIVERTO_PLAYER_ON_HORSE", 2},
+    {"DELIVERTO_WOLF", 2},
 };
-#pragma pop
 
 /* 80AAD414-80AAD424 -00001 0010+00 5/6 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[4] = {
-    (void*)&d_a_npc_post__stringBase0,
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0x3E),
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0x43),
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0x49),
+static char* l_resNameList[4] = {
+    "",
+    "post",
+    "post1",
+    "post2",
 };
 
 /* 80AAD424-80AAD428 000078 0003+01 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -466,9 +458,9 @@ SECTION_DATA static u8 l_motionSequenceData[176] = {
 #pragma pop
 
 /* 80AAD8F0-80AAD8F8 -00001 0008+00 1/1 0/0 0/0 .data            mCutNameList__12daNpc_Post_c */
-SECTION_DATA void* daNpc_Post_c::mCutNameList[2] = {
-    (void*)&d_a_npc_post__stringBase0,
-    (void*)(((char*)&d_a_npc_post__stringBase0) + 0xD),
+char* daNpc_Post_c::mCutNameList[2] = {
+    "",
+    "DELIVER",
 };
 
 /* 80AAD8F8-80AAD904 -00001 000C+00 1/1 0/0 0/0 .data            @3838 */

--- a/src/d/actor/d_a_npc_pouya.cpp
+++ b/src/d/actor/d_a_npc_pouya.cpp
@@ -302,35 +302,23 @@ SECTION_DATA static u8 l_bmdData[24] = {
 };
 
 /* 80AB2228-80AB2270 -00001 0048+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[18] = {
-    (void*)&d_a_npc_pouya__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x11),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x1D),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x2F),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x41),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x53),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x65),
-    (void*)0x00000002,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x77),
-    (void*)0x00000002,
+static daNpcT_evtData_c l_evtList[9] = {
+    {"", 0},
+    {"DEFAULT_GETITEM", 0},
+    {"NO_RESPONSE", 0},
+    {"HAVE_FAVORTO_ASK1", 1},
+    {"HAVE_FAVORTO_ASK2", 1},
+    {"RETURN_FAVOR_1_01", 1},
+    {"RETURN_FAVOR_1_02", 1},
+    {"RETURN_FAVOR_2_01", 2},
+    {"RETURN_FAVOR_2_02", 2},
 };
-#pragma pop
 
 /* 80AB2270-80AB227C -00001 000C+00 3/4 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[3] = {
-    (void*)&d_a_npc_pouya__stringBase0,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x89),
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x90),
+static char* l_resNameList[3] = {
+    "",
+    "pouyaA",
+    "pouyaB",
 };
 
 /* 80AB227C-80AB2280 00008C 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -493,10 +481,10 @@ SECTION_DATA static u8 l_motionSequenceData[304] = {
 #pragma pop
 
 /* 80AB2984-80AB2990 -00001 000C+00 1/1 0/0 0/0 .data            mCutNameList__13daNpc_Pouya_c */
-SECTION_DATA void* daNpc_Pouya_c::mCutNameList[3] = {
-    (void*)&d_a_npc_pouya__stringBase0,
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0x97),
-    (void*)(((char*)&d_a_npc_pouya__stringBase0) + 0xA8),
+char* daNpc_Pouya_c::mCutNameList[3] = {
+    "",
+    "HAVE_FAVORTO_ASK",
+    "RETURN_FAVOR",
 };
 
 /* 80AB2990-80AB299C -00001 000C+00 0/1 0/0 0/0 .data            @3817 */

--- a/src/d/actor/d_a_npc_shaman.cpp
+++ b/src/d/actor/d_a_npc_shaman.cpp
@@ -299,28 +299,19 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80AE6D40-80AE6D70 -00001 0030+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[12] = {
-    (void*)&d_a_npc_shaman__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0xD),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0x1C),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0x23),
-    (void*)0x00000001,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0x2A),
-    (void*)0x00000001,
+static daNpcT_evtData_c l_evtList[6] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
+    {"PERFORM_AUGURY", 1},
+    {"ALLGET", 1},
+    {"NOLOOK", 1},
+    {"RETURN", 1},
 };
-#pragma pop
 
 /* 80AE6D70-80AE6D78 -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_shaman__stringBase0,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0x31),
+static char* l_resNameList[2] = {
+    "",
+    "Sha",
 };
 
 /* 80AE6D78-80AE6D7C 000060 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -416,9 +407,9 @@ SECTION_DATA static u8 l_motionSequenceData[128] = {
 #pragma pop
 
 /* 80AE70A0-80AE70A8 -00001 0008+00 1/1 0/0 0/0 .data            mCutNameList__11daNpc_Sha_c */
-SECTION_DATA void* daNpc_Sha_c::mCutNameList[2] = {
-    (void*)&d_a_npc_shaman__stringBase0,
-    (void*)(((char*)&d_a_npc_shaman__stringBase0) + 0xD),
+char* daNpc_Sha_c::mCutNameList[2] = {
+    "",
+    "PERFORM_AUGURY",
 };
 
 /* 80AE70A8-80AE70B4 -00001 000C+00 0/1 0/0 0/0 .data            @3812 */

--- a/src/d/actor/d_a_npc_sola.cpp
+++ b/src/d/actor/d_a_npc_sola.cpp
@@ -232,20 +232,15 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80AEF21C-80AEF22C -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_sola__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_sola__stringBase0) + 0x1),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
 };
-#pragma pop
 
 /* 80AEF22C-80AEF234 -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_sola__stringBase0,
-    (void*)(((char*)&d_a_npc_sola__stringBase0) + 0xD),
+static char* l_resNameList[2] = {
+    "",
+    "solA",
 };
 
 /* 80AEF234-80AEF238 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -293,7 +288,7 @@ SECTION_DATA static u8 l_motionSequenceData[16] = {
 #pragma pop
 
 /* 80AEF294-80AEF298 -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__12daNpc_solA_c */
-SECTION_DATA void* daNpc_solA_c::mCutNameList = (void*)&d_a_npc_sola__stringBase0;
+char* daNpc_solA_c::mCutNameList[1] = {""};
 
 /* 80AEF298-80AEF2A4 0000A4 000C+00 2/2 0/0 0/0 .data            mCutList__12daNpc_solA_c */
 SECTION_DATA u8 daNpc_solA_c::mCutList[12] = {

--- a/src/d/actor/d_a_npc_soldierA.cpp
+++ b/src/d/actor/d_a_npc_soldierA.cpp
@@ -249,13 +249,10 @@ SECTION_DATA static u8 l_evtGetParamList[16] = {
 #pragma pop
 
 /* 80AF2900-80AF2908 -00001 0008+00 0/2 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[2] = {
-    (void*)NULL,
-    (void*)&d_a_npc_soldierA__stringBase0,
+static char* l_evtNames[2] = {
+    NULL,
+    "TALK_LAKE",
 };
-#pragma pop
 
 /* 80AF2908-80AF2914 000080 000C+00 1/0 0/0 0/0 .data            l_loadRes_SOLDIERaa */
 SECTION_DATA static u8 l_loadRes_SOLDIERaa[12] = {
@@ -279,21 +276,15 @@ SECTION_DATA static void* l_loadRes_list[4] = {
 SECTION_DATA static void* l_resNames = (void*)(((char*)&d_a_npc_soldierA__stringBase0) + 0xA);
 
 /* 80AF2934-80AF2938 -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_soldierA__stringBase0) + 0xA);
-#pragma pop
+static char* l_myName = "chtSolA";
 
 /* 80AF2938-80AF2944 -00001 000C+00 0/1 0/0 0/0 .data            mEvtCutNameList__16daNpc_SoldierA_c
  */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_SoldierA_c::mEvtCutNameList[3] = {
-    (void*)(((char*)&d_a_npc_soldierA__stringBase0) + 0x12),
-    (void*)&d_a_npc_soldierA__stringBase0,
-    (void*)(((char*)&d_a_npc_soldierA__stringBase0) + 0x13),
+char* daNpc_SoldierA_c::mEvtCutNameList[3] = {
+    "",
+    "TALK_LAKE",
+    "LISTEN_LAKE",
 };
-#pragma pop
 
 /* 80AF2944-80AF2950 -00001 000C+00 0/1 0/0 0/0 .data            @4018 */
 #pragma push

--- a/src/d/actor/d_a_npc_soldierB.cpp
+++ b/src/d/actor/d_a_npc_soldierB.cpp
@@ -272,23 +272,17 @@ SECTION_DATA static void* l_loadRes_list[2] = {
 };
 
 /* 80AF5C8C-80AF5C90 -00001 0004+00 4/5 0/0 0/0 .data            l_resNames */
-SECTION_DATA static void* l_resNames = (void*)&d_a_npc_soldierB__stringBase0;
+static char* l_resNames[1] = {"chtSolB"};
 
 /* 80AF5C90-80AF5C94 -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)&d_a_npc_soldierB__stringBase0;
-#pragma pop
+static char* l_myName = "chtSolB";
 
 /* 80AF5C94-80AF5C9C -00001 0008+00 0/1 0/0 0/0 .data            mEvtCutNameList__16daNpc_SoldierB_c
  */
-#pragma push
-#pragma force_active on
-SECTION_DATA void* daNpc_SoldierB_c::mEvtCutNameList[2] = {
-    (void*)(((char*)&d_a_npc_soldierB__stringBase0) + 0x8),
-    (void*)(((char*)&d_a_npc_soldierB__stringBase0) + 0x9),
+char* daNpc_SoldierB_c::mEvtCutNameList[2] = {
+    "",
+    "LISTEN_LAKE",
 };
-#pragma pop
 
 /* 80AF5C9C-80AF5CA8 -00001 000C+00 1/1 0/0 0/0 .data            @4024 */
 SECTION_DATA static void* lit_4024[3] = {

--- a/src/d/actor/d_a_npc_theB.cpp
+++ b/src/d/actor/d_a_npc_theB.cpp
@@ -292,23 +292,20 @@ SECTION_DATA static u8 l_btkGetParamList[8] = {
 };
 
 /* 80B010CC-80B010E4 -00001 0018+00 1/1 0/0 0/0 .data            l_evtNames */
-SECTION_DATA static void* l_evtNames[6] = {
-    (void*)NULL,
-    (void*)&d_a_npc_theB__stringBase0,
-    (void*)(((char*)&d_a_npc_theB__stringBase0) + 0x16),
-    (void*)(((char*)&d_a_npc_theB__stringBase0) + 0x2E),
-    (void*)(((char*)&d_a_npc_theB__stringBase0) + 0x44),
-    (void*)(((char*)&d_a_npc_theB__stringBase0) + 0x4E),
+static char* l_evtNames[6] = {
+    NULL,
+    "PERSONAL_COMBAT_INTRO",
+    "PERSONAL_COMBAT_REVENGE",
+    "ANNULATION_FIELD_RACE",
+    "THEB_HINT",
+    "COACH_GUARD_GAMEOVER",
 };
 
 /* 80B010E4-80B010E8 -00001 0004+00 8/9 0/0 0/0 .data            l_arcName */
-SECTION_DATA static void* l_arcName = (void*)(((char*)&d_a_npc_theB__stringBase0) + 0x63);
+static char* l_arcName = "Coach";
 
 /* 80B010E8-80B010EC -00001 0004+00 0/1 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_theB__stringBase0) + 0x69);
-#pragma pop
+static char* l_myName = "TheB";
 
 /* 80B010EC-80B010F8 -00001 000C+00 0/1 0/0 0/0 .data            @3823 */
 #pragma push

--- a/src/d/actor/d_a_npc_tkc.cpp
+++ b/src/d/actor/d_a_npc_tkc.cpp
@@ -265,24 +265,18 @@ SECTION_DATA static u8 l_btkGetParamList[8] = {
 };
 
 /* 80B10AA8-80B10AB8 -00001 0010+00 0/1 0/0 0/0 .data            l_evtNames */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtNames[4] = {
-    (void*)&d_a_npc_tkc__stringBase0,
-    (void*)(((char*)&d_a_npc_tkc__stringBase0) + 0x1),
-    (void*)(((char*)&d_a_npc_tkc__stringBase0) + 0xC),
-    (void*)(((char*)&d_a_npc_tkc__stringBase0) + 0x15),
+static char* l_evtNames[4] = {
+    "",
+    "TKS_SECRET",
+    "TKS_WARP",
+    "TKC_WARP",
 };
-#pragma pop
 
 /* 80B10AB8-80B10ABC -00001 0004+00 8/9 0/0 0/0 .data            l_arcName */
-SECTION_DATA static void* l_arcName = (void*)(((char*)&d_a_npc_tkc__stringBase0) + 0x1E);
+static char* l_arcName = "Tkc";
 
 /* 80B10ABC-80B10AC0 -00001 0004+00 0/2 0/0 0/0 .data            l_myName */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_myName = (void*)(((char*)&d_a_npc_tkc__stringBase0) + 0x1E);
-#pragma pop
+static char* l_myName = "Tkc";
 
 /* 80B10AC0-80B10ACC -00001 000C+00 0/1 0/0 0/0 .data            @3936 */
 #pragma push

--- a/src/d/actor/d_a_npc_toby.cpp
+++ b/src/d/actor/d_a_npc_toby.cpp
@@ -345,37 +345,27 @@ SECTION_DATA static u8 l_bmdData[24] = {
 };
 
 /* 80B24C80-80B24CB8 -00001 0038+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[14] = {
-    (void*)&d_a_npc_toby__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x1),
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0xD),
-    (void*)0x00000005,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x1C),
-    (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x2B),
-    (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x33),
-    (void*)0x00000004,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x4E),
-    (void*)0x00000004,
+static daNpcT_evtData_c l_evtList[7] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
+    {"TALKTO_ONESELF", 5},
+    {"REPAIR_SCANNON", 4},
+    {"SCANNON", 4},
+    {"CONVERSATION_ABOUT_SCANNON", 4},
+    {"CONVERSATION_ABOUT_ZRA", 4},
 };
-#pragma pop
 
 /* 80B24CB8-80B24CDC -00001 0024+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[9] = {
-    (void*)&d_a_npc_toby__stringBase0,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x65),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x6A),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x72),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x78),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x7E),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x84),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x8A),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x90),
+static char* l_resNameList[9] = {
+    "",
+    "Toby",
+    "Toby_TW",
+    "Toby0",
+    "Toby1",
+    "Toby2",
+    "Toby3",
+    "Toby4",
+    "Toby5",
 };
 
 /* 80B24CDC-80B24CE4 000094 0006+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -571,14 +561,14 @@ SECTION_DATA static u8 l_motionSequenceData[400] = {
 #pragma pop
 
 /* 80B25434-80B25450 -00001 001C+00 1/1 0/0 0/0 .data            mCutNameList__12daNpc_Toby_c */
-SECTION_DATA void* daNpc_Toby_c::mCutNameList[7] = {
-    (void*)&d_a_npc_toby__stringBase0,
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x96),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0xD),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x1C),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x2B),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x33),
-    (void*)(((char*)&d_a_npc_toby__stringBase0) + 0x4E),
+char* daNpc_Toby_c::mCutNameList[7] = {
+    "",
+    "TOBY_HOUSE_FIRE",
+    "TALKTO_ONESELF",
+    "REPAIR_SCANNON",
+    "SCANNON",
+    "CONVERSATION_ABOUT_SCANNON",
+    "CONVERSATION_ABOUT_ZRA",
 };
 
 /* 80B25450-80B2545C -00001 000C+00 0/1 0/0 0/0 .data            @3927 */

--- a/src/d/actor/d_a_npc_yamis.cpp
+++ b/src/d/actor/d_a_npc_yamis.cpp
@@ -269,20 +269,15 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80B497D0-80B497E0 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_yamis__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_yamis__stringBase0) + 0x1),
-    (void*)0x00000001,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"STOPPER", 1},
 };
-#pragma pop
 
 /* 80B497E0-80B497E8 -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_yamis__stringBase0,
-    (void*)(((char*)&d_a_npc_yamis__stringBase0) + 0x9),
+static char* l_resNameList[2] = {
+    "",
+    "yamiS",
 };
 
 /* 80B497E8-80B497EC 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -340,9 +335,9 @@ SECTION_DATA static u8 l_motionSequenceData[32] = {
 #pragma pop
 
 /* 80B498A8-80B498B0 -00001 0008+00 1/1 0/0 0/0 .data            mCutNameList__13daNpc_yamiS_c */
-SECTION_DATA void* daNpc_yamiS_c::mCutNameList[2] = {
-    (void*)&d_a_npc_yamis__stringBase0,
-    (void*)(((char*)&d_a_npc_yamis__stringBase0) + 0x1),
+char* daNpc_yamiS_c::mCutNameList[2] = {
+    "",
+    "STOPPER",
 };
 
 /* 80B498B0-80B498BC -00001 000C+00 1/1 0/0 0/0 .data            @3815 */

--- a/src/d/actor/d_a_npc_yamit.cpp
+++ b/src/d/actor/d_a_npc_yamit.cpp
@@ -271,20 +271,15 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80B4CEC4-80B4CED4 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_yamit__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_yamit__stringBase0) + 0x1),
-    (void*)0x00000001,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"STOPPER", 1},
 };
-#pragma pop
 
 /* 80B4CED4-80B4CEDC -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_yamit__stringBase0,
-    (void*)(((char*)&d_a_npc_yamit__stringBase0) + 0x9),
+static char* l_resNameList[2] = {
+    "",
+    "yamiT",
 };
 
 /* 80B4CEDC-80B4CEE0 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -345,9 +340,9 @@ SECTION_DATA static u8 l_motionSequenceData[48] = {
 #pragma pop
 
 /* 80B4CFC8-80B4CFD0 -00001 0008+00 1/1 0/0 0/0 .data            mCutNameList__13daNpc_yamiT_c */
-SECTION_DATA void* daNpc_yamiT_c::mCutNameList[2] = {
-    (void*)&d_a_npc_yamit__stringBase0,
-    (void*)(((char*)&d_a_npc_yamit__stringBase0) + 0x1),
+char* daNpc_yamiT_c::mCutNameList[2] = {
+    "",
+    "STOPPER",
 };
 
 /* 80B4CFD0-80B4CFDC -00001 000C+00 1/1 0/0 0/0 .data            @3814 */

--- a/src/d/actor/d_a_npc_zanb.cpp
+++ b/src/d/actor/d_a_npc_zanb.cpp
@@ -257,20 +257,15 @@ SECTION_DATA static u8 l_bmdData[8] = {
 };
 
 /* 80B6BDF8-80B6BE08 -00001 0010+00 0/1 0/0 0/0 .data            l_evtList */
-#pragma push
-#pragma force_active on
-SECTION_DATA static void* l_evtList[4] = {
-    (void*)&d_a_npc_zanb__stringBase0,
-    (void*)NULL,
-    (void*)(((char*)&d_a_npc_zanb__stringBase0) + 0x1),
-    (void*)NULL,
+static daNpcT_evtData_c l_evtList[2] = {
+    {"", 0},
+    {"NO_RESPONSE", 0},
 };
-#pragma pop
 
 /* 80B6BE08-80B6BE10 -00001 0008+00 2/3 0/0 0/0 .data            l_resNameList */
-SECTION_DATA static void* l_resNameList[2] = {
-    (void*)&d_a_npc_zanb__stringBase0,
-    (void*)(((char*)&d_a_npc_zanb__stringBase0) + 0xD),
+static char* l_resNameList[2] = {
+    "",
+    "zanB",
 };
 
 /* 80B6BE10-80B6BE14 000040 0002+02 1/0 0/0 0/0 .data            l_loadResPtrn0 */
@@ -324,7 +319,7 @@ SECTION_DATA static u8 l_motionSequenceData[32] = {
 #pragma pop
 
 /* 80B6BEA0-80B6BEA4 -00001 0004+00 1/1 0/0 0/0 .data            mCutNameList__12daNpc_zanB_c */
-SECTION_DATA void* daNpc_zanB_c::mCutNameList = (void*)&d_a_npc_zanb__stringBase0;
+char* daNpc_zanB_c::mCutNameList[1] = {""};
 
 /* 80B6BEA4-80B6BEB0 0000D4 000C+00 2/2 0/0 0/0 .data            mCutList__12daNpc_zanB_c */
 SECTION_DATA u8 daNpc_zanB_c::mCutList[12] = {

--- a/src/d/d_msg_object.cpp
+++ b/src/d/d_msg_object.cpp
@@ -601,10 +601,9 @@ int dMsgObject_c::_delete() {
 }
 
 /* 80233D04-80233E70 22E644 016C+00 2/2 2/2 0/0 .text setMessageIndex__12dMsgObject_cFUlUlb */
-// NONMATCHING reg swap
-void dMsgObject_c::setMessageIndex(u32 param_1, u32 param_2, bool param_3) {
-    field_0x158 = param_1;
-    u32 revoIndex = getRevoMessageIndex(param_1);
+void dMsgObject_c::setMessageIndex(u32 revoIndex, u32 param_2, bool param_3) {
+    field_0x158 = revoIndex;
+    revoIndex = getRevoMessageIndex(revoIndex);
     if (field_0x4cc == 0) {
         mNoDemoFlag = 1;
     }
@@ -624,7 +623,8 @@ void dMsgObject_c::setMessageIndex(u32 param_1, u32 param_2, bool param_3) {
 
     JMSMesgInfo_c* pMsg = (JMSMesgInfo_c*)((char*)mpMsgDt + 0x20);
     u8* iVar2 = (u8*)pMsg + pMsg->header.size;
-    dComIfGp_setMesgCameraAttrInfo(pMsg->entries[getMessageIndex(revoIndex)].camera_id);
+    u32 msg_id = getMessageIndex(revoIndex);
+    dComIfGp_setMesgCameraAttrInfo(pMsg->entries[msg_id].camera_id);
     if (field_0x15c == 1000) {
         mpRefer->setSelMsgPtr(NULL);
     } else {
@@ -632,7 +632,8 @@ void dMsgObject_c::setMessageIndex(u32 param_1, u32 param_2, bool param_3) {
         if (msgIndex == 0x264) {
             mpRefer->setSelMsgPtr(NULL);
         } else {
-            mpRefer->setSelMsgPtr(((char*)iVar2 + pMsg->entries[msgIndex].string_offset + 8));
+            char* my_ptr = (char*) (iVar2 + pMsg->entries[msgIndex].string_offset + 8);
+            mpRefer->setSelMsgPtr(my_ptr);
         }
     }
     if (param_3) {
@@ -642,9 +643,9 @@ void dMsgObject_c::setMessageIndex(u32 param_1, u32 param_2, bool param_3) {
 
 /* 80233E70-80233F84 22E7B0 0114+00 1/1 1/1 0/0 .text setMessageIndexDemo__12dMsgObject_cFUlb */
 // NONMATCHING reg swap
-void dMsgObject_c::setMessageIndexDemo(u32 param_1, bool param_2) {
-    field_0x158 = param_1;
-    int revoMsgIndex = getRevoMessageIndex(param_1);
+void dMsgObject_c::setMessageIndexDemo(u32 revoMsgIndex, bool param_2) {
+    field_0x158 = revoMsgIndex;
+    revoMsgIndex = getRevoMessageIndex(revoMsgIndex);
     mNoDemoFlag = 1;
     field_0x4d4 = 1;
     dMsgObject_onCameraCancelFlag();
@@ -662,9 +663,9 @@ void dMsgObject_c::setMessageIndexDemo(u32 param_1, bool param_2) {
     field_0x172 = 0;
     mpRefer->setPageNum(field_0x172);
     JMSMesgInfo_c* info_header_p = (JMSMesgInfo_c*)((char*)mpMsgDt + 0x20);
+    JMSMesgInfo_c* reg_25 = (JMSMesgInfo_c*)((char*) info_header_p + info_header_p->header.size);
     int ind = getMessageIndex(revoMsgIndex);
-    JMSMesgEntry_c* info_entries = (JMSMesgEntry_c*)((char*)info_header_p + 0x10);
-    dComIfGp_setMesgCameraAttrInfo(info_entries[ind].camera_id);
+    dComIfGp_setMesgCameraAttrInfo(info_header_p->entries[ind].camera_id);
     mpRefer->setSelMsgPtr(NULL);
     if (param_2) {
         mpCtrl->setMessageID(mMessageID, 0, NULL);


### PR DESCRIPTION
As the name implies, with this PR, if you do the following:
1. In `configure.py`, change `NonMatching = False` to `NonMatching = config.non_matching`
2. Perform `configure.py --non-matching`

Then you'll be able to replace the entirety of TP's gamecode with decomp code!

Some notes:
1. As-is, you won't get far. For whatever reason, `"d/d_msg_object.cpp"` needs to be left as normal, otherwise you'll get a green screen on boot.
  **EDIT:** This happens due to the "Hyrule Field Speed Hack". You must disable this.
2. As mentioned in Discord chat, Wall collision is broken. The worst consequence of this is that you can't scale ladders. If you try to play normally, you'll get stuck in Link's house on the 2nd day.
3. Assuming you prevent decomp's d_msg_object.cpp from linking, you'll get an illegal instruction early into the title cutscene. While this is bad, in Dolphin you can simply ignore said bad instruction for the rest of the session.

Speaking of title screen, you'll know you've set things up properly based on what you see upon boot-up XD