### PR TITLE
Small d_a_mg_rod fixes

### DIFF
--- a/include/d/d_com_inf_game.h
+++ b/include/d/d_com_inf_game.h
@@ -1910,7 +1910,7 @@ inline void dComIfGs_onLightDropGetFlag(u8 i_nowLevel) {
     g_dComIfG_gameInfo.info.getPlayer().getLightDrop().onLightDropGetFlag(i_nowLevel);
 }
 
-inline void dComIfGs_setTmpReg(const u16 i_reg, u8 i_no) {
+inline void dComIfGs_setTmpReg(u16 i_reg, u8 i_no) {
     g_dComIfG_gameInfo.info.getTmp().setEventReg(i_reg, i_no);
 }
 
@@ -1922,7 +1922,7 @@ inline u8 dComIfGs_getEventReg(u16 reg) {
     return g_dComIfG_gameInfo.info.getEvent().getEventReg(reg);
 }
 
-inline void dComIfGs_setEventReg(const u16 reg, u8 value) {
+inline void dComIfGs_setEventReg(u16 reg, u8 value) {
     g_dComIfG_gameInfo.info.getEvent().setEventReg(reg, value);
 }
 

--- a/include/d/d_event_debug.h
+++ b/include/d/d_event_debug.h
@@ -20,7 +20,7 @@ struct dEvDb_reg_c {
     /* 0x00 */ char* mFlagName;
     /* 0x04 */ char* mFlagDescription;
     /* 0x08 */ char* mFlagAuthor;
-    /* 0x0C */ const u16 mFlagValue;
+    /* 0x0C */ u16 mFlagValue;
     /* 0x10 */ char* mArea; // Area in the game where flag is used
     /* 0x14 */ u8 mRootReg;
     /* 0x15 */ u8 field_0x15;

--- a/include/d/d_save.h
+++ b/include/d/d_save.h
@@ -661,7 +661,7 @@ public:
     void onEventBit(const u16 i_no);
     void offEventBit(const u16 i_no);
     int isEventBit(const u16 i_no) const;
-    void setEventReg(const u16 i_reg, u8 i_no);
+    void setEventReg(u16 i_reg, u8 i_no);
     u8 getEventReg(u16 i_reg) const;
 
     void* getPEventBit() { return (void*)mEvent; }

--- a/src/d/actor/d_a_mg_rod.cpp
+++ b/src/d/actor/d_a_mg_rod.cpp
@@ -75,13 +75,13 @@ void dmg_rod_HIO_c::genMessage(JORMContext* ctx) {
     ctx->genComboBoxItem("ドジョウ", 2); //Loach
     ctx->genComboBoxItem("パイク", 3); // Pike
     ctx->genComboBoxItem("ナマズ", 4); // Catfish
-    ctx->genComboBoxItem("マス", 5); // ???
+    ctx->genComboBoxItem("マス", 5); // Trout
     ctx->genComboBoxItem("ギル", 6); // Gill
     ctx->genComboBoxItem("小バス", 7); // Small Bass
     ctx->genComboBoxItem("小ドジョウ", 8); // Small Loach
     ctx->genComboBoxItem("小パイク", 9); // Small Pike
     ctx->genComboBoxItem("小ナマズ", 10); // Small Catfish
-    ctx->genComboBoxItem("小マス", 11); // ???
+    ctx->genComboBoxItem("小マス", 11); // Small Trout
     ctx->endComboBox();
 }
 #endif
@@ -2525,9 +2525,8 @@ static void lure_hit(dmg_rod_class* i_this, mg_fish_class* i_mg_fish) {
 }
 
 /* 804B02C4-804B0A90 006DC4 07CC+00 1/1 0/0 0/0 .text            lure_catch__FP13dmg_rod_class */
-// NONMATCHING - regalloc, equivalent
 static void lure_catch(dmg_rod_class* i_this) {
-    fopAc_ac_c* actor = &i_this->actor;
+    fopAc_ac_c* actor = (fopAc_ac_c*)i_this;
     fopAc_ac_c* mgfish_a = fopAcM_SearchByID(i_this->mg_fish_id);
     mg_fish_class* mgfish = (mg_fish_class*)mgfish_a;
 
@@ -4550,12 +4549,11 @@ static void play_camera(dmg_rod_class* i_this) {
         i_this->play_cam_mode = 2;
         camera->mCamera.Stop();
         i_this->play_cam_timer = 0;
-        i_this->field_0x1420 = 500.0f;
-        i_this->field_0x141c = 500.0f;
+        i_this->field_0x141c = i_this->field_0x1420 = 500.0f;
         i_this->field_0x1424 = 180.0f + WREG_F(0);
         i_this->field_0x1428 = 100.0f + WREG_F(1);
 
-        camera_class* sp58 = dComIfGp_getCamera(0);
+        camera_class* sp58 = (camera_class*)dComIfGp_getCamera(0);
         i_this->field_0x144c = sp58->lookat.eye;
         i_this->field_0x1458 = sp58->lookat.center;
         i_this->play_cam_eye = i_this->field_0x144c;
@@ -4574,7 +4572,7 @@ static void play_camera(dmg_rod_class* i_this) {
         f32 sp60 = 100.0f + WREG_F(1);
         f32 sp5C = 30.0f;
 
-        if (i_this->play_cam_timer > YREG_S(6) + 8) {
+        if (i_this->play_cam_timer > (s16)(8 + YREG_S(6))) {
             cLib_addCalcAngleS2(&i_this->field_0x1418, daAlink_getAlinkActorClass()->getFishingRodAngleY(), 6, 2000);
         }
 
@@ -4833,7 +4831,7 @@ static void play_camera(dmg_rod_class* i_this) {
             cLib_addCalc2(&i_this->play_cam_center.y, sp150.y, 0.1f, 10.0f);
             cLib_addCalc2(&i_this->play_cam_center.z, sp150.z, 0.1f, 10.0f);
         }
-        if (i_this->play_cam_timer >= XREG_S(4) + 68) {
+        if (i_this->play_cam_timer >= (s16)(XREG_S(4) + 68)) {
             i_this->play_cam_mode = 2;
             i_this->play_cam_timer = 20;
             i_this->field_0x1418 = daAlink_getAlinkActorClass()->shape_angle.y;

--- a/src/d/d_save.cpp
+++ b/src/d/d_save.cpp
@@ -1317,7 +1317,7 @@ BOOL dSv_event_c::isEventBit(const u16 i_no) const {
 }
 
 /* 800349E0-80034A04 02F320 0024+00 0/0 12/12 17/17 .text            setEventReg__11dSv_event_cFUsUc */
-void dSv_event_c::setEventReg(const u16 i_reg, u8 i_no) {
+void dSv_event_c::setEventReg(u16 i_reg, u8 i_no) {
     mEvent[i_reg >> 8] &= ~(u8)i_reg;
     mEvent[i_reg >> 8] |= i_no;
 }


### PR DESCRIPTION
This PR has some small retail+debug fixes for `d_a_mg_fish` and related inlines, with `lure_catch` now matching. There's still a weird inlining issue with `play_camera` and the weak function order needs some work.