### PR TITLE
Move cBgS_GrpPassChk and cBgS_PolyPassChk to separate headers

### DIFF
--- a/include/SSystem/SComponent/c_bg_s_chk.h
+++ b/include/SSystem/SComponent/c_bg_s_chk.h
@@ -3,15 +3,10 @@
 
 #include "dolphin/mtx.h"
 #include "f_pc/f_pc_base.h"
+#include "SSystem/SComponent/c_bg_s_grp_pass_chk.h"
+#include "SSystem/SComponent/c_bg_s_poly_pass_chk.h"
 
 struct cBgD_Vtx_t : public Vec {};
-
-class cBgS_GrpPassChk {
-public:
-    virtual ~cBgS_GrpPassChk() {}
-};
-
-class cBgS_PolyPassChk;
 
 class cBgS_Chk {
 public:

--- a/include/SSystem/SComponent/c_bg_s_grp_pass_chk.h
+++ b/include/SSystem/SComponent/c_bg_s_grp_pass_chk.h
@@ -1,0 +1,9 @@
+#ifndef C_BG_S_GRP_PASS_CHK_H
+#define C_BG_S_GRP_PASS_CHK_H
+
+class cBgS_GrpPassChk {
+public:
+    virtual ~cBgS_GrpPassChk() {}
+};
+
+#endif /* C_BG_S_GRP_PASS_CHK_H */

--- a/include/SSystem/SComponent/c_bg_s_poly_pass_chk.h
+++ b/include/SSystem/SComponent/c_bg_s_poly_pass_chk.h
@@ -1,0 +1,9 @@
+#ifndef C_BG_S_POLY_PASS_CHK_H
+#define C_BG_S_POLY_PASS_CHK_H
+
+class cBgS_PolyPassChk {
+public:
+    virtual ~cBgS_PolyPassChk() {}
+};
+
+#endif /* C_BG_S_POLY_PASS_CHK_H */

--- a/include/d/d_bg_s_poly_pass_chk.h
+++ b/include/d/d_bg_s_poly_pass_chk.h
@@ -1,11 +1,8 @@
 #ifndef D_BG_D_BG_S_POLY_PASS_CHK_H
 #define D_BG_D_BG_S_POLY_PASS_CHK_H
 
+#include "SSystem/SComponent/c_bg_s_poly_pass_chk.h"
 
-class cBgS_PolyPassChk {
-public:
-    virtual ~cBgS_PolyPassChk() {}
-};
 
 class dBgS_PolyPassChk : public cBgS_PolyPassChk {
 public:

--- a/include/d/d_bg_w_kcol.h
+++ b/include/d/d_bg_w_kcol.h
@@ -4,6 +4,7 @@
 #include "JSystem/JUtility/JUTAssert.h"
 #include "SSystem/SComponent/c_m3d_g_aab.h"
 #include "d/d_bg_plc.h"
+#include "d/d_bg_s_sph_chk.h"
 #include "d/d_bg_w_base.h"
 
 class cBgS_GrpPassChk;

--- a/include/d/dolzel_base.pch
+++ b/include/d/dolzel_base.pch
@@ -12,16 +12,21 @@
 // Fixes weak function ordering
 #include "cmath.h" // IWYU pragma: export
 #include "string.h" // IWYU pragma: export
-#include "d/d_com_inf_game.h" // IWYU pragma: export
-#include "d/d_bg_s_sph_chk.h" // IWYU pragma: export
+#include "JSystem/JUtility/JUTGamePad.h" // IWYU pragma: export
+#include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h" // IWYU pragma: export
+#include "SSystem/SComponent/c_m3d_g_pla.h" // IWYU pragma: export
+#include "SSystem/SComponent/c_bg_s_chk.h" // IWYU pragma: export
+#include "f_op/f_op_actor.h" // IWYU pragma: export
+#include "d/d_bg_s_poly_pass_chk.h" // IWYU pragma: export
+#include "d/d_bg_s_chk.h" // IWYU pragma: export
 #include "d/d_bg_w.h" // IWYU pragma: export
+#include "d/d_com_inf_game.h" // IWYU pragma: export
 #include "m_Do/m_Do_graphic.h" // IWYU pragma: export
 #include "JSystem/J2DGraph/J2DOrthoGraph.h" // IWYU pragma: export
 #include "JSystem/J2DGraph/J2DPane.h" // IWYU pragma: export
 #include "JSystem/J2DGraph/J2DPictureEx.h" // IWYU pragma: export
 #include "JSystem/J2DGraph/J2DScreen.h" // IWYU pragma: export
 #include "JSystem/J2DGraph/J2DTextBoxEx.h" // IWYU pragma: export
-#include "JSystem/J3DGraphAnimator/J3DMaterialAnm.h" // IWYU pragma: export
 #include "JSystem/JUtility/JUTFont.h" // IWYU pragma: export
 #include "JSystem/JUtility/JUTReport.h" // IWYU pragma: export
 

--- a/src/d/d_camera.cpp
+++ b/src/d/d_camera.cpp
@@ -16,6 +16,7 @@
 #include "d/actor/d_a_tag_mhint.h"
 #include "d/actor/d_a_tag_mstop.h"
 #include "d/actor/d_a_tag_mwait.h"
+#include "d/d_bg_s_sph_chk.h"
 #include "d/d_com_inf_actor.h"
 #include "d/d_com_inf_game.h"
 #include "d/d_debug_viewer.h"


### PR DESCRIPTION
This is supported by RTTI ordering which only makes sense if these classes are in separate headers from the dBgS_* classes.