### PR TITLE
Enable regHIO for Wii USA R0

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -99,6 +99,11 @@ parser.add_argument(
     action="store_true",
     help="build with debug info (non-matching)",
 )
+parser.add_argument(
+    "--reghio",
+    action="store_true",
+    help="build with regHIO support",
+)
 if not is_windows():
     parser.add_argument(
         "--wrapper",
@@ -262,6 +267,9 @@ elif config.version in ["RZDE01_00", "RZDE01_02", "RZDJ01", "Shield"]:
     cflags_base.extend(["-O4,p", "-inline auto", "-ipa file", "-RTTI on", "-str reuse", "-enc SJIS", "-DWIDESCREEN_SUPPORT=1"])
 else:
     cflags_base.extend(["-O4,p", "-inline auto", "-RTTI off", "-str reuse", "-multibyte"])
+
+if config.version in ["RZDE01_00", "ShieldD"] or args.debug or args.reghio:
+    cflags_base.extend(["-DENABLE_REGHIO=1"])
 
 USE_REVOLUTION_SDK_VERSIONS = [
     "RZDE01_00", # Wii USA Rev 0

--- a/include/d/d_s_play.h
+++ b/include/d/d_s_play.h
@@ -19,7 +19,7 @@ class dScnPly_reg_HIO_c : public JORReflexible {
 public:
     virtual ~dScnPly_reg_HIO_c() {}
 
-#if 0 && VERSION == VERSION_WII_USA_R0 || DEBUG
+#if ENABLE_REGHIO
     void genMessage(JORMContext*);
 
     /* 0x4 */ s8 id;
@@ -83,7 +83,7 @@ public:
 extern dScnPly_env_HIO_c g_envHIO;
 extern dScnPly_reg_HIO_c g_regHIO;
 
-#if 0 && VERSION == VERSION_WII_USA_R0 || DEBUG
+#if ENABLE_REGHIO
 extern dScnPly_preset_HIO_c g_presetHIO;
 #endif
 
@@ -95,7 +95,7 @@ extern dScnPly_preset_HIO_c g_presetHIO;
  * Float Reg(25-29) ... -1.0 - +1.0
  */
 
-#if 0 && VERSION == VERSION_WII_USA_R0 || DEBUG
+#if ENABLE_REGHIO
 // Morita
 #define TREG_F(i) g_regHIO.mChildReg[0].mFloatReg[i]
 #define TREG_S(i) g_regHIO.mChildReg[0].mShortReg[i]

--- a/src/d/actor/d_a_e_pz.cpp
+++ b/src/d/actor/d_a_e_pz.cpp
@@ -89,6 +89,7 @@ int daE_PZ_c::draw() {
     }
 
     if (arg0 == 10) {
+#if DEBUG
         if (WREG_S(0) != 0) {
             GXColor color;
             color.r = 0xFF;
@@ -97,6 +98,7 @@ int daE_PZ_c::draw() {
             color.a = 0xFA;
             dDbVw_drawCircleXlu(home.pos, 100.0f, color, TRUE, 12);
         }
+#endif
         return 1;
     }
 

--- a/src/d/actor/d_a_e_st.cpp
+++ b/src/d/actor/d_a_e_st.cpp
@@ -2687,7 +2687,11 @@ static int daE_ST_Execute(e_st_class* i_this) {
             cMtx_YrotS(*calc_mtx, i_this->field_0x7f2);
             pos.x = 0.0f;
             pos.y = 0.0f;
+#if VERSION == VERSION_WII_USA_R0
+            pos.z = i_this->field_0x7ec * -cM_ssin(i_this->field_0x7f0 * (TREG_S(4) + 900));
+#else
             pos.z = i_this->field_0x7ec * -cM_ssin(i_this->field_0x7f0 * (TREG_F(4) + 900));
+#endif
             MtxPosition(&pos, &offset);
             i_this->field_0x7f0++;
             cLib_addCalc0(&i_this->field_0x7ec, 1.0f, 0.1f);

--- a/src/d/actor/d_a_e_wb.cpp
+++ b/src/d/actor/d_a_e_wb.cpp
@@ -1385,7 +1385,7 @@ static void e_wb_b_run2(e_wb_class* i_this) {
 
         for (int i = 0; i < 8; i++) {
             cMtx_YrotS(*calc_mtx, i << 0xd);
-            pos1.z = 3000.0f;
+            pos1.z = 3000.0f + ZREG_F(10);
             MtxPosition(&pos1, &pos2);
             pos2 += player_p->current.pos;
             b_path2[i] = pos2;
@@ -1530,8 +1530,6 @@ static void e_wb_b_run(e_wb_class* i_this) {
         i_this->mActionMode = 0;
     } else {
         s8 is_player_on_fast_horse = false;
-        f32 cavalry_max_speed = l_HIO.leader_cavalry_battle_max_speed;
-
         if (daPy_getPlayerActorClass()->checkHorseRide() &&
             dComIfGp_getHorseActor()->speedF >= 30.0f)
         {
@@ -1639,7 +1637,7 @@ static void e_wb_b_run(e_wb_class* i_this) {
                     }
                 }
 
-                if (fopAcM_searchPlayerDistanceXZ(a_this) < 2000.0f) {
+                if (fopAcM_searchPlayerDistanceXZ(a_this) < 2000.0f + KREG_F(0)) {
                     target_speed *= 1.2f;
 
                     if (a_this->speedF < l_HIO.max_speed) {
@@ -1698,20 +1696,19 @@ static void e_wb_b_run(e_wb_class* i_this) {
         case 10:  // jumping a fence / hit wall
             target_speed = l_HIO.max_speed;
             acceleration = 3.0f;
-            int current_anim = i_this->mAnmID;
 
-            if (current_anim == 0x18) {
+            if (i_this->mAnmID == 0x18) {
                 if (a_this->speed.y < 10.0f) {
                     anm_init(i_this, 0x19, 10.0f, 0, anim_speed_factor);
                 }
-            } else if (current_anim == 0x19) {
-                if (a_this->speed.y < -30.0f || i_this->mAcch.ChkGroundHit()) {
+            } else if (i_this->mAnmID == 0x19) {
+                if (a_this->speed.y < (-30.0f + JREG_F(9)) || i_this->mAcch.ChkGroundHit()) {
                     anm_init(i_this, 0x1a, 2.0f, 0, 1.0f);
                     i_this->mCollisionFlags |= 0xc;
                     i_this->mLandingFlag = 1;
                     i_this->mStatusFlags |= 0x200;
                 }
-            } else if (current_anim == 0x1a) {
+            } else if (i_this->mAnmID == 0x1a) {
                 i_this->mMovementType = 1;
 
                 if (i_this->mpModelMorf->isStop()) {
@@ -1724,8 +1721,9 @@ static void e_wb_b_run(e_wb_class* i_this) {
 
         if (i_this->mActionMode < 10) {
             cLib_addCalc2(&a_this->speedF, target_speed, 1.0f, acceleration);
+            s16 targetAngle = (TREG_S(7) - 4) * (a_this->current.angle.y - initial_facing_angle);
             cLib_addCalcAngleS2(&i_this->mBodyTiltAngle,
-                                -4 * (a_this->current.angle.y - initial_facing_angle), 8, 0x200);
+                                targetAngle, 8, 0x200);
             i_this->mpModelMorf->setPlaySpeed(i_this->mPlaySpeed);
             cLib_addCalc2(&i_this->mPlaySpeed, anim_speed_factor, 1.0f, 0.1f);
 

--- a/src/d/actor/d_a_e_zh.cpp
+++ b/src/d/actor/d_a_e_zh.cpp
@@ -130,6 +130,7 @@ static int mStartFlag;
 
 int daE_ZH_c::draw() {
     GXColor i_color, i_color2;
+#if DEBUG
     if (WREG_S(0) != 0) {
         cXyz i_pos = home.pos;
         i_color.r = 0x82;
@@ -212,6 +213,7 @@ int daE_ZH_c::draw() {
             }
         }
     }
+#endif
 
     J3DModelData* modelData;
     J3DMaterial* matNodeP;

--- a/src/d/actor/d_a_kago.cpp
+++ b/src/d/actor/d_a_kago.cpp
@@ -3214,11 +3214,15 @@ void daKago_c::moveDemoFly() {
                 field_0x6c4 = 8000.0f;
                 field_0x710 = field_0x712 = 0;
 
+#if VERSION == VERSION_WII_USA_R0
+                field_0x72c = 30;
+#else
                 if (dComIfGp_getStartStagePoint() == 0) {
                     field_0x72c = 30;
                 } else {
                     field_0x72c = 60 + nREG_S(1);
                 }
+#endif
 
                 shape_angle.y = current.angle.y;
 

--- a/src/d/actor/d_a_npc_henna.cpp
+++ b/src/d/actor/d_a_npc_henna.cpp
@@ -764,8 +764,13 @@ static void action(npc_henna_class* i_this) {
 
     s16 unkTarget1 = 0;
     s16 unkTarget2 = 0;
+#if VERSION == VERSION_WII_USA_R0
+    s16 unkTarget2Limit = 9000 + BREG_S(0);
+    s16 unkTarget1Limit = 10000 + BREG_S(1);
+#else
     s16 unkTarget2Limit = 9000 + BREG_F(0);
     s16 unkTarget1Limit = 10000 + BREG_F(1);
+#endif
     if (i_this->field_0x70d == 10 || (i_this->field_0x70d == 1 && i_this->field_0x61c < 700.0f)) {
         if (i_this->field_0x70c != 0) {
             mae = sub_actor->eyePos - actor->eyePos;

--- a/src/d/actor/d_a_obj_carry.cpp
+++ b/src/d/actor/d_a_obj_carry.cpp
@@ -1897,9 +1897,11 @@ BOOL daObjCarry_c::checkCulling() {
         is_cull = TRUE;
     }
 
+#if DEBUG
     if (KREG_S(2) == 10000) {
         is_cull = FALSE;
     }
+#endif
 
     return is_cull;
 }

--- a/src/d/actor/d_a_obj_scannon.cpp
+++ b/src/d/actor/d_a_obj_scannon.cpp
@@ -218,7 +218,17 @@ int daSCannon_c::draw() {
 
     if (mDrawShadow) {
         cXyz sp8(current.pos.x, current.pos.y, current.pos.z);
-        mShadowKey = dComIfGd_setShadow(mShadowKey, 1, mpModels[mIsRepaired], &sp8, 2500.0f, 0.0f, current.pos.y + aREG_F(1), mGroundY + aREG_F(3), mGroundPoly, &tevStr, 0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
+#if DEBUG
+        mShadowKey = dComIfGd_setShadow(mShadowKey, 1, mpModels[mIsRepaired], &sp8, 2500.0f, 0.0f,
+                                        current.pos.y + aREG_F(1), mGroundY + aREG_F(3),
+                                        mGroundPoly, &tevStr, 0, 1.0f,
+                                        dDlst_shadowControl_c::getSimpleTex());
+#else
+        mShadowKey = dComIfGd_setShadow(mShadowKey, 1, mpModels[mIsRepaired], &sp8, 2500.0f, 0.0f,
+                                        current.pos.y, mGroundY,
+                                        mGroundPoly, &tevStr, 0, 1.0f,
+                                        dDlst_shadowControl_c::getSimpleTex());
+#endif
     }
 
     return 1;

--- a/src/d/actor/d_a_obj_scannon_ten.cpp
+++ b/src/d/actor/d_a_obj_scannon_ten.cpp
@@ -157,7 +157,8 @@ void daObjSCannonTen_c::middleExe() {
 }
 
 void daObjSCannonTen_c::exeModeWait() {
-    if (aREG_F(0) == 0.0f && fopAcM_checkHookCarryNow(this) && dComIfGp_checkPlayerStatus1(0, 0x10)) {
+    if (!(DEBUG && aREG_F(0) != 0.0f) && fopAcM_checkHookCarryNow(this) &&
+        dComIfGp_checkPlayerStatus1(0, 0x10)) {
         eventInfo.setArchiveName(l_arcName);
         mEvtIdx = dComIfGp_getEventManager().getEventIdx(this, l_eventName, 0xFF);
 #if DEBUG

--- a/src/d/d_s_play.cpp
+++ b/src/d/d_s_play.cpp
@@ -566,7 +566,7 @@ dScnPly_reg_HIO_c g_regHIO;
 
 dScnPly_env_HIO_c g_envHIO;
 
-#if DEBUG
+#if ENABLE_REGHIO
 dScnPly_preset_HIO_c g_presetHIO;
 #endif
 


### PR DESCRIPTION
This PR adds a new define to control whether regHIO is enabled and enables it by default for `RZDE01_00`. There are several regressions reported; most of these not true regressions and are instead basically just noise due to instructions shifting around in incomplete functions. There are a number of broken matches in `d_a_e_hm` due to `.rodata` ordering - the ordering was already broken due to `-ipa file` stripping out dummy floats and those functions just happened to have their `.rodata` addresses align correctly.

The two exceptions are in `mDoGph_Painter` and `daFshop_Create` - for some reason the HIO code breaks inlining of `cXyz`'s constructor which significantly affects codegen. As of now I'm not really sure how to resolve these.