### PR TITLE
Fix DOL name for Wii

### DIFF
--- a/config/RZDE01_00/build.full.sha1
+++ b/config/RZDE01_00/build.full.sha1
@@ -1,4 +1,4 @@
-0f626c1bfbd05979ed78b634cc85248342452fc2  build/RZDE01_00/Rframework.dol
+0f626c1bfbd05979ed78b634cc85248342452fc2  build/RZDE01_00/framework.dol
 9230772a3dc20ffe822df0eee93bd684cbab280c  build/RZDE01_00/d_a_L7demo_dr/d_a_L7demo_dr.rel
 09c22aac4265cc230892203ba705fa28bb196a28  build/RZDE01_00/d_a_L7low_dr/d_a_L7low_dr.rel
 ede193738f3e07f70293853069cb3aad98d4d21f  build/RZDE01_00/d_a_L7op_demo_dr/d_a_L7op_demo_dr.rel

--- a/config/RZDE01_00/build.sha1
+++ b/config/RZDE01_00/build.sha1
@@ -1,4 +1,4 @@
-0f626c1bfbd05979ed78b634cc85248342452fc2  build/RZDE01_00/Rframework.dol
+0f626c1bfbd05979ed78b634cc85248342452fc2  build/RZDE01_00/framework.dol
 9230772a3dc20ffe822df0eee93bd684cbab280c  build/RZDE01_00/d_a_L7demo_dr/d_a_L7demo_dr.rel
 09c22aac4265cc230892203ba705fa28bb196a28  build/RZDE01_00/d_a_L7low_dr/d_a_L7low_dr.rel
 ede193738f3e07f70293853069cb3aad98d4d21f  build/RZDE01_00/d_a_L7op_demo_dr/d_a_L7op_demo_dr.rel

--- a/config/RZDE01_00/config.yml
+++ b/config/RZDE01_00/config.yml
@@ -1,4 +1,4 @@
-name: Rframework
+name: framework
 object_base: orig/RZDE01_00
 object: sys/main.dol
 hash: 0f626c1bfbd05979ed78b634cc85248342452fc2

--- a/config/RZDE01_02/config.yml
+++ b/config/RZDE01_02/config.yml
@@ -1,4 +1,4 @@
-name: Rframework
+name: framework
 object_base: orig/RZDE01_02
 object: sys/main.dol
 hash: 5a99acb37b98e19682924502ee14a6d03d536c69


### PR DESCRIPTION
Similar to #2607, having the DOL name be different between versions breaks version switching in objdiff, so it's better to make it consistent. This causes a one time break in progress tracking for RZDE01_00, but it just got added earlier today anyway.