### PR TITLE
Slightly Update README after GCN matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,68 @@
-The Legend of Zelda: Twilight Princess  
-[![Build Status]][actions] [![Code Progress]][progress] [![DOL Progress]][progress] [![RELs Progress]][progress] [![Discord Badge]][discord]
-=============
+# The Legend of Zelda: Twilight Princess
+
+[![Build Status]][actions] [![Discord Badge]][discord] [![GZ2E01]][progress] [![GZ2P01]][progress] [![GZ2J01]][progress] [![ShieldD]][progress]
 
 [Build Status]: https://github.com/zeldaret/tp/actions/workflows/build.yml/badge.svg
 [actions]: https://github.com/zeldaret/tp/actions/workflows/build.yml
-[Code Progress]: https://decomp.dev/zeldaret/tp.svg?mode=shield&category=all&measure=code&label=Code
-[DOL Progress]: https://decomp.dev/zeldaret/tp.svg?mode=shield&category=dol&measure=code&label=DOL
-[RELs Progress]: https://decomp.dev/zeldaret/tp.svg?mode=shield&category=modules&measure=code&label=RELs
-[progress]: https://decomp.dev/zeldaret/tp
 [Discord Badge]: https://img.shields.io/discord/688807550715560050?color=%237289DA&logo=discord&logoColor=%23FFFFFF
 [discord]: https://discord.com/invite/DqwyCBYKqf
 
-A work-in-progress decompilation of The Legend of Zelda: Twilight Princess (GCN USA).
+[GZ2E01]: https://decomp.dev/zeldaret/tp/GZ2E01.svg?mode=shield&label=GZ2E01
+[GZ2P01]: https://decomp.dev/zeldaret/tp/GZ2P01.svg?mode=shield&label=GZ2P01
+[GZ2J01]: https://decomp.dev/zeldaret/tp/GZ2J01.svg?mode=shield&label=GZ2J01
+<!-- [RZDE01_00]: https://decomp.dev/zeldaret/tp/RZDE01_00.svg?mode=shield&label=RZDE01_00
+[RZDE01_02]: https://decomp.dev/zeldaret/tp/RZDE01_02.svg?mode=shield&label=RZDE01_02
+[RZDP01]: https://decomp.dev/zeldaret/tp/RZDP01.svg?mode=shield&label=RZDP01
+[RZDJ01]: https://decomp.dev/zeldaret/tp/RZDJ01.svg?mode=shield&label=RZDJ01
+[Shield]: https://decomp.dev/zeldaret/tp/Shield.svg?mode=shield&label=Shield -->
+[ShieldD]: https://decomp.dev/zeldaret/tp/ShieldD.svg?mode=shield&label=ShieldD
+[progress]: https://decomp.dev/zeldaret/tp
 
-This repository does **not** contain any game assets or assembly whatsoever. An existing copy of the game is required.
+A work-in-progress decompilation of The Legend of Zelda: Twilight Princess.
 
-More information about the project can be found here: https://zsrtp.link  
+The code for the GameCube releases is completely matching. However, not every Translation Unit (TU) has been linked yet. Work is continuing by aligning the Debug version and getting the Wii versions to match. All versions are built from the same codebase using conditional compilation.
+
+> [!IMPORTANT]
+> This repository does **not** contain any game assets or assembly whatsoever. An existing copy of the game is required.
+>
+> This project itself **is not**, and will not, produce a port, to PC or any other platform. It is a decompilation of the original game code, which can be compiled back into a binary identical to the original.
+
+<!-- markdownlint-disable MD033 -->
+[<img src="https://decomp.dev/zeldaret/tp.svg?w=512&h=256" width="512" height="256" alt="A visual">][Progress]
+<!-- markdownlint-enable MD033 -->
+
+The project can target the following supported versions:
+
+- **`GZ2E01`**: GameCube - North America
+- **`GZ2P01`**: GameCube - Europe/Australia
+- **`GZ2J01`**: GameCube - Japan
+- `RZDE01_00`: Wii - North America (Rev 0)
+- `RZDE01_02`: Wii - North America (Rev 2)
+- `RZDP01`: Wii - Europe/Australia
+- `RZDJ01`: Wii - Japan
+- `Shield`: Nvidia Shield - China
+- `ShieldD`: Nvidia Shield - China (Debug Version)
+
+More information about the project can be found here: <https://zsrtp.link>  
 
 <!--ts-->
-* [Progress](https://zsrtp.link/progress)
-* [Dependencies](#dependencies)
-* [Building](#building)
-* [Diffing](#diffing)
-* [Contributing](https://zsrtp.link/contribute)
-* [FAQ](https://zsrtp.link/about)
+- [Progress](https://zsrtp.link/progress)
+- [Dependencies](#dependencies)
+- [Building](#building)
+- [Diffing](#diffing)
+- [Contributing](#contributing)
+- [FAQ](https://zsrtp.link/about)
 
-Dependencies
-============
+## Dependencies
 
-Windows
---------
+You will need the following dependencies:
+
+- git
+- ninja
+- python3
+- clang-format (optional)
+
+### Windows
 
 On Windows, it's **highly recommended** to use native tooling. WSL or msys2 are **not** required.  
 When running under WSL, [objdiff](#diffing) is unable to get filesystem notifications for automatic rebuilds.
@@ -39,8 +72,7 @@ When running under WSL, [objdiff](#diffing) is unable to get filesystem notifica
 - Download [ninja](https://github.com/ninja-build/ninja/releases) and add it to `%PATH%`.
   - Quick install via pip: `pip install ninja`
 
-macOS
-------
+### macOS
 
 - Install [ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages):
 
@@ -50,15 +82,13 @@ macOS
 
 [wibo](https://github.com/decompals/wibo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.
 
-Linux
-------
+### Linux
 
 - Install [ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).
 
 [wibo](https://github.com/decompals/wibo), a minimal 32-bit Windows binary wrapper, will be automatically downloaded and used.
 
-Building
-========
+## Building
 
 - Clone the repository:
 
@@ -76,15 +106,14 @@ Building
   python configure.py
   ```
 
-  To use a version other than `GZ2E01` (USA), specify it with `--version`.
+  To use a version other than `GZ2E01` (GCN USA), specify it with `--version`.
 - Build:
 
   ```sh
   ninja
   ```
 
-Diffing
-=======
+## Diffing
 
 Once the initial build succeeds, an `objdiff.json` should exist in the project root.
 
@@ -92,4 +121,8 @@ Download the latest release from [encounter/objdiff](https://github.com/encounte
 
 Select an object from the left sidebar to begin diffing. Changes to the project will rebuild automatically: changes to source files, headers, `configure.py`, `splits.txt` or `symbols.txt`.
 
-![](assets/objdiff.png)
+![objdiff application window](assets/objdiff.png)
+
+## Contributing
+
+If you've got all the requirements set up and want to learn how to contribute to the decompilation effort, join our [Discord server][discord] and check out our [contribution guide](https://zsrtp.link/contribute).


### PR DESCRIPTION
With even more attention now, I thought it would be nice to polish the readme a bit. Something that the contributors rarely think about, but it is the first thing new people see and the current one is a bit barebones. I stole some stuff from other decomps.

- Added a PC Port warning/info, hopefully leading to less lost people joining the discord asking about it
- Added a list of all configured versions
- Removed the DOL and REL shields, but added version shields (that work if the bot doesnt choke on the api)
- Added a small text explaining the current state of the project at a quick glance
- Added the grid svg, would be even nicer if unliked TUs get a different color.
- Fixed markdownlint violations

lmk if this was too much or anything should be changed