### PR TITLE
Fix errors when building with -ipa program

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1084,7 +1084,7 @@ config.libs = [
             Object(MatchingFor(ALL_GCN), "JSystem/JAudio2/JASOscillator.cpp"),
             Object(MatchingFor(ALL_GCN), "JSystem/JAudio2/JASAiCtrl.cpp"),
             Object(MatchingFor(ALL_GCN), "JSystem/JAudio2/JASAudioThread.cpp"),
-            Object(MatchingFor(ALL_GCN, "ShieldD"), "JSystem/JAudio2/JASAudioReseter.cpp"),
+            Object(MatchingFor(ALL_GCN), "JSystem/JAudio2/JASAudioReseter.cpp"),
             Object(MatchingFor(ALL_GCN, "ShieldD"), "JSystem/JAudio2/JASDSPChannel.cpp"),
             Object(MatchingFor(ALL_GCN), "JSystem/JAudio2/JASDSPInterface.cpp"),
             Object(MatchingFor(ALL_GCN), "JSystem/JAudio2/JASDriverIF.cpp"),

--- a/include/JSystem/JAudio2/JASDSPChannel.h
+++ b/include/JSystem/JAudio2/JASDSPChannel.h
@@ -29,6 +29,7 @@ struct JASDSPChannel {
     void drop();
     void setPriority(u8);
     void updateProc();
+    u8 getStatus() const { return mStatus; }
 
     static void initAll();
     static JASDSPChannel* alloc(u8, Callback, void*);

--- a/include/JSystem/JMath/JMATrigonometric.h
+++ b/include/JSystem/JMath/JMATrigonometric.h
@@ -2,7 +2,17 @@
 #define JMATRIGONOMETRIC_H
 
 #include "dolphin/types.h"
+#include <math>
 #include <utility>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    extern double asin(double);
+    extern double atan(double);
+#ifdef __cplusplus
+}
+#endif
 
 namespace JMath {
 template<typename T>
@@ -27,6 +37,16 @@ struct TAngleConstant_<f32> {
 template<int N, typename T>
 struct TSinCosTable {
     std::pair<T, T> table[1 << N];
+
+    TSinCosTable() {
+        init();
+    }
+    void init() {
+        for (int i = 0; i < 1 << N; i++) {
+            table[i].first = sin((i * f64(TAngleConstant_<f32>::RADIAN_DEG360())) / (1 << N));
+            table[i].second = cos((i * f64(TAngleConstant_<f32>::RADIAN_DEG360())) / (1 << N));
+        }
+    }
 
     T sinShort(s16 v) const { return table[(u16)v >> (16U - N)].first; }
     T cosShort(s16 v) const { return table[(u16)v >> (16U - N)].second; }
@@ -68,6 +88,19 @@ template<int N, typename T>
 struct TAtanTable {
     T table[N + 1];
     u8 pad[0x1C];
+
+    TAtanTable() {
+        init();
+    }
+
+    void init() {
+        // u32 cast needed for cmplwi instead of cmpwi
+        for (int i = 0; i < (u32)N; i++) {
+            table[i] = atan(i / (f64)N);
+        }
+        table[0] = 0.0f;
+        table[N] = TAngleConstant_<T>::RADIAN_DEG180() / 4.0f;
+    }
 };
 
 /**
@@ -78,6 +111,18 @@ template<int N, typename T>
 struct TAsinAcosTable {
     T table[N + 1];
     u8 pad[0x1C];
+
+    TAsinAcosTable() {
+        init();
+    }
+
+    void init() {
+        for (int i = 0; i < 1024; i++) {
+            table[i] = asin(i / (f64)N);
+        }
+        table[0] = 0.0f;
+        table[N] = TAngleConstant_<T>::RADIAN_DEG180() / 4.0f;
+    }
 
     T acos_(T x) const {
         if (x >= 1.0f) {

--- a/include/JSystem/JSystem.pch
+++ b/include/JSystem/JSystem.pch
@@ -4,6 +4,7 @@
 #include "JSystem/J3DGraphAnimator/J3DMaterialAttach.h"
 #include "JSystem/J3DGraphBase/J3DPacket.h"
 #include "JSystem/J3DGraphBase/J3DShape.h"
+#include "JSystem/JAudio2/JASDSPChannel.h"
 #include "JSystem/JSupport/JSUList.h"
 
 #endif // JSYSTEM_PCH

--- a/src/DynamicLink.cpp
+++ b/src/DynamicLink.cpp
@@ -474,14 +474,14 @@ extern "C" void ModuleUnresolved() {
     OSReport_Error("\n");
 }
 
-extern "C" void ModuleConstructorsX(void (**ctors)()) {
+extern "C" void ModuleConstructorsX(void (*const *ctors)()) {
     while (*ctors != 0) {
         (**ctors)();
         ctors++;
     }
 }
 
-extern "C" void ModuleDestructorsX(void (**dtors)()) {
+extern "C" void ModuleDestructorsX(void (*const *dtors)()) {
     while (*dtors != 0) {
         (**dtors)();
         dtors++;

--- a/src/JSystem/JAudio2/JASAudioReseter.cpp
+++ b/src/JSystem/JAudio2/JASAudioReseter.cpp
@@ -4,15 +4,8 @@
 #include "JSystem/JAudio2/JASAudioThread.h"
 #include "JSystem/JAudio2/JASCriticalSection.h"
 #include "JSystem/JAudio2/JASDriverIF.h"
+#include "JSystem/JAudio2/JASDSPChannel.h"
 #include "dolphin/types.h"
-
-struct JASDSPChannel {
-    void drop();
-    static JASDSPChannel* getHandle(u32);
-
-    inline u8 getStatus() const { return mStatus; }
-    u32 mStatus;
-};
 
 JASAudioReseter::JASAudioReseter() {
     field_0x0 = 0;
@@ -52,16 +45,15 @@ s32 JASAudioReseter::checkDone() const {
     return mDoneFlag;
 }
 
-
 s32 JASAudioReseter::calc() {
-    if(field_0x0==0) {
-        for(size_t i = 0; i<64; i++) {
+    if (field_0x0==0) {
+        for (size_t i = 0; i<64; i++) {
             JASDSPChannel* handle = JASDSPChannel::getHandle(i);
-            if ((handle->getStatus())==0) {
+            if (handle->getStatus() == 0) {
                 handle->drop();
             }
         }
-        if(mThreadStopFlag!=false) {
+        if (mThreadStopFlag!=false) {
             JASAudioThread* pAudioThread = JASGlobalInstance<JASAudioThread>::getInstance();
             JUT_ASSERT(78, pAudioThread);
             pAudioThread->stop();

--- a/src/JSystem/JAudio2/dsptask.cpp
+++ b/src/JSystem/JAudio2/dsptask.cpp
@@ -9,7 +9,7 @@ static void DspHandShake(void* param_0);
 static int DspStartWork(u32 param_0, void (*param_1)(u16));
 
 extern int Dsp_Running_Check();
-extern int Dsp_Running_Start();
+extern void Dsp_Running_Start();
 
 void DspHandShake(void*) {
     OS_REPORT("DSP InitCallback \n");

--- a/src/JSystem/JAudio2/osdsp_task.cpp
+++ b/src/JSystem/JAudio2/osdsp_task.cpp
@@ -151,8 +151,8 @@ static void Dsp_Update_Request() {
     }
 }
 
-bool Dsp_Running_Check() {
-    return struct_80451308 == 1;
+int Dsp_Running_Check() {
+    return struct_80451308 == 1 ? TRUE : FALSE;
 }
 
 void Dsp_Running_Start() {

--- a/src/JSystem/JMath/JMATrigonometric.cpp
+++ b/src/JSystem/JMath/JMATrigonometric.cpp
@@ -1,7 +1,6 @@
 #include "JSystem/JSystem.h" // IWYU pragma: keep
 
-// don't include header until this "zero" mess is figured out
-// #include "JSystem/JMath/JMATrigonometric.h"
+#include "JSystem/JMath/JMATrigonometric.h"
 #include <math>
 #include "global.h"
 
@@ -9,77 +8,13 @@ static f32 dummy() {
     return 0.0f;
 }
 
-namespace std {
-template <typename A1, typename B1>
-struct pair {
-    A1 a1;
-    B1 b1;
-    pair() {
-        a1 = A1();
-        b1 = B1();
-    }
-};
-}  // namespace std
-
 namespace JMath {
 template<typename T>
 struct TAngleConstant_;
 
-template<>
-struct TAngleConstant_<f32> {
-    static f32 RADIAN_DEG180() { return M_PI;}
-    static f32 RADIAN_DEG360() { return M_PI * 2; }
-};
-
-template<int N, typename T>
-struct TSinCosTable {
-    std::pair<T, T> table[1 << N];
-    TSinCosTable() {
-        init();
-    }
-    void init() {
-        for (int i = 0; i < 1 << N; i++) {
-            table[i].a1 = sin((i * f64(TAngleConstant_<f32>::RADIAN_DEG360())) / (1 << N));
-            table[i].b1 = cos((i * f64(TAngleConstant_<f32>::RADIAN_DEG360())) / (1 << N));
-        }
-    }
-};
-
 inline f64 getConst2() {
     return 9.765625E-4;
 }
-
-template<int N, typename T>
-struct TAtanTable {
-    T table[N + 1];
-    u8 pad[0x1C];
-    TAtanTable() {
-        init();
-    }
-    void init() {
-        for (int i = 0; i < u32(N); i++) {
-            table[i] = atan(getConst2() * i);
-        }
-        table[0] = 0.0f;
-        table[N] = TAngleConstant_<f32>::RADIAN_DEG180() * 0.25f;  // 0.25 * PI
-    }
-};
-
-template<int N, typename T>
-struct TAsinAcosTable {
-    T table[N + 1];
-    u8 pad[0x1C];
-    TAsinAcosTable() {
-        init();
-    }
-    void init() {
-        for (int i = 0; i < N; i++) {
-            table[i] = asin(getConst2() * i);
-        }
-        table[0] = 0.0f;
-        table[N] = TAngleConstant_<f32>::RADIAN_DEG180() * 0.25f;  // 0.25 * PI
-    }
-};
 
 TSinCosTable<13, f32> sincosTable_ ATTRIBUTE_ALIGN(32);
 

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include/ansi_fp.h
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include/ansi_fp.h
@@ -20,4 +20,15 @@ typedef struct decform {
 	short digits;
 } decform;
 
+void __ull2dec(decimal*, unsigned long long);
+void __timesdec(decimal*, const decimal*, const decimal*);
+void __str2dec(decimal*, const char*, short);
+void __two_exp(decimal*, long);
+int __equals_dec(const decimal*, const decimal*);
+int __less_dec(const decimal*, const decimal*);
+void __minus_dec(decimal*, const decimal*, const decimal*);
+void __num2dec_internal(decimal*, double);
+void __num2dec(const decform*, double, decimal*);
+double __dec2num(const decimal*);
+
 #endif

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include/arith.h
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Include/arith.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct div_t {
     int quot;  /* quotient */
     int rem;   /* remainder */
 } div_t;

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/ansi_files.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/ansi_files.c
@@ -1,3 +1,4 @@
+#include "alloc.h"
 #include "ansi_files.h"
 #include "critical_regions.h"
 

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/char_io.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/char_io.c
@@ -1,5 +1,7 @@
+#include "buffer_io.h"
 #include "char_io.h"
 #include "critical_regions.h"
+#include "FILE_POS.h"
 #include "misc_io.h"
 #include "wchar_io.h"
 

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/direct_io.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/direct_io.c
@@ -1,6 +1,10 @@
-#include "direct_io.h"
+#include "buffer_io.h"
 #include "critical_regions.h"
+#include "direct_io.h"
+#include "FILE_POS.h"
+#include "misc_io.h"
 #include "wchar_io.h"
+#include <cstring>
 
 size_t fwrite(const void* buffer, size_t size, size_t count, FILE* stream) {
     size_t retval;

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/file_io.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/file_io.c
@@ -1,4 +1,7 @@
+#include "alloc.h"
+#include "buffer_io.h"
 #include "file_io.h"
+#include "FILE_POS.h"
 #include <ctype>
 
 int fclose(FILE* file) {

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/mem.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/mem.c
@@ -1,3 +1,4 @@
+#include "mem_funcs.h"
 #include <cstring>
 
 void* memmove(void* dst, const void* src, size_t n) {

--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/printf.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/printf.c
@@ -1,13 +1,15 @@
 #include "printf.h"
 #include "ansi_fp.h"
 #include "critical_regions.h"
-#include <ctype>
+#include "direct_io.h"
+#include "mbstring.h"
 #include "scanf.h"
+#include "wchar_io.h"
+#include <ctype>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <cstdint>
-#include "wchar_io.h"
 
 #define LDBL_MANT_DIG 53
 
@@ -19,8 +21,7 @@
 #define TARGET_FLOAT_MANT_BITS (TARGET_FLOAT_MANT_DIG - TARGET_FLOAT_IMPLICIT_J_BIT)
 #define TARGET_FLOAT_EXP_BITS (TARGET_FLOAT_BITS - TARGET_FLOAT_MANT_BITS - 1)
 
-#define PTRDIFF __typeof__((char*)0 - (char*)0)
-typedef PTRDIFF ptrdiff_t;
+extern void __msl_runtime_constraint_violation_s(const char* msg, void* ptr, int error);
 
 enum justification_options { left_justification, right_justification, zero_fill };
 


### PR DESCRIPTION
This PR fixes some issues that prevent building with `-ipa program`, mostly relating to inconsistent definitions across TUs.

Of note, `JASAudioReseter` is no longer marked as matching for `ShieldD` - I couldn't find a way to merge `JASDSPChannel::getStatus` into the main `.text` section without declaring it in `JASAudioReseter.cpp` (which obviously is fake and the duplicate definition causes issues with `-ipa program`).