### PR TITLE
Clean up some fakematches, mostly around gameInfo loads

### DIFF
--- a/include/SSystem/SComponent/c_m3d.h
+++ b/include/SSystem/SComponent/c_m3d.h
@@ -93,10 +93,6 @@ void cM3d_CrawVec(const Vec&, const Vec&, Vec*);
 inline bool cM3d_IsZero(f32 f) {
     return fabsf(f) < G_CM3D_F_ABS_MIN;
 }
-// this is the inline cM3d_IsZero but inverted. Sometimes this will get a match where the regular cM3d_IsZero inline won't
-inline bool cM3d_IsZero_inverted(f32 param_0) {
-    return !(fabsf(param_0) < G_CM3D_F_ABS_MIN);
-}
 
 inline f32 cM3d_LenSq(const Vec* a, const Vec* b) {
     return VECSquareDistance(a, b);

--- a/src/d/actor/d_a_mg_fish.cpp
+++ b/src/d/actor/d_a_mg_fish.cpp
@@ -2186,7 +2186,7 @@ static void pota_set(mg_fish_class* i_this) {
 
 /* 8053055C-80530924 00691C 03C8+00 1/1 0/0 0/0 .text            mf_catch__FP13mg_fish_class */
 static void mf_catch(mg_fish_class* i_this) {
-    daAlink_c* player = g_dComIfG_gameInfo.play.mPlayer[0];
+    daPy_py_c* player = (daPy_py_c*)dComIfGp_getPlayer(0);
     if (i_this->actor.health == 2) {
         fopAcM_delete(&i_this->actor);
         return;
@@ -2480,7 +2480,7 @@ static void mf_esa_hit(mg_fish_class* i_this) {
 
 /* 805313D8-8053198C 007798 05B4+00 1/1 0/0 0/0 .text            mf_esa_catch__FP13mg_fish_class */
 static s32 mf_esa_catch(mg_fish_class* i_this) {
-    daAlink_c* player = g_dComIfG_gameInfo.play.mPlayer[0];
+    fopAc_ac_c* player = dComIfGp_getPlayer(0);
     dmg_rod_class* rod = (dmg_rod_class*)fopAcM_SearchByID(i_this->mRodId);
 
     if (rod == NULL) {

--- a/src/d/actor/d_a_npc4.cpp
+++ b/src/d/actor/d_a_npc4.cpp
@@ -622,7 +622,7 @@ int daNpcF_c::draw(BOOL i_isTest, BOOL param_1, f32 i_shadowDepth, _GXColorS10* 
             damage_ratio = 0.0f;
         }
 
-        if (cM3d_IsZero_inverted(damage_ratio)) {
+        if (cM3d_IsZero(damage_ratio) == FALSE) {
             tevStr.TevColor.r = (s16)(damage_ratio * 20.0f);
             tevStr.TevColor.g = 0;
         } else if (i_isTest) {
@@ -765,7 +765,7 @@ void daNpcF_c::setMtx2() {
     model->setBaseTRMtx(mDoMtx_stack_c::get());
     model->setUserArea((uintptr_t)this);
 
-    if (cM3d_IsZero_inverted(mExpressionMorf)) {
+    if (cM3d_IsZero(mExpressionMorf) == FALSE) {
         mAnm_p->onMorfNone();
     } else {
         mAnm_p->offMorfNone();

--- a/src/d/actor/d_a_npc_ash.cpp
+++ b/src/d/actor/d_a_npc_ash.cpp
@@ -441,7 +441,7 @@ bool daNpcAsh_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
         mAnm_p->changeAnm(bckAnm);
     }
 
-    if (cM3d_IsZero_inverted(mExpressionMorf)) {
+    if (cM3d_IsZero(mExpressionMorf) == FALSE) {
         if (jointNo == 12) {
             mAnm_p->onMorfNone();
         } else if (jointNo == 4) {

--- a/src/d/actor/d_a_npc_zrz.cpp
+++ b/src/d/actor/d_a_npc_zrz.cpp
@@ -343,7 +343,7 @@ int daNpc_zrZ_c::draw(int i_isTest, int param_1, f32 i_shadowDepth, _GXColorS10*
             damage_ratio = 0.0f;
         }
 
-        if (cM3d_IsZero_inverted(damage_ratio)) {
+        if (cM3d_IsZero(damage_ratio) == FALSE) {
             tevStr.TevColor.r = (s16)(damage_ratio * 20.0f);
             tevStr.TevColor.g = 0;
         } else if (i_isTest) {

--- a/src/d/actor/d_a_obj_dmelevator.cpp
+++ b/src/d/actor/d_a_obj_dmelevator.cpp
@@ -709,7 +709,7 @@ int daObjDmElevator_c::Delete() {
     mSoundObj.deleteObject();
 
     if ((mpBgW != NULL) && mpBgW->ChkUsed()) {
-        g_dComIfG_gameInfo.play.mBgs.Release(mpBgW);
+        dComIfG_Bgsp().Release(mpBgW);
     }
 
     dComIfG_resDelete(&mPhaseReq, l_el_arcName);

--- a/src/d/actor/d_a_obj_lv6SzGate.cpp
+++ b/src/d/actor/d_a_obj_lv6SzGate.cpp
@@ -96,7 +96,7 @@ cPhs__Step daLv6SzGate_c::create() {
                               l_cull_box.max.x, l_cull_box.max.y, l_cull_box.max.y);
 
         if (field_0x5e8 != NULL) {
-            g_dComIfG_gameInfo.play.mBgs.Regist(field_0x5e8, this);
+            dComIfG_Bgsp().Regist(field_0x5e8, this);
             field_0x5e8->Move();
         }
         field_0x5e2 = getSw();

--- a/src/d/actor/d_a_obj_magne_arm.cpp
+++ b/src/d/actor/d_a_obj_magne_arm.cpp
@@ -212,8 +212,8 @@ int daObjMarm_c::Create() {
         mIsYRotForward = 0;
     }
 
-    if (g_dComIfG_gameInfo.play.mBgs.Regist((dBgW_Base*)mpBgW1, this) != NULL ||
-        g_dComIfG_gameInfo.play.mBgs.Regist((dBgW_Base*)mpBgW2, this) != NULL)
+    if (dComIfG_Bgsp().Regist((dBgW_Base*)mpBgW1, this) != NULL ||
+        dComIfG_Bgsp().Regist((dBgW_Base*)mpBgW2, this) != NULL)
     {
         return FALSE;
     }

--- a/src/d/actor/d_a_obj_stick.cpp
+++ b/src/d/actor/d_a_obj_stick.cpp
@@ -64,7 +64,7 @@ int daObj_Stick_c::create() {
         mStts.Init(0xFF, 0, this);
         mSph.Set(daObj_Stick_c::mCcDSph);
         mSph.SetStts(&mStts);
-        mAcch.CrrPos(g_dComIfG_gameInfo.play.mBgs);
+        mAcch.CrrPos(dComIfG_Bgsp());
         mGndChk = mAcch.m_gnd;
         mGroundHeight = mAcch.m_ground_h;
 

--- a/src/d/d_meter2_draw.cpp
+++ b/src/d/d_meter2_draw.cpp
@@ -4016,7 +4016,7 @@ static const char* tex_name[] = {"tt_heart_00.bti", "tt_heart_01.bti", "tt_heart
  */
 bool dMeter2Draw_c::getCanoeFishing() {
     if (!strcmp(dComIfGp_getStartStageName(), "F_SP127") &&
-        g_dComIfG_gameInfo.play.mPlayer[0]->checkCanoeRide())
+        ((daPy_py_c*)dComIfGp_getPlayer(0))->checkCanoeRide())
     {
         return TRUE;
     } else {


### PR DESCRIPTION
This PR cleans up some fakematches surrounding `g_dComIfG_gameInfo` that are no longer needed as of the PCH changes, in addition to fakematches for `cM3d_isZero` that are fixed with an explicit `== FALSE` comparison.