### PR TITLE
Clean up conditional compilation a bit

### DIFF
--- a/include/JSystem/JStudio/JStudio/functionvalue.h
+++ b/include/JSystem/JStudio/JStudio/functionvalue.h
@@ -369,10 +369,8 @@ public:
 
 #if DEBUG
         /* 0x00 */ const TFunctionValue_list_parameter* pOwn_;
-        /* 0x04 */ const f32* pf_;
-#else
-        /* 0x00 */ const f32* pf_;
 #endif
+        /* 0x00 */ const f32* pf_;
     };
     typedef f64 (*update_INTERPOLATE)(const TFunctionValue_list_parameter&, f64);
 

--- a/include/JSystem/JUtility/JUTAssert.h
+++ b/include/JSystem/JUtility/JUTAssert.h
@@ -21,6 +21,10 @@
     JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, LINE, TEXT);                    \
     OSPanic(__FILE__, LINE, "Halt");
 
+#define JUT_PANIC_F(LINE, MSG, ...)                                                               \
+    JUTAssertion::showAssert_f(JUTAssertion::getSDevice(), __FILE__, LINE, MSG, __VA_ARGS__);        \
+    OSPanic(__FILE__, LINE, MSG, __VA_ARGS__);
+
 #define JUT_WARN_DEVICE(LINE, DEVICE, ...)                                                                        \
     JUTAssertion::setWarningMessage_f(DEVICE, __FILE__, LINE, __VA_ARGS__);    \
 
@@ -42,8 +46,9 @@
 #define JUT_ASSERT_MSG_F(...) (void)0;
 #define J3D_PANIC(...) (void)0;
 #define JUT_PANIC(...)
-#define JUT_WARN(...)
+#define JUT_PANIC_F(...)
 #define JUT_WARN_DEVICE(...)
+#define JUT_WARN(...)
 #define JUT_LOG(...)
 #define JUT_CONFIRM(...)
 #endif

--- a/include/Z2AudioLib/Z2SeMgr.h
+++ b/include/Z2AudioLib/Z2SeMgr.h
@@ -86,12 +86,12 @@ public:
 private:
     /* 0x000 */ JAISoundHandle mSoundHandle[24];
     /* 0x060 */ JAISoundHandles mSoundHandles;
-    #if VERSION == VERSION_SHIELD_DEBUG
-    /* 0x068 */ JAISoundHandle dbg_field_0x68;
-    /* 0x06C */ f32 dbg_field_0x6c;
-    /* 0x070 */ f32 dbg_field_0x70;
-    /* 0x074 */ f32 dbg_field_0x74;
-    /* 0x078 */ f32 dbg_field_0x78;
+    #if VERSION >= VERSION_WII_USA_R0
+    /* 0x068 */ JAISoundHandle wii_field_0x68;
+    /* 0x06C */ f32 wii_field_0x6c;
+    /* 0x070 */ f32 wii_field_0x70;
+    /* 0x074 */ f32 wii_field_0x74;
+    /* 0x078 */ f32 wii_field_0x78;
     #endif
     /* 0x068 */ Z2MultiSeObj mLevelObjSe[10];
     /* 0x1D0 */ u8 mLevelObjectSeCount;

--- a/include/Z2AudioLib/Z2SoundObjMgr.h
+++ b/include/Z2AudioLib/Z2SoundObjMgr.h
@@ -100,12 +100,12 @@ public:
     bool isForceBattle() { return forceBattle_; }
     JSUList<Z2CreatureEnemy>* getEnemyList() { return this; }
 
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     JSUList<Z2SoundObjBase>* getAllList() { return &allList_; }
     #endif
 
 private:
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     /* 0x0C */ JSUList<Z2SoundObjBase> allList_;
     #endif
     /* 0x0C */ Z2EnemyArea enemyArea_;

--- a/include/Z2AudioLib/Z2SoundObject.h
+++ b/include/Z2AudioLib/Z2SoundObject.h
@@ -7,7 +7,7 @@
 class Z2SoundStarter;
 
 class Z2SoundObjBase : public Z2SoundHandles
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
 , public JSULink<Z2SoundObjBase>
 #endif
 {

--- a/include/d/d_camera.h
+++ b/include/d/d_camera.h
@@ -1115,7 +1115,7 @@ public:
     static engine_fn engine_tbl[];
 
     /* 0x000 */ camera_class* field_0x0;
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     cXyz dbg_field_0x04[16];
     u8 dbg_field_c4[0xDC - 0xC4];
 #endif

--- a/include/d/d_s_play.h
+++ b/include/d/d_s_play.h
@@ -19,7 +19,7 @@ class dScnPly_reg_HIO_c : public JORReflexible {
 public:
     virtual ~dScnPly_reg_HIO_c() {}
 
-#if DEBUG
+#if 0 && VERSION == VERSION_WII_USA_R0 || DEBUG
     void genMessage(JORMContext*);
 
     /* 0x4 */ s8 id;
@@ -83,7 +83,7 @@ public:
 extern dScnPly_env_HIO_c g_envHIO;
 extern dScnPly_reg_HIO_c g_regHIO;
 
-#if DEBUG
+#if 0 && VERSION == VERSION_WII_USA_R0 || DEBUG
 extern dScnPly_preset_HIO_c g_presetHIO;
 #endif
 
@@ -95,7 +95,7 @@ extern dScnPly_preset_HIO_c g_presetHIO;
  * Float Reg(25-29) ... -1.0 - +1.0
  */
 
-#if DEBUG
+#if 0 && VERSION == VERSION_WII_USA_R0 || DEBUG
 // Morita
 #define TREG_F(i) g_regHIO.mChildReg[0].mFloatReg[i]
 #define TREG_S(i) g_regHIO.mChildReg[0].mShortReg[i]

--- a/include/d/d_save.h
+++ b/include/d/d_save.h
@@ -994,7 +994,7 @@ public:
 
     static const int ZONE_MAX = 0x20;
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     /* 0x000 */ u8 unk_0x0;
     /* 0x001 */ u8 unk_0x1;
     /* 0x000 */ u8 unk_0x2[0x48 - 0x2];
@@ -1013,7 +1013,7 @@ public:
     /* 0xF1B */ u8 field_0xf1b[13];
     /* 0xF28 */ s64 mStartTime;
     /* 0xF30 */ s64 mSaveTotalTime;
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     /* 0xF80 */ flagFile_c mFlagFile;
 #endif
 };  // Size: 0xF38

--- a/include/m_Do/m_Do_graphic.h
+++ b/include/m_Do/m_Do_graphic.h
@@ -112,7 +112,7 @@ public:
     }
 
     static f32 getWidthF() {
-        #if PLATFORM_WII || PLATFORM_SHIELD
+        #if WIDESCREEN_SUPPORT
         return m_widthF;
         #else
         return FB_WIDTH;
@@ -120,7 +120,7 @@ public:
     }
 
     static f32 getHeightF() {
-        #if PLATFORM_WII || PLATFORM_SHIELD
+        #if WIDESCREEN_SUPPORT
         return m_heightF;
         #else
         return FB_HEIGHT;
@@ -131,7 +131,7 @@ public:
     static f32 getHeight() { return FB_HEIGHT; }
 
     static f32 getMinYF() {
-        #if PLATFORM_WII || PLATFORM_SHIELD
+        #if WIDESCREEN_SUPPORT
         return m_minYF;
         #else
         return 0.0f;
@@ -139,7 +139,7 @@ public:
     }
 
     static f32 getMinXF() {
-        #if PLATFORM_WII || PLATFORM_SHIELD
+        #if WIDESCREEN_SUPPORT
         return m_minXF;
         #else
         return 0.0f;
@@ -147,7 +147,7 @@ public:
     }
 
     static f32 getMaxYF() {
-        #if PLATFORM_WII || PLATFORM_SHIELD
+        #if WIDESCREEN_SUPPORT
         return m_maxYF;
         #else
         return FB_HEIGHT;
@@ -155,7 +155,7 @@ public:
     }
 
     static f32 getMaxXF() {
-        #if PLATFORM_WII || PLATFORM_SHIELD
+        #if WIDESCREEN_SUPPORT
         return m_maxXF;
         #else
         return FB_WIDTH;
@@ -233,7 +233,13 @@ public:
         #endif
     }
 
-    static f32 getScale() { return 1.0f; }
+    static f32 getScale() {
+        #if WIDESCREEN_SUPPORT
+        return m_scale;
+        #else
+        return 1.0f;
+        #endif
+    }
 
     #if WIDESCREEN_SUPPORT
     static void setTvSize();

--- a/src/JSystem/J2DGraph/J2DPictureEx.cpp
+++ b/src/JSystem/J2DGraph/J2DPictureEx.cpp
@@ -1006,6 +1006,7 @@ bool J2DPictureEx::getBlackWhite(JUtility::TColor* black, JUtility::TColor* whit
     *white = 0xffffffff;
 
     if (bVar1) {
+        // possible fakematch?
         #if DEBUG || VERSION == VERSION_WII_USA_R0 || VERSION == VERSION_WII_USA_R2
         J2DGXColorS10 tevColor0 = *mMaterial->getTevBlock()->getTevColor(0);
         J2DGXColorS10 tevColor1 = *mMaterial->getTevBlock()->getTevColor(1);

--- a/src/Z2AudioLib/Z2SeMgr.cpp
+++ b/src/Z2AudioLib/Z2SeMgr.cpp
@@ -30,12 +30,12 @@ Z2MultiSeObj::Z2MultiSeObj() {
 }
 
 void Z2SeMgr::initSe() {
-    #if VERSION == VERSION_SHIELD_DEBUG
-    dbg_field_0x68.releaseSound();
-    dbg_field_0x6c = 0.5f;
-    dbg_field_0x70 = 0.0f;
-    dbg_field_0x74 = 0.0f;
-    dbg_field_0x78 = 0.0f;
+    #if VERSION >= VERSION_WII_USA_R0
+    wii_field_0x68.releaseSound();
+    wii_field_0x6c = 0.5f;
+    wii_field_0x70 = 0.0f;
+    wii_field_0x74 = 0.0f;
+    wii_field_0x78 = 0.0f;
     #endif
 
     for (u8 i = 0; i < 10; i++) {

--- a/src/Z2AudioLib/Z2SoundObject.cpp
+++ b/src/Z2AudioLib/Z2SoundObject.cpp
@@ -14,7 +14,7 @@
 #endif
 
 Z2SoundObjBase::Z2SoundObjBase()
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
 : JSULink<Z2SoundObjBase>(this)
 #endif
 {
@@ -30,7 +30,7 @@ Z2SoundObjBase::~Z2SoundObjBase() {
 }
 
 void Z2SoundObjBase::init(Vec* posPtr, u8 handleNum) {
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     Z2GetSoundObjMgr()->getAllList()->append(this);
     #endif
 
@@ -40,7 +40,7 @@ void Z2SoundObjBase::init(Vec* posPtr, u8 handleNum) {
 }
 
 void Z2SoundObjBase::deleteObject() {
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     Z2GetSoundObjMgr()->getAllList()->remove(this);
     #endif
 

--- a/src/Z2AudioLib/Z2SpeechMgr2.cpp
+++ b/src/Z2AudioLib/Z2SpeechMgr2.cpp
@@ -475,7 +475,7 @@ void Z2SpeechMgr2::setString(const u16* s, s16 textNum, u8 speakerID, u16 mood) 
         mTextNum = textNum;
     }
 
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if VERSION >= VERSION_WII_USA_R2
     for (int i = 0; i <= mTextNum; i++)
     #else
     for (int i = 0; i < mTextNum; i++)

--- a/src/d/actor/d_a_alink_cut.inc
+++ b/src/d/actor/d_a_alink_cut.inc
@@ -155,17 +155,12 @@ bool daAlink_c::checkCutTurnInput() const {
     return 0xF800 < abs(field_0x3180);
 }
 
-// Debug version is correct, but breaks other versions due no longer inlining
 int daAlink_c::getCutTurnDirection() const {
-#if VERSION == VERSION_SHIELD_DEBUG
     if (field_0x3180 < 0) {
         return 1;
     } else {
         return 0;
     }
-#else
-    return field_0x3180 < 0;
-#endif
 }
 
 void daAlink_c::resetCombo(int param_0) {

--- a/src/d/actor/d_a_e_fb.cpp
+++ b/src/d/actor/d_a_e_fb.cpp
@@ -120,7 +120,7 @@ int daE_FB_c::JointCallBack(J3DJoint* i_joint, int param_1) {
     return 1;
 }
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
 static f32 dummy_117095() {
     // For rodata ordering in the debug version, this must be put here:
     return 100.0f;
@@ -818,7 +818,7 @@ void daE_FB_c::dead_eff_set() {
     }
 }
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
 static char* dummy_117771() {
     return "Delete -> E_FB(id=%d)\n";
 }

--- a/src/d/actor/d_a_e_kr.cpp
+++ b/src/d/actor/d_a_e_kr.cpp
@@ -2106,16 +2106,17 @@ static int daE_Kr_Execute(e_kr_class* i_this) {
             unkFloat1 = 5.0f + TREG_F(14);
         }
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if PLATFORM_GCN
+        cLib_addCalc2(&i_this->field_0x920, unkFloat1, 1.0f, 2.0f);
+#endif
+
+#if VERSION >= VERSION_WII_USA_R0
         actor->current.pos.y = actor->current.pos.y - unkFloat1;
         actor->old.pos.y = actor->old.pos.y - unkFloat1;
         i_this->mAcch.CrrPos(dComIfG_Bgsp());
         actor->current.pos.y = actor->current.pos.y + unkFloat1;
         actor->old.pos.y = actor->old.pos.y + unkFloat1;
 #else
-
-        cLib_addCalc2(&i_this->field_0x920, unkFloat1, 1.0f, 2.0f);
-
         actor->current.pos.y = actor->current.pos.y - i_this->field_0x920;
         actor->old.pos.y = actor->old.pos.y - i_this->field_0x920;
         i_this->mAcch.CrrPos(dComIfG_Bgsp());

--- a/src/d/actor/d_a_e_sm2.cpp
+++ b/src/d/actor/d_a_e_sm2.cpp
@@ -812,8 +812,8 @@ static u8 new_col_d[] = {
     TYPE_GREEN,  TYPE_BLUE,   TYPE_PURPLE, TYPE_PURPLE, TYPE_PURPLE, TYPE_PURPLE, TYPE_RARE,
     TYPE_BLUE,   TYPE_RED,    TYPE_PURPLE, TYPE_PURPLE, TYPE_PURPLE, TYPE_PURPLE, TYPE_RARE,
     TYPE_PURPLE, TYPE_PURPLE, TYPE_BLUE,
-    // For some reason, the data differs here between retail and ShieldD?
-    #if VERSION == VERSION_SHIELD_DEBUG
+    // For some reason, the data differs here between GCN and Wii/Shield versions
+    #if VERSION >= VERSION_WII_USA_R0
     TYPE_GREEN,
     #else
     TYPE_PURPLE,

--- a/src/d/actor/d_a_mg_rod.cpp
+++ b/src/d/actor/d_a_mg_rod.cpp
@@ -5678,6 +5678,9 @@ static void play_camera_u(dmg_rod_class* i_this) {
 static int dmg_rod_Execute(dmg_rod_class* i_this) {
     fopAc_ac_c* actor = &i_this->actor;
 
+    //TODO: It seems possible that dComIfGs_getPalLanguage returns a constant value for non-PAL
+    //      versions (causing the first block to be elided), and it's also possible that the value
+    //      being compared against is an enum value with per-version definitions.
     #if VERSION == VERSION_SHIELD_DEBUG
     if (dComIfGs_getPalLanguage() == 1) {
         data_804BBBD4 = 2;
@@ -5686,7 +5689,7 @@ static int dmg_rod_Execute(dmg_rod_class* i_this) {
     }
     #elif VERSION == VERSION_SHIELD
     data_804BBBD4 = 0;
-    #elif REGION_PAL
+    #elif REGION_PAL || VERSION >= VERSION_WII_USA_R2
     if (dComIfGs_getPalLanguage() == 0) {
         data_804BBBD4 = 2;
     } else {
@@ -6244,7 +6247,7 @@ static int dmg_rod_Create(fopAc_ac_c* i_this) {
     }
     #elif VERSION == VERSION_SHIELD
     data_804BBBD4 = 0;
-    #elif REGION_PAL
+    #elif REGION_PAL || VERSION >= VERSION_WII_USA_R2
     if (dComIfGs_getPalLanguage() == 0) {
         data_804BBBD4 = 2;
     } else {

--- a/src/d/actor/d_a_npc_kn_teach01.inc
+++ b/src/d/actor/d_a_npc_kn_teach01.inc
@@ -433,7 +433,7 @@ int daNpc_Kn_c::ECut_firstEncount(int i_idx) {
             break;
         case 10:
             daPy_getPlayerActorClass()->changeDemoMoveAngle(fopAcM_searchPlayerAngleY(this) + 0x8000);
-#if VERSION == VERSION_SHIELD_DEBUG
+#if VERSION >= VERSION_WII_USA_R0
             field_0xdec = 50;
 #else
             field_0xdec = 52;

--- a/src/d/actor/d_a_npc_prayer.cpp
+++ b/src/d/actor/d_a_npc_prayer.cpp
@@ -246,7 +246,7 @@ void daNpcPray_c::setParam() {
     attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcPray_Param_c::m.common.talk_distance, daNpcPray_Param_c::m.common.talk_angle);
     attention_info.flags = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     scale.set(daNpcPray_Param_c::m.common.scale, daNpcPray_Param_c::m.common.scale, daNpcPray_Param_c::m.common.scale);
     mAcchCir.SetWallR(daNpcPray_Param_c::m.common.width);
     mAcchCir.SetWallH(daNpcPray_Param_c::m.common.knee_length);
@@ -291,7 +291,7 @@ void daNpcPray_c::setAttnPos() {
     cyl_center.y = current.pos.y;
 
     mCcCyl.SetC(cyl_center);
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     mCcCyl.SetH(daNpcPray_Param_c::m.common.height);
     mCcCyl.SetR(daNpcPray_Param_c::m.common.width);
 #endif

--- a/src/d/actor/d_a_npc_toby.cpp
+++ b/src/d/actor/d_a_npc_toby.cpp
@@ -644,7 +644,7 @@ int daNpc_Toby_c::checkChangeEvt() {
                 break;
             }
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if VERSION >= VERSION_WII_USA_R0
             if (chkAttnZra() && !dComIfGs_isSaveSwitch(0x51))
 #else
             // 0x31E - F_0798 - Heard about Zora from Fyer

--- a/src/d/actor/d_a_obj_kago.cpp
+++ b/src/d/actor/d_a_obj_kago.cpp
@@ -472,7 +472,7 @@ int daObj_Kago_c::Execute() {
 
 int daObj_Kago_c::Draw() {
     if(field_0xb9f == 0 && health != 3) {
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
         mObjAcch.DrawWall(dComIfG_Bgsp());
 #endif
         g_env_light.settingTevStruct(0, &current.pos, &tevStr);

--- a/src/d/actor/d_a_obj_tks.cpp
+++ b/src/d/actor/d_a_obj_tks.cpp
@@ -789,7 +789,7 @@ void daObjTks_c::setParam() {
     calcSpringF(&field_0xdcc, 0.7f, &field_0xdd0);
     scale.setall(field_0xdcc);
 
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     mAcchCir.SetWallR(daObjTks_Param_c::m.common.width);
     mAcchCir.SetWallH(daObjTks_Param_c::m.common.height);
     #endif
@@ -858,7 +858,7 @@ void daObjTks_c::setAttnPos() {
 
     if (!fopAcM_checkCarryNow(this)) {
         mCcCyl.SetC(current.pos);
-        #if VERSION == VERSION_SHIELD_DEBUG
+        #if DEBUG
         mCcCyl.SetH(daObjTks_Param_c::m.common.height);
         mCcCyl.SetR(daObjTks_Param_c::m.common.width);
         #endif

--- a/src/d/actor/d_a_obj_warp_kbrg.cpp
+++ b/src/d/actor/d_a_obj_warp_kbrg.cpp
@@ -202,7 +202,7 @@ int daObjWarpKBrg_c::CreateHeap() {
             return 0;
         }
 
-        #if VERSION == VERSION_SHIELD_DEBUG
+        #if DEBUG
         pbrk = (J3DAnmTevRegKey*)dComIfG_getObjectRes(l_arcName[getNameArg()], 15);
         JUT_ASSERT(463, pbrk != NULL);
         #endif
@@ -256,7 +256,7 @@ int daObjWarpKBrg_c::create1st() {
 }
 
 int daObjWarpKBrg_c::Execute(Mtx** param_0) {
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     calcMidnaWaitPos();
     #endif
 

--- a/src/d/actor/d_a_obj_warp_obrg.cpp
+++ b/src/d/actor/d_a_obj_warp_obrg.cpp
@@ -177,7 +177,7 @@ int daObjWarpOBrg_c::create1st() {
 }
 
 int daObjWarpOBrg_c::Execute(Mtx** param_0) {
-    #if VERSION == VERSION_SHIELD_DEBUG
+    #if DEBUG
     calcMidnaWaitPos();
     #endif
 

--- a/src/d/actor/d_a_spinner.cpp
+++ b/src/d/actor/d_a_spinner.cpp
@@ -669,7 +669,7 @@ int daSpinner_c::execute() {
 
         move_angle = (mDoCPd_c::getStickAngle3D(PAD_1) + 0x10000 + dCam_getControledAngleY(dComIfGp_getCamera(dComIfGp_getPlayerCameraID(0)))) - 0x8000;
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if PLATFORM_WII || VERSION == VERSION_SHIELD_DEBUG
         if (dComIfG_getTrigB(PAD_1) && dComIfGp_getSelectItem(3) == fpcNm_ITEM_SPINNER) {
 #else
         if (dComIfG_getTrigA(PAD_1)) {

--- a/src/d/d_menu_letter.cpp
+++ b/src/d/d_menu_letter.cpp
@@ -164,7 +164,8 @@ dMenu_Letter_c::~dMenu_Letter_c() {
 void dMenu_Letter_c::_create() {
     mpDrawCursor = new dSelect_cursor_c(2, 1.0f, NULL);
     JUT_ASSERT(231, mpDrawCursor != NULL);
-    #if VERSION == VERSION_SHIELD_DEBUG
+    // shield prod uses same values as GCN?
+    #if PLATFORM_WII || VERSION == VERSION_SHIELD_DEBUG
     mpDrawCursor->setParam(1.01f, 0.85f, 0.02f, 0.5f, 0.5f);
     #else
     mpDrawCursor->setParam(1.06f, 0.9f, 0.02f, 0.4f, 0.4f);

--- a/src/d/d_msg_class.cpp
+++ b/src/d/d_msg_class.cpp
@@ -4997,7 +4997,7 @@ void jmessage_string_tRenderingProcessor::do_widthcenter() {
         scale = 1.0f;
         scale = mDoGph_gInf_c::getScale();
 
-        #if VERSION == VERSION_SHIELD_DEBUG 
+        #if VERSION >= VERSION_WII_USA_R0
         for (; pane != NULL; pane = pane->getParentPane()) {
             if (pane->getUserInfo() == 'n_43') {
                 scale = 1.0f;

--- a/src/d/d_save.cpp
+++ b/src/d/d_save.cpp
@@ -709,7 +709,7 @@ void dSv_player_item_record_c::init() {
 }
 
 void dSv_player_item_record_c::setBombNum(u8 i_bagIdx, u8 i_bombNum) {
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     if (i_bagIdx == 8) {
         return;
     }
@@ -989,10 +989,10 @@ void dSv_player_config_c::init() {
     mAttentionType = 0;
     mVibration = 1;
 
-#if VERSION == VERSION_GCN_PAL
-    mLanguage = OSGetLanguage();
-#elif VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     mLanguage = SCGetLanguage();
+#elif REGION_PAL || VERSION >= VERSION_WII_USA_R2
+    mLanguage = OSGetLanguage();
 #else
     mLanguage = 0;
 #endif
@@ -1043,7 +1043,7 @@ u8 dSv_player_config_c::getPalLanguage() const {
     case 4:
         return LANGAUGE_ITALIAN;
     }
-#elif VERSION == VERSION_SHIELD_DEBUG
+#elif VERSION >= VERSION_WII_USA_R0
     switch (SCGetLanguage()) {
     case 1:
         return 0;
@@ -1298,7 +1298,7 @@ BOOL dSv_danBit_c::isItem(int i_no) const {
     return mItem[i_no >> 5] & 1 << (i_no & 0x1F) ? TRUE : FALSE;
 }
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
 static void dummyString() {
     DEAD_STRING("i_no < 6");
 }
@@ -1449,7 +1449,7 @@ void dSv_info_c::init() {
     initZone();
     mTmp.init();
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
     unk_0x0 = 0;
     unk_0x1 = 0;
 #endif

--- a/src/d/d_simple_model.cpp
+++ b/src/d/d_simple_model.cpp
@@ -144,7 +144,7 @@ BOOL diff_model_c::create(J3DModelData* i_modelData, int roomNo, u8 drawBG) {
                 int result = mDoExt_adjustSolidHeapToSystem(mpHeap);
                 mRoomNo = roomNo;
                 mDrawBG = drawBG;
-                #if VERSION == VERSION_SHIELD_DEBUG
+                #if DEBUG
                 field_0x12 = 0;
                 #endif
                 return 1;
@@ -170,7 +170,7 @@ void diff_model_c::remove(int param_0) {
 
     if (mCreateNum == 0 || param_0 != 0) {
         if (mpHeap != NULL) {
-            #if VERSION == VERSION_SHIELD_DEBUG
+            #if DEBUG
             if (field_0x12 != 0) {
                 JUT_WARN(510, "%s", "Simple Model Denger Remove !!\n");
             }
@@ -196,11 +196,11 @@ void diff_model_c::draw() {
         }
         mDoExt_modelUpdateDL(mpModel);
         dComIfGd_setList();
-        #if VERSION == VERSION_SHIELD_DEBUG
+        #if DEBUG
         field_0x12 = 1;
         #endif
     } else {
-        #if VERSION == VERSION_SHIELD_DEBUG
+        #if DEBUG
         field_0x12 = 0;
         #endif
     }

--- a/src/f_pc/f_pc_base.cpp
+++ b/src/f_pc/f_pc_base.cpp
@@ -13,10 +13,7 @@
 #include "f_pc/f_pc_pause.h"
 #include "f_pc/f_pc_profile.h"
 #include "f_pc/f_pc_debug_sv.h"
-
-#if VERSION == VERSION_SHIELD_DEBUG
 #include "Z2AudioLib/Z2AudioMgr.h"
-#endif
 
 BOOL fpcBs_Is_JustOfType(int i_typeA, int i_typeB) {
     if (i_typeB == i_typeA) {
@@ -94,21 +91,21 @@ int fpcBs_Delete(base_process_class* i_proc) {
             i_proc->type = 0;
             cMl::free(i_proc);
 
-            #if VERSION == VERSION_SHIELD_DEBUG
-            // JSUList<Z2SoundObjBase>* allList = Z2GetAudioMgr()->getAllList();
-            
-            // for (JSUListIterator<Z2SoundObjBase> it(allList->getFirst()); it != allList->getEnd(); it++) {
-            //     static JSULink<Z2SoundObjBase>* DUMMY_FILL_IT = NULL;
-            //     static Z2SoundObjBase* DUMMY_FILL_P = NULL;
-            //     if (it == DUMMY_FILL_IT || it.getObject() == DUMMY_FILL_P) {
-            //         const char* stageName = dStage_getName2(profname, 0);
-            //         if (stageName == NULL) {
-            //             JUT_PANIC_F(341, "Sound Object Not Delete !! <%d>\n", profname);
-            //         } else {
-            //             JUT_PANIC_F(345, "Sound Object Not Delete !! <%s>\n", stageName);
-            //         }
-            //     }
-            // }
+            #if DEBUG
+            JSUList<Z2SoundObjBase>* allList = Z2GetAudioMgr()->getAllList();
+
+            for (JSUListIterator<Z2SoundObjBase> it(allList->getFirst()); it != allList->getEnd(); it++) {
+                static JSULink<Z2SoundObjBase>* DUMMY_FILL_IT = NULL;
+                static Z2SoundObjBase* DUMMY_FILL_P = NULL;
+                if (it == DUMMY_FILL_IT || it.getObject() == DUMMY_FILL_P) {
+                    const char* stageName = dStage_getName2(profname, 0);
+                    if (stageName == NULL) {
+                        JUT_PANIC_F(341, "Sound Object Not Delete !! <%d>\n", profname);
+                    } else {
+                        JUT_PANIC_F(345, "Sound Object Not Delete !! <%s>\n", stageName);
+                    }
+                }
+            }
             #endif
         }
     }

--- a/src/m_Do/m_Do_ext.cpp
+++ b/src/m_Do/m_Do_ext.cpp
@@ -665,7 +665,7 @@ JKRExpHeap* mDoExt_getZeldaHeap() {
     return zeldaHeap;
 }
 
-#if VERSION == VERSION_SHIELD_DEBUG
+#if DEBUG
 s32 safeZeldaHeapSize = -1;
 
 s32 mDoExt_getSafeZeldaHeapSize() {


### PR DESCRIPTION
This PR includes some cleanup for conditional compilation macros, mainly replacing explicit version checks with debug or platform checks where appropriate and also applying some debug matches to Wii as well where appropriate. This yields a modest boost in match percentage across the affected TUs.

There are some regressions reported with `Shield` - these are due to incorrect inlining behavior in that version and don't represent true regressions.