### PR TITLE
Clean up HIO for TUs using HIOParam/Param_c/HIO_c pattern

### DIFF
--- a/include/d/actor/d_a_bullet.h
+++ b/include/d/actor/d_a_bullet.h
@@ -5,6 +5,39 @@
 #include "d/d_bg_s_acch.h"
 #include "d/d_cc_d.h"
 
+struct daBullet_HIOParam {
+    /* 0x00 */ f32 gravity;
+    /* 0x04 */ f32 weight;
+    /* 0x08 */ f32 height;
+    /* 0x0C */ f32 knee_height;
+    /* 0x10 */ f32 width;
+    /* 0x14 */ s16 lifetime;
+};
+
+class daBullet_Param_c {
+public:
+    virtual ~daBullet_Param_c() {}
+
+    static daBullet_HIOParam const m;
+};
+
+#if DEBUG
+class daBullet_HIO_c : public mDoHIO_entry_c {
+public:
+    daBullet_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daBullet_HIOParam m;
+};
+
+#define BULLET_HIO_CLASS daBullet_HIO_c
+#else
+#define BULLET_HIO_CLASS daBullet_Param_c
+#endif
+
 /**
  * @ingroup actors-unsorted
  * @class daBullet_c
@@ -24,7 +57,7 @@ public:
     /* 0x788 */ dBgS_AcchCir mAcchCir;
     /* 0x7C8 */ dCcD_Sph mCcSph;
     /* 0x900 */ cBgS_GndChk mGndChk;
-    /* 0x93C */ u8 field_0x93C[0x940 - 0x93C];
+    /* 0x93C */ BULLET_HIO_CLASS* mpHIO;
     /* 0x940 */ f32 mGroundY;
     /* 0x944 */ processFn mProcess;
     /* 0x950 */ int mLifetime;
@@ -52,22 +85,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daBullet_c) == 0x95c);
-
-struct daBullet_HIOParam {
-    /* 0x00 */ f32 gravity;
-    /* 0x04 */ f32 weight;
-    /* 0x08 */ f32 height;
-    /* 0x0C */ f32 knee_height;
-    /* 0x10 */ f32 width;
-    /* 0x14 */ s16 lifetime;
-};
-
-class daBullet_Param_c {
-public:
-    virtual ~daBullet_Param_c() {}
-
-    static daBullet_HIOParam const m;
-};
-
 
 #endif /* D_A_BULLET_H */

--- a/include/d/actor/d_a_npc_aru.h
+++ b/include/d/actor/d_a_npc_aru.h
@@ -3,15 +3,6 @@
 
 #include "d/actor/d_a_npc.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_Aru_c
- * @brief Fado
- *
- * @details
- *
-*/
-
 struct daNpc_Aru_HIOParam {
     /* 0x00 */ daNpcT_HIOParam common;
     /* 0x8C */ f32 warning_range;       // 警戒範囲 - Warning Range
@@ -22,11 +13,6 @@ struct daNpc_Aru_HIOParam {
     /* 0x9C */ f32 forward_visibility;  // 前方視界 - Forward Visibility        
 };
 
-class daNpc_Aru_HIO_c : public mDoHIO_entry_c {
-public:
-    /* 0x8 */ daNpc_Aru_HIOParam param;
-};
-
 class daNpc_Aru_Param_c {
 public:
     virtual ~daNpc_Aru_Param_c() {}
@@ -34,6 +20,30 @@ public:
     static daNpc_Aru_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_Aru_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Aru_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpc_Aru_HIOParam m;
+};
+#define NPC_ARU_HIO_CLASS daNpc_Aru_HIO_c
+#else
+#define NPC_ARU_HIO_CLASS daNpc_Aru_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_Aru_c
+ * @brief Fado
+ *
+ * @details
+ *
+*/
 class daNpc_Aru_c : public daNpcT_c {
 public:
     enum Joint {
@@ -168,7 +178,7 @@ public:
     static cutFunc mCutList[7];
 
 private:
-    /* 0xE40 */ daNpc_Aru_HIO_c* mHIO;
+    /* 0xE40 */ NPC_ARU_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ daNpcT_ActorMngr_c mActorMngrs[4];

--- a/include/d/actor/d_a_npc_besu.h
+++ b/include/d/actor/d_a_npc_besu.h
@@ -6,6 +6,35 @@
 #endif
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Besu_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;
+};
+
+class daNpc_Besu_Param_c {
+public:
+    virtual ~daNpc_Besu_Param_c() {}
+
+    static const daNpc_Besu_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Besu_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Besu_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Besu_HIOParam m;
+};
+
+#define NPC_BESU_HIO_CLASS daNpc_Besu_HIO_c
+#else
+#define NPC_BESU_HIO_CLASS daNpc_Besu_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Besu_c
@@ -116,7 +145,7 @@ public:
 
 private:
     /* 0x0E40 */ mDoExt_McaMorfSO* mpCupModelMorf;
-    /* 0x0E44 */ u8 field_0xe44[0x0E48 - 0xE44];
+    /* 0x0E44 */ NPC_BESU_HIO_CLASS* mpHIO;
     /* 0x0E48 */ J3DModel* mpClothModel[1];
     /* 0x0E4C */ dCcD_Cyl mCyl1;
     /* 0x0F88 */ dCcD_Cyl mCyl2;
@@ -139,17 +168,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Besu_c) == 0x1138);
-
-struct daNpc_Besu_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-    /* 0x8C */ f32 field_0x8c;
-};
-
-class daNpc_Besu_Param_c {
-public:
-    virtual ~daNpc_Besu_Param_c() {}
-
-    static const daNpc_Besu_HIOParam m;
-};
 
 #endif /* D_A_NPC_BESU_H */

--- a/include/d/actor/d_a_npc_blue_ns.h
+++ b/include/d/actor/d_a_npc_blue_ns.h
@@ -5,6 +5,33 @@
 #include "d/actor/d_a_tag_yami.h"
 #include "d/actor/d_a_obj_carry.h"
 
+struct daNpcBlueNS_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+    /* 0x6C */ f32 field_0x6c;
+};
+
+class daNpcBlueNS_Param_c {
+public:
+    virtual ~daNpcBlueNS_Param_c() {}
+
+    static const daNpcBlueNS_HIOParam m;
+};
+
+#if DEBUG
+class daNpcBlueNS_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcBlueNS_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    daNpcBlueNS_HIOParam m;
+};
+
+#define NPC_BLUE_NS_HIO_CLASS daNpcBlueNS_HIO_c
+#else
+#define NPC_BLUE_NS_HIO_CLASS daNpcBlueNS_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpcBlueNS_c
@@ -103,7 +130,7 @@ public:
     /* 0xBD8 */ u8 field_0xBD8[0xBDC - 0xBD8];
     /* 0xBDC */ daNpcF_Lookat_c mLookat;
     /* 0xC78 */ daNpcF_ActorMngr_c mActorMngr[1];
-    /* 0xC80 */ u8 field_0xC80[0xC84 - 0xC80];
+    /* 0xC80 */ NPC_BLUE_NS_HIO_CLASS* mpHIO;
     /* 0xC84 */ dCcD_Cyl mCyl;
     /* 0xDC0 */ u16 field_0xdc0;
     /* 0xDC4 */ int (daNpcBlueNS_c::*mAction)(int);
@@ -129,18 +156,6 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daNpcBlueNS_c) == 0xe14);
-
-struct daNpcBlueNS_HIOParam {
-    /* 0x00 */ daNpcF_HIOParam common;
-    /* 0x6C */ f32 field_0x6c;
-};
-
-class daNpcBlueNS_Param_c {
-public:
-    virtual ~daNpcBlueNS_Param_c() {}
-
-    static const daNpcBlueNS_HIOParam m;
-};
 
 
 #endif /* D_A_NPC_BLUE_NS_H */

--- a/include/d/actor/d_a_npc_bou.h
+++ b/include/d/actor/d_a_npc_bou.h
@@ -3,6 +3,38 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Bou_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c; // 16.0f
+    /* 0x90 */ f32 field_0x90; // 1000.0f
+    /* 0x94 */ f32 field_0x94; // 500.0f
+    /* 0x98 */ f32 field_0x98; // -500.0f
+};
+
+ class daNpc_Bou_Param_c {
+public:
+    virtual ~daNpc_Bou_Param_c() {}
+
+    static const daNpc_Bou_HIOParam m;
+ };
+
+#if DEBUG
+class daNpc_Bou_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Bou_HIO_c();
+    virtual ~daNpc_Bou_HIO_c() {}
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Bou_HIOParam m;
+};
+#define NPC_BOU_HIO_CLASS daNpc_Bou_HIO_c
+#else
+#define NPC_BOU_HIO_CLASS daNpc_Bou_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Bou_c
@@ -11,58 +43,6 @@
  * @details
  *
  */
- class daNpc_Bou_Param_c {
-    public:
-        virtual ~daNpc_Bou_Param_c() {}
-
-        struct Data {
-            /* 0x00 */ f32 field_0x00; // 255.0f
-            /* 0x04 */ f32 field_0x04; // 3.0f
-            /* 0x08 */ f32 field_0x08; // 1.0f
-            /* 0x0C */ f32 field_0x0c; // 600.0f
-            /* 0x10 */ f32 field_0x10; // 255.0f
-            /* 0x14 */ f32 field_0x14; // 200.0f
-            /* 0x18 */ f32 field_0x18; // 35.0f
-            /* 0x1C */ f32 field_0x1c; // 40.0f
-            /* 0x20 */ f32 field_0x20; // 0.0f
-            /* 0x24 */ f32 field_0x24; // 0.0f
-            /* 0x28 */ f32 field_0x28; // 10.0f
-            /* 0x2C */ f32 field_0x2c; // -10.0f
-            /* 0x30 */ f32 field_0x30; // 30.0f
-            /* 0x34 */ f32 field_0x34; // -10.0f
-            /* 0x38 */ f32 field_0x38; // 45.0f
-            /* 0x3C */ f32 field_0x3c; // -45.0f
-            /* 0x40 */ f32 field_0x40; // 0.6f
-            /* 0x44 */ f32 field_0x44; // 12.0f
-            /* 0x48 */ s16 field_0x48; // 3
-            /* 0x4a */ s16 field_0x4a; // 6
-            /* 0x4c */ s16 field_0x4c; // 5
-            /* 0x4e */ s16 field_0x4e; // 6
-            /* 0x50 */ f32 field_0x50; // 110.0f
-            /* 0x54 */ f32 field_0x54; // 500.0f
-            /* 0x58 */ f32 field_0x58; // 300.0f
-            /* 0x5c */ f32 field_0x5c; // -300.0f
-            /* 0x60 */ s16 field_0x60; // 60
-            /* 0x62 */ s16 field_0x62; // 8
-            /* 0x64 */ f32 field_0x64; // 0.0f
-            /* 0x68 */ f32 field_0x68; // 0.0f
-            /* 0x6c */ f32 field_0x6c; // 4.0f
-            /* 0x70 */ f32 field_0x70; // 0.0f
-            /* 0x74 */ f32 field_0x74; // 0.0f
-            /* 0x78 */ f32 field_0x78; // 0.0f
-            /* 0x7c */ f32 field_0x7c; // 0.0f
-            /* 0x80 */ f32 field_0x80; // 0.0f
-            /* 0x84 */ f32 field_0x84; // 0.0f
-            /* 0x88 */ f32 field_0x88; // 0.0f
-            /* 0x8c */ f32 field_0x8c; // 16.0f
-            /* 0x90 */ f32 field_0x90; // 1000.0f
-            /* 0x94 */ f32 field_0x94; // 500.0f
-            /* 0x98 */ f32 field_0x98; // -500.0f
-        };
-
-        static const Data m;
-};
-
 class daNpc_Bou_c : public daNpcT_c {
 public:
     typedef int (daNpc_Bou_c::*cutFunc)(int);
@@ -145,8 +125,9 @@ public:
 
     BOOL chkFindWolf() {
         int iVar1 = daNpcT_getDistTableIdx(field_0xfe0, field_0xfe4);
-        return daNpcT_c::chkFindWolf(mCurAngle.y, iVar1, field_0xfdc, daNpc_Bou_Param_c::m.field_0x54,
-            daNpc_Bou_Param_c::m.field_0x50, daNpc_Bou_Param_c::m.field_0x58, daNpc_Bou_Param_c::m.field_0x5c, 1);
+        return daNpcT_c::chkFindWolf(mCurAngle.y, iVar1, field_0xfdc,
+            mpHIO->m.common.search_distance, mpHIO->m.common.fov,
+            mpHIO->m.common.search_height, mpHIO->m.common.search_depth, 1);
     }
 
     int chkCondition(int i_val) {
@@ -187,7 +168,7 @@ public:
     }
 
 private:
-    /* 0xE40 */ int field_0xe40;
+    /* 0xE40 */ NPC_BOU_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl1;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ daNpcT_ActorMngr_c mActorMngr[3];

--- a/include/d/actor/d_a_npc_chat.h
+++ b/include/d/actor/d_a_npc_chat.h
@@ -3,23 +3,8 @@
 
 #include "d/actor/d_a_npc4.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpcChat_c
- * @brief NPC Chat
- *
- * @details
- *
-*/
-
 struct daNpcChat_HIOParam {
     /* 0x0 */ daNpcF_HIOParam common;
-};
-
-class daNpcChat_HIO_c : public mDoHIO_entry_c {
-    void genMessage(JORMContext*);
-
-    /* 0x8 */ daNpcChat_HIOParam param;
 };
 
 class daNpcChat_Param_c {
@@ -29,6 +14,29 @@ public:
     static daNpcChat_HIOParam const m;
 };
 
+#if DEBUG
+class daNpcChat_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcChat_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpcChat_HIOParam m;
+};
+
+#define NPC_CHAT_HIO_CLASS daNpcChat_HIO_c
+#else
+#define NPC_CHAT_HIO_CLASS daNpcChat_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpcChat_c
+ * @brief NPC Chat
+ *
+ * @details
+ *
+*/
 class daNpcChat_c : public daNpcF_c {
 public:
     typedef bool (daNpcChat_c::*actionFunc)(void*);
@@ -102,7 +110,7 @@ private:
     /* 0xBF0 */ J3DModel* mObjModel;
     /* 0xBF4 */ daNpcF_Lookat_c mLookat;
     /* 0xC90 */ daNpcF_ActorMngr_c mActorMngr[1];
-    /* 0xC98 */ daNpcChat_HIO_c* mHIO;
+    /* 0xC98 */ NPC_CHAT_HIO_CLASS* mpHIO;
     /* 0xC9C */ dCcD_Cyl mCyl;
     /* 0xDD8 */ actionFunc mAction;
     /* 0xDE4 */ request_of_phase_process_class mPhase1;

--- a/include/d/actor/d_a_npc_doorboy.h
+++ b/include/d/actor/d_a_npc_doorboy.h
@@ -4,6 +4,32 @@
 #include "d/actor/d_a_npc4.h"
 #include "d/d_msg_object.h"
 
+struct daNpcDoorBoy_HIOParam {
+    /* 0x0 */ daNpcF_HIOParam common;
+};
+
+class daNpcDoorBoy_Param_c {
+public:
+    virtual ~daNpcDoorBoy_Param_c() {}
+
+    static daNpcDoorBoy_HIOParam const m;
+};
+
+#if DEBUG
+class daNpcDoorBoy_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcDoorBoy_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    daNpcDoorBoy_HIOParam m;
+};
+
+#define NPC_DOORBOY_HIO_CLASS daNpcDoorBoy_HIO_c
+#else
+#define NPC_DOORBOY_HIO_CLASS daNpcDoorBoy_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpcDoorBoy_c
@@ -12,11 +38,6 @@
  * @details
  *
 */
-
-struct daNpcDoorBoy_HIOParam {
-    /* 0x0 */ daNpcF_HIOParam common;
-};
-
 class daNpcDoorBoy_c : public daNpcF_c {
 public:
     typedef bool (daNpcDoorBoy_c::*actionFunc)(void*);
@@ -64,7 +85,7 @@ private:
     /* 0xBEC */ u8 field_0xbec[0xbf0 - 0xbec];
     /* 0xBF0 */ daNpcF_Lookat_c mLookat;
     /* 0xC8C */ daNpcF_ActorMngr_c mActorMngr[1];
-    /* 0xC95 */ u8 field_0xc94[0xc98 - 0xc94];
+    /* 0xC95 */ NPC_DOORBOY_HIO_CLASS* mpHIO;
     /* 0xC98 */ dCcD_Cyl field_0xc98;
     /* 0xDD4 */ actionFunc mAction;
     /* 0xDE0 */ request_of_phase_process_class mPhases[2];
@@ -79,13 +100,6 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpcDoorBoy_c) == 0xe08);
-
-class daNpcDoorBoy_Param_c {
-public:
-    virtual ~daNpcDoorBoy_Param_c() {}
-
-    static daNpcDoorBoy_HIOParam const m;
-};
 
 
 #endif /* D_A_NPC_DOORBOY_H */

--- a/include/d/actor/d_a_npc_drainSol.h
+++ b/include/d/actor/d_a_npc_drainSol.h
@@ -3,6 +3,32 @@
 
 #include "d/actor/d_a_npc4.h"
 
+struct daNpcDrSol_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+};
+
+class daNpcDrSol_Param_c {
+public:
+    virtual ~daNpcDrSol_Param_c() {}
+
+    static const daNpcDrSol_HIOParam m;
+};
+
+#if DEBUG
+class daNpcDrSol_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcDrSol_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    daNpcDrSol_HIOParam m;
+};
+
+#define NPC_DRSOL_HIO_CLASS daNpcDrSol_HIO_c
+#else
+#define NPC_DRSOL_HIO_CLASS daNpcDrSol_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpcDrSol_c
@@ -44,7 +70,7 @@ public:
 
     /* 0xB48 */ Z2Creature mSound;
     /* 0xBD8 */ J3DModel* field_0xbd8;
-    /* 0xBDC */ u8 field_0xBDC[0xBE0 - 0xBDC];
+    /* 0xBDC */ NPC_DRSOL_HIO_CLASS* mpHIO;
     /* 0xBE0 */ dCcD_Cyl mCyl;
     /* 0xD1C */ bool (daNpcDrSol_c::*mAction)(void*);
     /* 0xD28 */ request_of_phase_process_class mPhase;
@@ -56,17 +82,6 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daNpcDrSol_c) == 0xd3c);
-
-struct daNpcDrSol_HIOParam {
-    /* 0x00 */ daNpcF_HIOParam common;
-};
-
-class daNpcDrSol_Param_c {
-public:
-    virtual ~daNpcDrSol_Param_c() {}
-
-    static const daNpcDrSol_HIOParam m;
-};
 
 
 #endif /* D_A_NPC_DRAINSOL_H */

--- a/include/d/actor/d_a_npc_fairy_seirei.h
+++ b/include/d/actor/d_a_npc_fairy_seirei.h
@@ -3,6 +3,34 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_FairySeirei_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;
+    /* 0x90 */ f32 field_0x90;
+};
+
+class daNpc_FairySeirei_Param_c {
+public:
+    virtual ~daNpc_FairySeirei_Param_c() {}
+
+    static daNpc_FairySeirei_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_FairySeirei_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_FairySeirei_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    daNpc_FairySeirei_HIOParam m;
+};
+
+#define NPC_FAIRY_SEIREI_HIO_CLASS daNpc_FairySeirei_HIO_c
+#else
+#define NPC_FAIRY_SEIREI_HIO_CLASS daNpc_FairySeirei_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_FairySeirei_c
@@ -66,7 +94,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ u8 field_0xE40[4];
+    /* 0xE40 */ NPC_FAIRY_SEIREI_HIO_CLASS* mpHIO;
     /* 0xE44 */ u8 mType;
     /* 0xE48 */ dCcD_Cyl mCyl;
     /* 0xF84 */ actionFunc mInitFunc;
@@ -78,12 +106,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_FairySeirei_c) == 0xfb0);
-
-class daNpc_FairySeirei_Param_c {
-public:
-    virtual ~daNpc_FairySeirei_Param_c() {}
-
-    static f32 const m[37];
-};
 
 #endif /* D_A_NPC_FAIRY_SEIREI_H */

--- a/include/d/actor/d_a_npc_gra.h
+++ b/include/d/actor/d_a_npc_gra.h
@@ -7,7 +7,7 @@
 
 class daNpc_grA_HIOParam {
 public:
-    /* 0x00 */ daNpcF_HIOParam mNpcFParams;
+    /* 0x00 */ daNpcF_HIOParam common;
     /* 0x6C */ s16 mBowTimer;
     /* 0x70 */ f32 mRotationalSpeed;
     /* 0x74 */ f32 mWalkingSpeed;
@@ -19,7 +19,7 @@ public:
 
 class daNpc_grA_Param_c {
 public:
-    virtual ~daNpc_grA_Param_c(){};
+    virtual ~daNpc_grA_Param_c() {}
 
     static daNpc_grA_HIOParam const m;
 };
@@ -28,19 +28,14 @@ public:
 class daNpc_grA_HIO_c : public mDoHIO_entry_c {
 public:
     daNpc_grA_HIO_c();
-#if DEBUG
     void listenPropertyEvent(const JORPropertyEvent*);
     void genMessage(JORMContext*);
-#endif
-    daNpc_grA_HIOParam mHioParams;
+    daNpc_grA_HIOParam m;
 };
 
 #define NPC_GRA_HIO_CLASS daNpc_grA_HIO_c
-
 #else
-
 #define NPC_GRA_HIO_CLASS daNpc_grA_Param_c
-
 #endif
 
 /**
@@ -155,7 +150,7 @@ private:
     /* 0x0BDC */ int field_0xBDC;
     /* 0x0BE0 */ daNpcF_Lookat_c mNpcfLookAt;
     /* 0x0C7C */ daNpcF_ActorMngr_c mNpcfActorManager[3];
-    /* 0x0C94 */ NPC_GRA_HIO_CLASS* mpHio;
+    /* 0x0C94 */ NPC_GRA_HIO_CLASS* mpHIO;
     /* 0x0C98 */ dCcD_Cyl field_0xC98;
     /* 0x0DD4 */ daNpcF_Path_c field_0xDD4;
     /* 0x1404 */ daNpc_grA_c_Action mAction2;

--- a/include/d/actor/d_a_npc_grc.h
+++ b/include/d/actor/d_a_npc_grc.h
@@ -4,6 +4,34 @@
 #include "d/actor/d_a_npc4.h"
 #include "d/d_particle_copoly.h"
 
+struct daNpc_grC_HIOParam {
+    /* 0x0 */ daNpcF_HIOParam common;
+};
+
+class daNpc_grC_Param_c {
+public:
+    virtual ~daNpc_grC_Param_c() {}
+
+    static daNpc_grC_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_grC_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_grC_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpc_grC_HIOParam m;
+};
+
+#define NPC_GRC_HIO_CLASS daNpc_grC_HIO_c
+#else
+#define NPC_GRC_HIO_CLASS daNpc_grC_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_grC_c
@@ -12,8 +40,6 @@
  * @details
  *
 */
-
-
 class daNpc_grC_c : public daNpcF_c {
 public:
     typedef BOOL (daNpc_grC_c::*ActionFn)(void*);
@@ -72,7 +98,7 @@ private:
     /* 0xBDC */ daNpcF_Lookat_c mLookat;
     /* 0xC78 */ dPaPo_c mPaPo;
     /* 0xCB0 */ daNpcF_ActorMngr_c mActorMngr[2];
-    /* 0xCC0 */ u8 field_0xcc0[0xcc4 - 0xcc0];
+    /* 0xCC0 */ NPC_GRC_HIO_CLASS* mpHIO;
     /* 0xCC4 */ dCcD_Cyl mCyl;
     /* 0xE00 */ ActionFn mNextAction;
     /* 0xE0C */ ActionFn mAction;
@@ -91,21 +117,6 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_grC_c) == 0xe54);
-
-struct daNpc_grC_HIOParam {
-    /* 0x0 */ daNpcF_HIOParam common;
-};
-
-class daNpc_grC_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_grC_HIOParam field_0x8;
-};
-
-class daNpc_grC_Param_c {
-public:
-    virtual ~daNpc_grC_Param_c() {}
-
-    static daNpc_grC_HIOParam const m;
-};
 
 
 #endif /* D_A_NPC_GRC_H */

--- a/include/d/actor/d_a_npc_grm.h
+++ b/include/d/actor/d_a_npc_grm.h
@@ -4,6 +4,33 @@
 #include "d/actor/d_a_npc.h"
 #include "d/d_shop_system.h"
 
+struct daNpc_grM_HIOParam {
+    /* 0x0 */ daNpcT_HIOParam common;
+};
+
+class daNpc_grM_Param_c {
+public:
+    virtual ~daNpc_grM_Param_c() {}
+
+    static daNpc_grM_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_grM_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_grM_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpc_grM_HIOParam m;
+};
+#define NPC_GRM_HIO_CLASS daNpc_grM_HIO_c
+#else
+#define NPC_GRM_HIO_CLASS daNpc_grM_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_grM_c
@@ -108,7 +135,7 @@ public:
     static cutFunc mCutList[2];
 
 private:
-    /* 0x0F7C */ u8 field_0xf7c[0xf80 - 0xf7c];
+    /* 0x0F7C */ NPC_GRM_HIO_CLASS* mpHIO;
     /* 0x0F80 */ dCcD_Cyl mCyl;
     /* 0x10BC */ u8 mType;
     /* 0x10C0 */ actionFunc mNextAction;
@@ -121,21 +148,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_grM_c) == 0x10e4);
-
-struct daNpc_grM_HIOParam {
-    /* 0x0 */ daNpcT_HIOParam common;
-};
-
-class daNpc_grM_HIO_c : public mDoHIO_entry_c {
-public:
-    /* 0x8 */ daNpc_grM_HIOParam param;
-};
-
-class daNpc_grM_Param_c {
-public:
-    virtual ~daNpc_grM_Param_c() {}
-
-    static daNpc_grM_HIOParam const m;
-};
 
 #endif /* D_A_NPC_GRM_H */

--- a/include/d/actor/d_a_npc_grmc.h
+++ b/include/d/actor/d_a_npc_grmc.h
@@ -26,6 +26,12 @@ struct daNpc_grMC_HIOParam {
 class daNpc_grMC_HIO_c : public mDoHIO_entry_c {
 public:
     /* 0x8 */ daNpc_grMC_HIOParam m;
+
+    daNpc_grMC_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
 };
 
 class daNpc_grMC_Param_c {
@@ -122,7 +128,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0x0F7C */ NPC_GRMC_HIO_CLASS* mHIO;
+    /* 0x0F7C */ NPC_GRMC_HIO_CLASS* mpHIO;
     /* 0x0F80 */ dCcD_Cyl mCyl;
     /* 0x10BC */ u8 mType;
     /* 0x10C0 */ actionFunc mNextAction;

--- a/include/d/actor/d_a_npc_grr.h
+++ b/include/d/actor/d_a_npc_grr.h
@@ -3,25 +3,8 @@
 
 #include "d/actor/d_a_npc4.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_grR_c
- * @brief Gor Liggs
- *
- * @details
- *
-*/
-
 struct daNpc_grR_HIOParam {
     /* 0x0 */ daNpcF_HIOParam common;
-};
-
-class daNpc_grR_HIO_c
-#if DEBUG
-: public mDoHIO_entry_c
-#endif
-{
-    /* 0x8 */ daNpc_grR_HIOParam param;
 };
 
 class daNpc_grR_Param_c {
@@ -31,6 +14,31 @@ public:
     static daNpc_grR_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_grR_HIO_c : public mDoHIO_entry_c {
+public:
+    /* 0x8 */ daNpc_grR_HIOParam m;
+
+    daNpc_grR_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent* event);
+
+    void genMessage(JORMContext* ctx);
+};
+
+#define NPC_GRR_HIO_CLASS daNpc_grR_HIO_c
+#else
+#define NPC_GRR_HIO_CLASS daNpc_grR_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_grR_c
+ * @brief Gor Liggs
+ *
+ * @details
+ *
+*/
 class daNpc_grR_c : public daNpcF_c {
 public:
     typedef int (daNpc_grR_c::*cutFunc)(int);
@@ -83,7 +91,7 @@ private:
     /* 0xBD8 */ daNpcF_MatAnm_c* mpMatAnm;
     /* 0xBDC */ daNpcF_Lookat_c mLookat;
     /* 0xC78 */ daNpcF_ActorMngr_c mActorMngr[2];
-    /* 0xC88 */ daNpc_grR_HIO_c* mHIO;
+    /* 0xC88 */ NPC_GRR_HIO_CLASS* mpHIO;
     /* 0xC8C */ dCcD_Cyl mCyl;
     /* 0xDC8 */ actionFunc mNextAction;
     /* 0xDD4 */ actionFunc mAction;

--- a/include/d/actor/d_a_npc_grz.h
+++ b/include/d/actor/d_a_npc_grz.h
@@ -24,9 +24,29 @@ struct daNpc_Grz_HIOParam {
     /* 0x7C */ f32 demo_start_distance;     // デモ開始距離 - Demo Start Distance    
 };
 
-class daNpc_Grz_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_Grz_HIOParam param;
+class daNpc_Grz_Param_c {
+public:
+    virtual ~daNpc_Grz_Param_c() {}
+
+    static daNpc_Grz_HIOParam const m;
 };
+
+#if DEBUG
+class daNpc_Grz_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Grz_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent* event);
+
+    void genMessage(JORMContext* ctx);
+
+    /* 0x8 */ daNpc_Grz_HIOParam m;
+};
+
+#define NPC_GRZ_HIO_CLASS daNpc_Grz_HIO_c
+#else
+#define NPC_GRZ_HIO_CLASS daNpc_Grz_Param_c
+#endif
 
 class daNpc_Grz_c : public daNpcF_c {
 public:
@@ -105,7 +125,7 @@ private:
     /* 0x0BDC */ daNpcF_Lookat_c mLookat;
     /* 0x0C78 */ daNpcF_Path_c mPath;
     /* 0x12A8 */ daNpcF_ActorMngr_c mActorMngrs[4];
-    /* 0x12C8 */ daNpc_Grz_HIO_c* mHIO;
+    /* 0x12C8 */ NPC_GRZ_HIO_CLASS* mpHIO;
     /* 0x12CC */ dCcD_Cyl mCyl1;
     /* 0x1408 */ dCcD_Cyl mCyl2;
     /* 0x1544 */ dCcD_Sph mSphs[4];
@@ -132,12 +152,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Grz_c) == 0x1b08);
-
-class daNpc_Grz_Param_c {
-public:
-    virtual ~daNpc_Grz_Param_c() {}
-
-    static daNpc_Grz_HIOParam const m;
-};
 
 #endif /* D_A_NPC_GRZ_H */

--- a/include/d/actor/d_a_npc_gwolf.h
+++ b/include/d/actor/d_a_npc_gwolf.h
@@ -3,15 +3,6 @@
 
 #include "d/actor/d_a_npc4.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_GWolf_c
- * @brief Golden Wolf
- *
- * @details
- *
-*/
-
 struct daNpc_GWolf_HIOParam {
     /* 0x00 */ daNpcF_HIOParam common;
     /* 0x6C */ f32 attack_spd_horizontal;       // 攻撃速度横 - Attack Speed Horizontal
@@ -24,10 +15,6 @@ struct daNpc_GWolf_HIOParam {
     /* 0x88 */ f32 warp_start_dist;             // ワープ開始距離 - Warp Start Distance
 };
 
-class daNpc_GWolf_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_GWolf_HIOParam param;
-};
-
 class daNpc_GWolf_Param_c {
 public:
     virtual ~daNpc_GWolf_Param_c() {}
@@ -35,6 +22,31 @@ public:
     static daNpc_GWolf_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_GWolf_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_GWolf_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpc_GWolf_HIOParam m;
+};
+
+#define NPC_GWOLF_HIO_CLASS daNpc_GWolf_HIO_c
+#else
+#define NPC_GWOLF_HIO_CLASS daNpc_GWolf_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_GWolf_c
+ * @brief Golden Wolf
+ *
+ * @details
+ *
+*/
 class daNpc_GWolf_c : public daNpcF_c {
 public:
     typedef BOOL (daNpc_GWolf_c::*actionFunc)(void*);
@@ -100,7 +112,7 @@ private:
     /* 0xBD8 */ daNpcF_MatAnm_c* mpMatAnm;
     /* 0xBDC */ daNpcF_Lookat_c mLookat;
     /* 0xC78 */ daNpcF_ActorMngr_c mActorMngrs[2];
-    /* 0xC88 */ daNpc_GWolf_HIO_c* mHIO;
+    /* 0xC88 */ NPC_GWOLF_HIO_CLASS* mpHIO;
     /* 0xC8C */ dCcD_Cyl mCyl;
     /* 0xDC8 */ actionFunc mNextAction;
     /* 0xDD4 */ actionFunc mAction;

--- a/include/d/actor/d_a_npc_hanjo.h
+++ b/include/d/actor/d_a_npc_hanjo.h
@@ -3,6 +3,46 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Hanjo_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;
+    /* 0x90 */ f32 field_0x90;
+    /* 0x94 */ f32 field_0x94;
+    /* 0x98 */ f32 field_0x98;
+    /* 0x9C */ f32 field_0x9c;
+    /* 0xA0 */ f32 field_0xa0;
+    /* 0xA4 */ f32 field_0xa4;
+    /* 0xA8 */ f32 field_0xa8;
+    /* 0xAC */ s16 field_0xac;
+    /* 0xAE */ s16 field_0xae;
+    /* 0xB0 */ s16 field_0xb0;
+    /* 0xB2 */ s16 field_0xb2;
+};
+
+class daNpc_Hanjo_Param_c {
+public:
+    virtual ~daNpc_Hanjo_Param_c() {}
+
+    static const daNpc_Hanjo_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Hanjo_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Hanjo_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent* event);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Hanjo_HIOParam m;
+};
+
+#define NPC_HANJO_HIO_CLASS daNpc_Hanjo_HIO_c
+#else
+#define NPC_HANJO_HIO_CLASS daNpc_Hanjo_Param_c
+#endif
+
 class daNpc_HanjoStone_c {
 public:
     ~daNpc_HanjoStone_c() {}
@@ -182,7 +222,7 @@ public:
     static cutFunc mCutList[6];
     static dCcD_SrcSph mStoneCcDSph;
 private:
-    /* 0x0E40 */ int field_0x0E40;
+    /* 0x0E40 */ NPC_HANJO_HIO_CLASS* mpHIO;
     /* 0x0E44 */ J3DModel* mModel1;
     /* 0x0E48 */ J3DModel* mModel2;
     /* 0x0E4C */ dCcD_Cyl mCyl1;
@@ -212,65 +252,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Hanjo_c) == 0x172c);
-
-class daNpc_Hanjo_Param_c {
-public:
-    virtual ~daNpc_Hanjo_Param_c() {}
-
-    struct Data {
-        /* 0x00 */ f32 field_0x00;
-        /* 0x04 */ f32 field_0x04;
-        /* 0x08 */ f32 field_0x08;
-        /* 0x0C */ f32 field_0x0c;
-        /* 0x10 */ f32 field_0x10;
-        /* 0x14 */ f32 field_0x14;
-        /* 0x18 */ f32 field_0x18;
-        /* 0x1C */ f32 field_0x1c;
-        /* 0x20 */ f32 field_0x20;
-        /* 0x24 */ f32 field_0x24;
-        /* 0x28 */ f32 field_0x28;
-        /* 0x2C */ f32 field_0x2c;
-        /* 0x30 */ f32 field_0x30;
-        /* 0x34 */ f32 field_0x34;
-        /* 0x38 */ f32 field_0x38;
-        /* 0x3C */ f32 field_0x3c;
-        /* 0x40 */ f32 field_0x40;
-        /* 0x44 */ f32 field_0x44;
-        /* 0x48 */ s16 field_0x48;
-        /* 0x4A */ s16 field_0x4a;
-        /* 0x4C */ s16 field_0x4c;
-        /* 0x4E */ s16 field_0x4e;
-        /* 0x50 */ f32 field_0x50;
-        /* 0x54 */ f32 field_0x54;
-        /* 0x58 */ f32 field_0x58;
-        /* 0x5C */ f32 field_0x5c;
-        /* 0x60 */ s16 field_0x60;
-        /* 0x62 */ s16 field_0x62;
-        /* 0x64 */ int field_0x64;
-        /* 0x68 */ int field_0x68;
-        /* 0x6C */ f32 field_0x6c;
-        /* 0x70 */ f32 field_0x70;
-        /* 0x74 */ f32 field_0x74;
-        /* 0x78 */ f32 field_0x78;
-        /* 0x7C */ f32 field_0x7c;
-        /* 0x80 */ f32 field_0x80;
-        /* 0x84 */ f32 field_0x84;
-        /* 0x88 */ f32 field_0x88;
-        /* 0x8C */ f32 field_0x8c;
-        /* 0x90 */ f32 field_0x90;
-        /* 0x94 */ f32 field_0x94;
-        /* 0x98 */ f32 field_0x98;
-        /* 0x9C */ f32 field_0x9c;
-        /* 0xA0 */ f32 field_0xa0;
-        /* 0xA4 */ f32 field_0xa4;
-        /* 0xA8 */ f32 field_0xa8;
-        /* 0xAC */ s16 field_0xac;
-        /* 0xAE */ s16 field_0xae;
-        /* 0xB0 */ s16 field_0xb0;
-        /* 0xB2 */ s16 field_0xb2;
-    };
-
-    static const Data m;
-};
 
 #endif /* D_A_NPC_HANJO_H */

--- a/include/d/actor/d_a_npc_hoz.h
+++ b/include/d/actor/d_a_npc_hoz.h
@@ -4,6 +4,35 @@
 #include "d/actor/d_a_npc.h"
 #include "d/actor/d_a_startAndGoal.h"
 
+struct daNpc_Hoz_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;
+};
+
+class daNpc_Hoz_Param_c {
+public:
+    virtual ~daNpc_Hoz_Param_c() {}
+
+    static const daNpc_Hoz_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Hoz_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Hoz_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Hoz_HIOParam m;
+};
+
+#define NPC_HOZ_HIO_CLASS daNpc_Hoz_HIO_c
+#else
+#define NPC_HOZ_HIO_CLASS daNpc_Hoz_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Hoz_c
@@ -100,7 +129,7 @@ public:
     static cutFunc mCutList[];
 
 private:
-    /* 0xE40 */ int field_0xE40;
+    /* 0xE40 */ NPC_HOZ_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ daStartAndGoal_c* field_0xf84;
@@ -121,17 +150,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Hoz_c) == 0xFC8);
-
-struct daNpc_Hoz_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-    /* 0x8C */ f32 field_0x8c;
-};
-
-class daNpc_Hoz_Param_c {
-public:
-    virtual ~daNpc_Hoz_Param_c() {}
-
-    static const daNpc_Hoz_HIOParam m;
-};
 
 #endif /* D_A_NPC_HOZ_H */

--- a/include/d/actor/d_a_npc_ins.h
+++ b/include/d/actor/d_a_npc_ins.h
@@ -3,22 +3,9 @@
 
 #include "d/actor/d_a_npc4.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpcIns_c
- * @brief Agitha
- *
- * @details
- *
-*/
-
 struct daNpcIns_HIOParam {
     /* 0x00 */ daNpcF_HIOParam common;
     /* 0x70 */ f32 walk_speed;          // 歩行速度 - Walking Speed
-};
-
-class daNpcIns_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpcIns_HIOParam param;
 };
 
 class daNpcIns_Param_c {
@@ -28,6 +15,21 @@ public:
     static daNpcIns_HIOParam const m;
 };
 
+#if DEBUG
+class daNpcIns_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcIns_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpcIns_HIOParam m;
+};
+
+#define NPC_INS_HIO_CLASS daNpcIns_HIO_c
+#else
+#define NPC_INS_HIO_CLASS daNpcIns_Param_c
+#endif
+
 struct insect_param_data {
     int evt_bit_no;
     s16 msg_no;
@@ -35,6 +37,14 @@ struct insect_param_data {
     u8 field_0x7;
 };
 
+/**
+ * @ingroup actors-npcs
+ * @class daNpcIns_c
+ * @brief Agitha
+ *
+ * @details
+ *
+*/
 class daNpcIns_c : public daNpcF_c {
 public:
     typedef int (daNpcIns_c::*actionFunc)(void*);
@@ -118,7 +128,7 @@ private:
     /* 0xBE0 */ daNpcF_MatAnm_c* mpMatAnm;
     /* 0xBE4 */ daNpcF_Lookat_c mLookat;
     /* 0xC80 */ daNpcF_ActorMngr_c mActorMngr[1];
-    /* 0xC88 */ daNpcIns_HIO_c* mHIO;
+    /* 0xC88 */ NPC_INS_HIO_CLASS* mpHIO;
     /* 0xC8C */ dCcD_Cyl mCyl;
     /* 0xDC8 */ actionFunc mAction;
     /* 0xDD4 */ actionFunc mPrevAction;

--- a/include/d/actor/d_a_npc_kakashi.h
+++ b/include/d/actor/d_a_npc_kakashi.h
@@ -3,6 +3,37 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Kakashi_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;
+    /* 0x90 */ f32 field_0x90;
+    /* 0x94 */ f32 field_0x94;
+};
+
+class daNpc_Kakashi_Param_c {
+public:
+    virtual ~daNpc_Kakashi_Param_c() {}
+
+    static const daNpc_Kakashi_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Kakashi_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Kakashi_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Kakashi_HIOParam m;
+};
+
+#define NPC_KAKASHI_HIO_CLASS daNpc_Kakashi_HIO_c
+#else
+#define NPC_KAKASHI_HIO_CLASS daNpc_Kakashi_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Kakashi_c
@@ -86,7 +117,7 @@ public:
     static int (daNpc_Kakashi_c::*mCutList[])(int);
 
 private:
-    /* 0x0E40 */ u8 field_0xE40[0xE44 - 0xE40];
+    /* 0x0E40 */ NPC_KAKASHI_HIO_CLASS* mpHIO;
     /* 0x0E44 */ Z2SoundObjSimple mSound;
     /* 0x0E64 */ dCcD_Cyl mCcCyl;
     /* 0x0FA0 */ dCcD_Sph mCcSph[3];
@@ -108,20 +139,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Kakashi_c) == 0x1398);
-
-struct daNpc_Kakashi_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-    /* 0x8C */ f32 field_0x8c;
-    /* 0x90 */ f32 field_0x90;
-    /* 0x94 */ f32 field_0x94;
-};
-
-class daNpc_Kakashi_Param_c {
-public:
-    virtual ~daNpc_Kakashi_Param_c() {}
-
-    static const daNpc_Kakashi_HIOParam m;
-};
-
 
 #endif /* D_A_NPC_KAKASHI_H */

--- a/include/d/actor/d_a_npc_kasi_hana.h
+++ b/include/d/actor/d_a_npc_kasi_hana.h
@@ -211,7 +211,7 @@ private:
     /* 0x0BF0 */ daNpcF_Lookat_c mLookat;
     /* 0x0C8C */ daNpcF_ActorMngr_c mActorMngr[1];
     /* 0x0C94 */ daNpcF_Path_c mPath;
-    /* 0x12C4 */ NPC_KASI_HANA_HIO_CLASS* mHIO;
+    /* 0x12C4 */ NPC_KASI_HANA_HIO_CLASS* mpHIO;
     /* 0x12C8 */ dCcD_Cyl mCyl;
     /* 0x1404 */ s8 mType;
     /* 0x1405 */ u8 field_0x1405;

--- a/include/d/actor/d_a_npc_kasi_kyu.h
+++ b/include/d/actor/d_a_npc_kasi_kyu.h
@@ -4,6 +4,34 @@
 #include "d/actor/d_a_npc4.h"
 #include "d/actor/d_a_tag_escape.h"
 
+struct daNpcKasiKyu_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+    /* 0x6C */ s16 escape_time;         // 逃げるまでの時間 - Escape Time
+    /* 0x70 */ f32 escape_spd;          // 逃げる速度 - Escape Speed
+};
+
+class daNpcKasiKyu_Param_c {
+public:
+    virtual ~daNpcKasiKyu_Param_c() {}
+
+    static daNpcKasiKyu_HIOParam const m;
+};
+
+#if DEBUG
+class daNpcKasiKyu_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcKasiKyu_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpcKasiKyu_HIOParam m;
+};
+
+#define NPC_KASI_KYU_HIO_CLASS daNpcKasiKyu_HIO_c
+#else
+#define NPC_KASI_KYU_HIO_CLASS daNpcKasiKyu_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpcKasiKyu_c
@@ -12,21 +40,6 @@
  * @details
  *
 */
-
-struct daNpcKasiKyu_HIOParam {
-    /* 0x00 */ daNpcF_HIOParam common;
-    /* 0x6C */ s16 escape_time;         // 逃げるまでの時間 - Escape Time
-    /* 0x70 */ f32 escape_spd;          // 逃げる速度 - Escape Speed
-};
-
-class daNpcKasiKyu_HIO_c
-#if DEBUG
-: public mDoHIO_entry_c
-#endif
-{
-    /* 0x8 */ daNpcKasiKyu_HIOParam param;
-};
-
 class daNpcKasiKyu_c : public daNpcF_c {
 public:
     typedef int (daNpcKasiKyu_c::*actionFunc)(int);
@@ -117,7 +130,7 @@ private:
     /* 0x0BF0 */ daNpcF_Lookat_c mLookat;
     /* 0x0C8C */ daNpcF_ActorMngr_c mActorMngr[1];
     /* 0x0C94 */ daNpcF_Path_c mPath;
-    /* 0x12C4 */ daNpcKasiKyu_HIO_c* mHIO;
+    /* 0x12C4 */ NPC_KASI_KYU_HIO_CLASS* mpHIO;
     /* 0x12C8 */ dCcD_Cyl mCyl;
     /* 0x1404 */ s16 mMode;
     /* 0x1408 */ actionFunc mAction;
@@ -142,12 +155,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpcKasiKyu_c) == 0x146c);
-
-class daNpcKasiKyu_Param_c {
-public:
-    virtual ~daNpcKasiKyu_Param_c() {}
-
-    static daNpcKasiKyu_HIOParam const m;
-};
 
 #endif /* D_A_NPC_KASI_KYU_H */

--- a/include/d/actor/d_a_npc_kasi_mich.h
+++ b/include/d/actor/d_a_npc_kasi_mich.h
@@ -19,13 +19,27 @@ struct daNpcKasiMich_HIOParam {
     /* 0x70 */ f32 escape_spd;          // 逃げる速度 - Escape Speed
 };
 
-class daNpcKasiMich_HIO_c
-#if DEBUG
-: public mDoHIO_entry_c
-#endif
-{
-    /* 0x8 */ daNpcKasiMich_HIOParam param;
+class daNpcKasiMich_Param_c {
+public:
+    virtual ~daNpcKasiMich_Param_c() {}
+
+    static daNpcKasiMich_HIOParam const m;
 };
+
+#if DEBUG
+class daNpcKasiMich_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcKasiMich_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    /* 0x8 */ daNpcKasiMich_HIOParam m;
+};
+
+#define NPC_KASI_MICH_HIO_CLASS daNpcKasiMich_HIO_c
+#else
+#define NPC_KASI_MICH_HIO_CLASS daNpcKasiMich_Param_c
+#endif
 
 class daNpcKasiMich_c : public daNpcF_c {
 public:
@@ -117,7 +131,7 @@ private:
     /* 0x0BF0 */ daNpcF_Lookat_c mLookat;
     /* 0x0C8C */ daNpcF_ActorMngr_c mActorMngr[1];
     /* 0x0C94 */ daNpcF_Path_c mPath;
-    /* 0x12C4 */ daNpcKasiMich_HIO_c* mHIO;
+    /* 0x12C4 */ NPC_KASI_MICH_HIO_CLASS* mpHIO;
     /* 0x12C8 */ dCcD_Cyl mCyl;
     /* 0x1404 */ s16 mMode;
     /* 0x1408 */ actionFunc mAction;
@@ -142,12 +156,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpcKasiMich_c) == 0x146c);
-
-class daNpcKasiMich_Param_c {
-public:
-    virtual ~daNpcKasiMich_Param_c() {}
-
-    static daNpcKasiMich_HIOParam const m;
-};
 
 #endif /* D_A_NPC_KASI_MICH_H */

--- a/include/d/actor/d_a_npc_kkri.h
+++ b/include/d/actor/d_a_npc_kkri.h
@@ -3,6 +3,34 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Kkri_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+class daNpc_Kkri_Param_c {
+public:
+    virtual ~daNpc_Kkri_Param_c() {}
+
+    static const daNpc_Kkri_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Kkri_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Kkri_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Kkri_HIOParam m;
+};
+
+#define NPC_KKRI_HIO_CLASS daNpc_Kkri_HIO_c
+#else
+#define NPC_KKRI_HIO_CLASS daNpc_Kkri_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Kkri_c
@@ -94,7 +122,7 @@ public:
     static int (daNpc_Kkri_c::*mCutList[])(int);
 
 private:
-    /* 0xE40 */ u8 field_0xE40[0xE44 - 0xE40];
+    /* 0xE40 */ NPC_KKRI_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCcCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ daNpcT_ActorMngr_c mActorMng[1];
@@ -111,17 +139,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Kkri_c) == 0xfdc);
-
-struct daNpc_Kkri_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-};
-
-class daNpc_Kkri_Param_c {
-public:
-    virtual ~daNpc_Kkri_Param_c() {}
-
-    static const daNpc_Kkri_HIOParam m;
-};
-
 
 #endif /* D_A_NPC_KKRI_H */

--- a/include/d/actor/d_a_npc_kolin.h
+++ b/include/d/actor/d_a_npc_kolin.h
@@ -3,15 +3,6 @@
 
 #include "d/actor/d_a_npc.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_Kolin_c
- * @brief Colin
- *
- * @details
- *
-*/
-
 struct daNpc_Kolin_HIOParam {
     /* 0x00 */ daNpcT_HIOParam common;
     /* 0x8C */ f32 start_distance;      // 走りはじめ距離   - Start Distance
@@ -29,6 +20,31 @@ public:
     static daNpc_Kolin_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_Kolin_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Kolin_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Kolin_HIOParam m;
+};
+
+#define NPC_KOLIN_HIO_CLASS daNpc_Kolin_HIO_c
+#else
+#define NPC_KOLIN_HIO_CLASS daNpc_Kolin_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_Kolin_c
+ * @brief Colin
+ *
+ * @details
+ *
+*/
 class daNpc_Kolin_c : public daNpcT_c {
 public:
     typedef int (daNpc_Kolin_c::*cutFunc)(int);
@@ -146,7 +162,7 @@ public:
     }
 
 private:
-    /* 0x0E40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0x0E40 */ NPC_KOLIN_HIO_CLASS* mpHIO;
     /* 0x0E44 */ J3DModel* mpClothModel;
     /* 0x0E48 */ dCcD_Cyl field_0xe48;
     /* 0x0F84 */ u8 mType;

--- a/include/d/actor/d_a_npc_kolinb.h
+++ b/include/d/actor/d_a_npc_kolinb.h
@@ -4,15 +4,6 @@
 #include "d/actor/d_a_npc.h"
 #include "d/d_bg_w.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_Kolinb_c
- * @brief Colin (Bedridden) / Ralis (Bedridden)
- *
- * @details
- *
-*/
-
 struct daNpc_Kolinb_HIOParam {
     /* 0x00 */ daNpcT_HIOParam common;
 };
@@ -24,6 +15,31 @@ public:
     static daNpc_Kolinb_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_Kolinb_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Kolinb_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Kolinb_HIOParam m;
+};
+
+#define NPC_KOLINB_HIO_CLASS daNpc_Kolinb_HIO_c
+#else
+#define NPC_KOLINB_HIO_CLASS daNpc_Kolinb_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_Kolinb_c
+ * @brief Colin (Bedridden) / Ralis (Bedridden)
+ *
+ * @details
+ *
+*/
 class daNpc_Kolinb_c : public daNpcT_c {
 public:
     enum Joint {
@@ -151,7 +167,7 @@ public:
     u32 getModelType() { return fopAcM_GetParam(this) >> 28; }
 
 private:
-    /* 0xE40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_KOLINB_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl field_0xe44;
     /* 0xF80 */ Mtx mMtx;
     /* 0xFB0 */ dBgW* mpBgW;

--- a/include/d/actor/d_a_npc_maro.h
+++ b/include/d/actor/d_a_npc_maro.h
@@ -5,6 +5,35 @@
 #include "d/actor/d_a_npc.h"
 #include "d/d_shop_system.h"
 
+struct daNpc_Maro_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ s16 field_0x8c;
+};
+
+class daNpc_Maro_Param_c {
+public:
+    virtual ~daNpc_Maro_Param_c() {}
+
+    static const daNpc_Maro_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Maro_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Maro_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Maro_HIOParam m;
+};
+
+#define NPC_MARO_HIO_CLASS daNpc_Maro_HIO_c
+#else
+#define NPC_MARO_HIO_CLASS daNpc_Maro_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Maro_c
@@ -153,7 +182,7 @@ public:
     }
 
 private:
-    /* 0x0F7C */ int field_0xf7c;
+    /* 0x0F7C */ NPC_MARO_HIO_CLASS* mpHIO;
     /* 0x0F80 */ dCcD_Cyl mCyl1;
     /* 0x10BC */ int field_0x10bc;
     /* 0x10C0 */ u8 mType;
@@ -178,18 +207,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Maro_c) == 0x1140);
-
-struct daNpc_Maro_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-    /* 0x8C */ u32 field_0x8c;
-};
-
-class daNpc_Maro_Param_c {
-public:
-    virtual ~daNpc_Maro_Param_c() {}
-
-    static const daNpc_Maro_HIOParam m;
-};
-
 
 #endif /* D_A_NPC_MARO_H */

--- a/include/d/actor/d_a_npc_midp.h
+++ b/include/d/actor/d_a_npc_midp.h
@@ -16,16 +16,29 @@ struct daNpc_midP_HIOParam {
     /* 0x0 */ daNpcT_HIOParam common;
 };
 
-class daNpc_midP_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_midP_HIOParam param;
-};
-
 class daNpc_midP_Param_c {
 public:
     virtual ~daNpc_midP_Param_c() {}
 
     static const daNpc_midP_HIOParam m;
 };
+
+#if DEBUG
+class daNpc_midP_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_midP_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_midP_HIOParam m;
+};
+
+#define NPC_MIDP_HIO_CLASS daNpc_midP_HIO_c
+#else
+#define NPC_MIDP_HIO_CLASS daNpc_midP_Param_c
+#endif
 
 class daNpc_midP_c : public daNpcT_c {
 public:
@@ -139,10 +152,9 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ u8 field_0xE40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_MIDP_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
-    /* 0xF81 */ u8 field_0xf81[0xf84-0xf81];
     /* 0xF84 */ actionFunc field_0xf84;
     /* 0xF90 */ actionFunc field_0xf90;
     /* 0xF9C */ int field_0xf9c;

--- a/include/d/actor/d_a_npc_moi.h
+++ b/include/d/actor/d_a_npc_moi.h
@@ -24,7 +24,7 @@ struct daNpc_Moi_HIOParam {
 
 class daNpc_Moi_Param_c {
 public:
-    virtual ~daNpc_Moi_Param_c() {};
+    virtual ~daNpc_Moi_Param_c() {}
 
     static const daNpc_Moi_HIOParam m;
 };

--- a/include/d/actor/d_a_npc_myna2.h
+++ b/include/d/actor/d_a_npc_myna2.h
@@ -3,6 +3,36 @@
 
 #include "d/actor/d_a_npc4.h"
 
+struct daNpc_myna2_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+    /* 0x6C */ f32 field_0x6c;
+    /* 0x70 */ f32 field_0x70;
+};
+
+class daNpc_myna2_Param_c {
+public:
+    virtual ~daNpc_myna2_Param_c() {}
+
+    static const daNpc_myna2_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_myna2_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_myna2_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_myna2_HIOParam m;
+};
+
+#define NPC_MYNA2_HIO_CLASS daNpc_myna2_HIO_c
+#else
+#define NPC_MYNA2_HIO_CLASS daNpc_myna2_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_myna2_c
@@ -64,7 +94,7 @@ public:
     /* 0xB4C */ daNpcF_Lookat_c mLookat;
     /* 0xBE8 */ Z2CreatureSumomo mSound;
     /* 0xC78 */ daNpcF_ActorMngr_c mActorMgrs[1];
-    /* 0xC80 */ u8 field_0xC80[0xC84 - 0xC80];
+    /* 0xC80 */ NPC_MYNA2_HIO_CLASS* mpHIO;
     /* 0xC84 */ dCcD_Cyl mCyl;
     /* 0xDC0 */ ActionFn mNextAction;
     /* 0xDCC */ ActionFn mAction;
@@ -87,19 +117,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daNpc_myna2_c) == 0xe34);
-
-struct daNpc_myna2_HIOParam {
-    /* 0x00 */ daNpcF_HIOParam common;
-    /* 0x6C */ f32 field_0x6c;
-    /* 0x70 */ f32 field_0x70;
-};
-
-class daNpc_myna2_Param_c {
-public:
-    virtual ~daNpc_myna2_Param_c() {}
-
-    static const daNpc_myna2_HIOParam m;
-};
-
 
 #endif /* D_A_NPC_MYNA2_H */

--- a/include/d/actor/d_a_npc_pachi_besu.h
+++ b/include/d/actor/d_a_npc_pachi_besu.h
@@ -3,22 +3,8 @@
 
 #include "d/actor/d_a_npc.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_Pachi_Besu_c
- * @brief Beth (Slingshot Tutorial)
- *
- * @details
- *
-*/
-
 struct daNpc_Pachi_Besu_HIOParam {
     /* 0x0 */ daNpcT_HIOParam common;
-};
-
-class daNpc_Pachi_Besu_HIO_c : public mDoHIO_entry_c {
-public:
-    /* 0x8 */ daNpc_Pachi_Besu_HIOParam param;
 };
 
 class daNpc_Pachi_Besu_Param_c {
@@ -28,6 +14,31 @@ public:
     static daNpc_Pachi_Besu_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_Pachi_Besu_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Pachi_Besu_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Pachi_Besu_HIOParam m;
+};
+
+#define NPC_PACHI_BESU_HIO_CLASS daNpc_Pachi_Besu_HIO_c
+#else
+#define NPC_PACHI_BESU_HIO_CLASS daNpc_Pachi_Besu_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_Pachi_Besu_c
+ * @brief Beth (Slingshot Tutorial)
+ *
+ * @details
+ *
+*/
 class daNpc_Pachi_Besu_c : public daNpcT_c {
 public:
     typedef BOOL (daNpc_Pachi_Besu_c::*actionFunc)(void*);
@@ -137,7 +148,7 @@ public:
     static cutFunc mCutList[11];
 
 private:
-    /* 0xE40 */ daNpc_Pachi_Besu_HIO_c* mHIO;
+    /* 0xE40 */ NPC_PACHI_BESU_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF81 */ u8 mTalk;

--- a/include/d/actor/d_a_npc_prayer.h
+++ b/include/d/actor/d_a_npc_prayer.h
@@ -3,6 +3,32 @@
 
 #include "d/actor/d_a_npc4.h"
 
+struct daNpcPray_HIOParam {
+    daNpcF_HIOParam common;
+};
+
+class daNpcPray_Param_c {
+public:
+    virtual ~daNpcPray_Param_c() {}
+
+    static const daNpcPray_HIOParam m;
+};
+
+#if DEBUG
+class daNpcPray_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcPray_HIO_c();
+
+    void genMessage(JORMContext*);
+
+    daNpcPray_HIOParam m;
+};
+
+#define NPC_PRAY_HIO_CLASS daNpcPray_HIO_c
+#else
+#define NPC_PRAY_HIO_CLASS daNpcPray_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpcPray_c
@@ -58,7 +84,7 @@ private:
     /* 0xBEC */ u8 field_0xBEC[0xBF0 - 0xBEC];
     /* 0xBF0 */ daNpcF_Lookat_c mLookat;
     /* 0xC8C */ daNpcF_ActorMngr_c mActorMngr[2];
-    /* 0xC9C */ u8 field_0xC9C[0xCA0 - 0xC9C];
+    /* 0xC9C */ NPC_PRAY_HIO_CLASS* mpHIO;
     /* 0xCA0 */ dCcD_Cyl mCcCyl;
     /* 0xDDC */ bool (daNpcPray_c::*mAction)(void*);
     /* 0xDE8 */ request_of_phase_process_class mPhase[2];
@@ -73,17 +99,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpcPray_c) == 0xe10);
-
-struct daNpcPray_HIOParam {
-    daNpcF_HIOParam common;
-};
-
-class daNpcPray_Param_c {
-public:
-    virtual ~daNpcPray_Param_c() {}
-
-    static const daNpcPray_HIOParam m;
-};
-
 
 #endif /* D_A_NPC_PRAYER_H */

--- a/include/d/actor/d_a_npc_raca.h
+++ b/include/d/actor/d_a_npc_raca.h
@@ -16,16 +16,29 @@ struct daNpc_Raca_HIOParam {
     /* 0x0 */ daNpcT_HIOParam common;
 };
 
-class daNpc_Raca_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_Raca_HIOParam param;
-};
-
 class daNpc_Raca_Param_c {
 public:
     virtual ~daNpc_Raca_Param_c() {}
 
     static daNpc_Raca_HIOParam const m;
 };
+
+#if DEBUG
+class daNpc_Raca_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Raca_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Raca_HIOParam m;
+};
+
+#define NPC_RACA_HIO_CLASS daNpc_Raca_HIO_c
+#else
+#define NPC_RACA_HIO_CLASS daNpc_Raca_Param_c
+#endif
 
 class daNpc_Raca_c : public daNpcT_c {
 public:
@@ -136,7 +149,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ daNpc_Raca_HIO_c* mHIO;
+    /* 0xE40 */ NPC_RACA_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ daNpcT_ActorMngr_c mActorMngr[1];

--- a/include/d/actor/d_a_npc_saru.h
+++ b/include/d/actor/d_a_npc_saru.h
@@ -15,24 +15,31 @@
 struct daNpc_Saru_HIOParam {
     /* 0x00 */ daNpcT_HIOParam common;
     /* 0x8C */ s16 scared_time;          // 怯える時間       - Scared Time
-    /* 0x8E */ s16 field_0x8e;
 };
 
-class daNpc_Saru_Param_c : public JORReflexible {
+class daNpc_Saru_Param_c {
 public:
     virtual ~daNpc_Saru_Param_c() {}
-
-#if DEBUG
-    void genMessage(JORMContext*);
-#endif
 
     static const daNpc_Saru_HIOParam m;
 };
 
+#if DEBUG
 class daNpc_Saru_HIO_c : public mDoHIO_entry_c {
 public:
-    daNpc_Saru_HIOParam param;
+    daNpc_Saru_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Saru_HIOParam m;
 };
+
+#define NPC_SARU_HIO_CLASS daNpc_Saru_HIO_c
+#else
+#define NPC_SARU_HIO_CLASS daNpc_Saru_Param_c
+#endif
 
 class daNpc_Saru_c : public daNpcT_c {
 public:
@@ -129,10 +136,7 @@ public:
     static char* mCutNameList[4];
     static cutFunc mCutList[4];
 private:
-    #if DEBUG
-    /* 0xE90 */ daNpc_Saru_HIO_c* field_0xe90;
-    #endif
-    /* 0xE40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_SARU_HIO_CLASS* mpHIO;
     /* 0xE44 */ J3DModel* mpRoseModels[2];
     /* 0xE4C */ dCcD_Cyl field_0xe4c;
     /* 0xF88 */ u8 mType;

--- a/include/d/actor/d_a_npc_seib.h
+++ b/include/d/actor/d_a_npc_seib.h
@@ -3,6 +3,36 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_seiB_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;
+    /* 0x90 */ f32 mDist;
+};
+
+class daNpc_seiB_Param_c {
+public:
+    virtual ~daNpc_seiB_Param_c() {};
+
+    static const daNpc_seiB_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_seiB_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_seiB_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_seiB_HIOParam m;
+};
+
+#define NPC_SEIB_HIO_CLASS daNpc_seiB_HIO_c
+#else
+#define NPC_SEIB_HIO_CLASS daNpc_seiB_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_seiB_c
@@ -11,52 +41,6 @@
  * @details
  *
  */
-
-class daNpc_seiB_Param_c {
-public:
-    virtual ~daNpc_seiB_Param_c() {};
-    struct Data {
-        /* 0x00 */ f32 field_0x00;
-        /* 0x04 */ f32 mGravity;
-        /* 0x08 */ f32 mScale;
-        /* 0x0C */ f32 field_0xc;
-        /* 0x10 */ f32 mWeight;
-        /* 0x14 */ f32 mCylH;
-        /* 0x18 */ f32 mWallH;
-        /* 0x1C */ f32 mWallR;
-        /* 0x20 */ f32 field_0x20;
-        /* 0x24 */ f32 field_0x24;
-        /* 0x28 */ f32 field_0x28;
-        /* 0x2C */ f32 field_0x2c;
-        /* 0x30 */ f32 field_0x30;
-        /* 0x34 */ f32 field_0x34;
-        /* 0x38 */ f32 field_0x38;
-        /* 0x3C */ f32 field_0x3c;
-        /* 0x40 */ f32 field_0x40;
-        /* 0x44 */ f32 mMorfFrames;
-        /* 0x48 */ f32 field_0x48;
-        /* 0x4C */ f32 field_0x4c;
-        /* 0x50 */ f32 field_0x50;
-        /* 0x54 */ f32 field_0x54;
-        /* 0x58 */ f32 field_0x58;
-        /* 0x5C */ f32 field_0x5c;
-        /* 0x60 */ f32 field_0x60;
-        /* 0x64 */ f32 field_0x64;
-        /* 0x68 */ f32 field_0x68;
-        /* 0x6C */ f32 field_0x6c;
-        /* 0x70 */ f32 field_0x70;
-        /* 0x74 */ f32 field_0x74;
-        /* 0x78 */ f32 field_0x78;
-        /* 0x7C */ f32 field_0x7c;
-        /* 0x80 */ f32 field_0x80;
-        /* 0x84 */ f32 field_0x84;
-        /* 0x88 */ f32 field_0x88;
-        /* 0x8C */ f32 field_0x8c;
-        /* 0x90 */ f32 mDist;
-    };
-
-    static const Data m;
-};
 class daNpc_seiB_c : public daNpcT_c {
 public:
     typedef int (daNpc_seiB_c::*cutFunc)(int);
@@ -104,7 +88,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ daNpc_seiB_Param_c* mpParam;
+    /* 0xE40 */ NPC_SEIB_HIO_CLASS* mpHIO;
     /* 0xE44 */ u8 mType;
     /* 0xE48 */ actionFunc mActionFunc1;
     /* 0xE54 */ actionFunc mActionFunc2;

--- a/include/d/actor/d_a_npc_seic.h
+++ b/include/d/actor/d_a_npc_seic.h
@@ -13,66 +13,34 @@
  */
 
  struct daNpc_seiC_HIOParam {
-    /* 0x00 */ f32 field_0x00;
-    /* 0x04 */ f32 mGravity;
-    /* 0x08 */ f32 mScale;
-    /* 0x0C */ f32 field_0x0c;
-    /* 0x10 */ f32 mSttsWeight;
-    /* 0x14 */ f32 mCylH;
-    /* 0x18 */ f32 mWallH;
-    /* 0x1C */ f32 mWallR;
-    /* 0x20 */ f32 field_0x20;
-    /* 0x24 */ f32 field_0x24;
-    /* 0x28 */ f32 field_0x28;
-    /* 0x2C */ f32 field_0x2c;
-    /* 0x30 */ f32 field_0x30;
-    /* 0x34 */ f32 field_0x34;
-    /* 0x38 */ f32 field_0x38;
-    /* 0x3C */ f32 field_0x3c;
-    /* 0x40 */ f32 field_0x40;
-    /* 0x44 */ f32 mMorfFrames;
-    /* 0x48 */ f32 field_0x48;
-    /* 0x4C */ f32 field_0x4c;
-    /* 0x50 */ f32 field_0x50;
-    /* 0x54 */ f32 field_0x54;
-    /* 0x58 */ f32 field_0x58;
-    /* 0x5C */ f32 field_0x5c;
-    /* 0x60 */ f32 field_0x60;
-    /* 0x64 */ f32 field_0x64;
-    /* 0x68 */ f32 field_0x68;
-    /* 0x6C */ f32 field_0x6c;
-    /* 0x70 */ f32 field_0x70;
-    /* 0x74 */ f32 field_0x74;
-    /* 0x78 */ f32 field_0x78;
-    /* 0x7C */ f32 field_0x7c;
-    /* 0x80 */ f32 field_0x80;
-    /* 0x84 */ f32 field_0x84;
-    /* 0x88 */ f32 field_0x88;
-    /* 0x8C */ f32 field_0x8c;
-    /* 0x90 */ f32 field_0x90;
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c;  // "強制会話距離" "Forced conversation distance" | Slider
+    /* 0x90 */ f32 field_0x90;  // "会話距離" "Conversation distance" | Slider
 };
 
 class daNpc_seiC_Param_c {
-    public:
-        virtual ~daNpc_seiC_Param_c() {};
+public:
+    virtual ~daNpc_seiC_Param_c() {}
 
-        static const daNpc_seiC_HIOParam m;
+    static const daNpc_seiC_HIOParam m;
 };
 
-class daNpc_seiC_HIO_c
 #if DEBUG
-: public mDoHIO_entry_c 
-#endif
-{
+class daNpc_seiC_HIO_c : public mDoHIO_entry_c {
 public:
+    daNpc_seiC_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
     void genMessage(JORMContext*);
 
-    #if DEBUG
-    /* 0x08 */ daNpc_seiC_HIOParam field_0x8;
-    /* 0x94 */ f32 field_0x94;                  // "強制会話距離" "Forced conversation distance" | Slider
-    /* 0x98 */ f32 field_0x98;                  // "会話距離" "Conversation distance" | Slider
-    #endif
+    /* 0x08 */ daNpc_seiC_HIOParam m;
 };
+
+#define NPC_SEIC_HIO_CLASS daNpc_seiC_HIO_c
+#else
+#define NPC_SEIC_HIO_CLASS daNpc_seiC_Param_c
+#endif
 
 class daNpc_seiC_c : public daNpcT_c {
 public:
@@ -123,7 +91,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ daNpc_seiC_HIO_c* field_0xe40;
+    /* 0xE40 */ NPC_SEIC_HIO_CLASS* mpHIO;
     /* 0xE44 */ u8 mType;
     /* 0xE45 */ u8 field_0xe45[0xe48 - 0xe45];
     /* 0xE48 */ actionFunc mAction;

--- a/include/d/actor/d_a_npc_seid.h
+++ b/include/d/actor/d_a_npc_seid.h
@@ -13,66 +13,34 @@
  */
 
  struct daNpc_seiD_HIOParam {
-    /* 0x00 */ f32 field_0x00;
-    /* 0x04 */ f32 mGravity;
-    /* 0x08 */ f32 mScale;
-    /* 0x0C */ f32 field_0x0c;
-    /* 0x10 */ f32 mSttsWeight;
-    /* 0x14 */ f32 mCylH;
-    /* 0x18 */ f32 mWallH;
-    /* 0x1C */ f32 mWallR;
-    /* 0x20 */ f32 field_0x20;
-    /* 0x24 */ f32 field_0x24;
-    /* 0x28 */ f32 field_0x28;
-    /* 0x2C */ f32 field_0x2c;
-    /* 0x30 */ f32 field_0x30;
-    /* 0x34 */ f32 field_0x34;
-    /* 0x38 */ f32 field_0x38;
-    /* 0x3C */ f32 field_0x3c;
-    /* 0x40 */ f32 field_0x40;
-    /* 0x44 */ f32 mMorfFrames;
-    /* 0x48 */ f32 field_0x48;
-    /* 0x4C */ f32 field_0x4c;
-    /* 0x50 */ f32 field_0x50;
-    /* 0x54 */ f32 field_0x54;
-    /* 0x58 */ f32 field_0x58;
-    /* 0x5C */ f32 field_0x5c;
-    /* 0x60 */ f32 field_0x60;
-    /* 0x64 */ f32 field_0x64;
-    /* 0x68 */ f32 field_0x68;
-    /* 0x6C */ f32 field_0x6c;
-    /* 0x70 */ f32 field_0x70;
-    /* 0x74 */ f32 field_0x74;
-    /* 0x78 */ f32 field_0x78;
-    /* 0x7C */ f32 field_0x7c;
-    /* 0x80 */ f32 field_0x80;
-    /* 0x84 */ f32 field_0x84;
-    /* 0x88 */ f32 field_0x88;
-    /* 0x8C */ f32 field_0x8c;
-    /* 0x90 */ f32 field_0x90;
+    /* 0x00 */ daNpcT_HIOParam common;
+    /* 0x8C */ f32 field_0x8c; // "強制会話距離" "Forced conversation distance" | Slider
+    /* 0x90 */ f32 field_0x90;  // "会話距離" "Conversation distance" | Slider
 };
 
 class daNpc_seiD_Param_c {
-    public:
-        virtual ~daNpc_seiD_Param_c() {};
+public:
+    virtual ~daNpc_seiD_Param_c() {}
 
-        static const daNpc_seiD_HIOParam m;
+    static const daNpc_seiD_HIOParam m;
 };
 
-class daNpc_seiD_HIO_c
 #if DEBUG
-: public mDoHIO_entry_c 
-#endif
-{
+class daNpc_seiD_HIO_c : public mDoHIO_entry_c {
 public:
+    daNpc_seiD_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
     void genMessage(JORMContext*);
 
-    #if DEBUG
-    /* 0x08 */ daNpc_seiD_HIOParam field_0x8;
-    // /* 0x94 */ f32 field_0x94;                  // "強制会話距離" "Forced conversation distance" | Slider
-    // /* 0x98 */ f32 field_0x98;                  // "会話距離" "Conversation distance" | Slider
-    #endif
+    /* 0x08 */ daNpc_seiD_HIOParam m;
 };
+
+#define NPC_SEID_HIO_CLASS daNpc_seiD_HIO_c
+#else
+#define NPC_SEID_HIO_CLASS daNpc_seiD_Param_c
+#endif
 
 class daNpc_seiD_c : public daNpcT_c {
 public:
@@ -122,9 +90,8 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ daNpc_seiD_HIO_c* field_0xe40;
+    /* 0xE40 */ NPC_SEID_HIO_CLASS* mpHIO;
     /* 0xE44 */ u8 mType;
-    /* 0xE45 */ u8 field_0xe45[0xe48 - 0xe45];
     /* 0xE48 */ actionFunc mAction;
     /* 0xE54 */ actionFunc mAction2;
     /* 0xE60 */ int field_0xe60;

--- a/include/d/actor/d_a_npc_seira.h
+++ b/include/d/actor/d_a_npc_seira.h
@@ -4,6 +4,34 @@
 #include "d/actor/d_a_npc.h"
 #include "d/d_shop_system.h"
 
+struct daNpc_Seira_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+class daNpc_Seira_Param_c {
+public:
+    virtual ~daNpc_Seira_Param_c() {}
+
+    static const daNpc_Seira_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Seira_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Seira_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Seira_HIOParam m;
+};
+
+#define NPC_SEIRA_HIO_CLASS daNpc_Seira_HIO_c
+#else
+#define NPC_SEIRA_HIO_CLASS daNpc_Seira_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Seira_c
@@ -91,7 +119,7 @@ public:
 
 private:
     /* 0x0F7C */ mDoExt_McaMorfSO* mpSeiraMorf;
-    /* 0x0F80 */ int field_0x0F80;
+    /* 0x0F80 */ NPC_SEIRA_HIO_CLASS* mpHIO;
     /* 0x0F80 */ dCcD_Cyl mCyl1;
     /* 0x10C0 */ u8 mChkBottle;
     /* 0x10C1 */ u8 mType;
@@ -110,17 +138,6 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Seira_c) == 0x1108);
-
-struct daNpc_Seira_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-};
-
-class daNpc_Seira_Param_c {
-public:
-    virtual ~daNpc_Seira_Param_c() {}
-
-    static const daNpc_Seira_HIOParam m;
-};
 
 
 #endif /* D_A_NPC_SEIRA_H */

--- a/include/d/actor/d_a_npc_seira2.h
+++ b/include/d/actor/d_a_npc_seira2.h
@@ -4,6 +4,34 @@
 #include "d/actor/d_a_npc.h"
 #include "d/d_shop_system.h"
 
+struct daNpc_Seira2_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+class daNpc_Seira2_Param_c {
+public:
+    virtual ~daNpc_Seira2_Param_c() {}
+
+    static const daNpc_Seira2_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Seira2_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Seira2_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Seira2_HIOParam m;
+};
+
+#define NPC_SEIRA2_HIO_CLASS daNpc_Seira2_HIO_c
+#else
+#define NPC_SEIRA2_HIO_CLASS daNpc_Seira2_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Seira2_c
@@ -83,8 +111,8 @@ public:
 
 private:
     /* 0x0F7C */ mDoExt_McaMorfSO* mpSeiraMorf;
-    /* 0x0F80 */ int field_0x0F80;
-    /* 0x0F80 */ dCcD_Cyl mCyl1;
+    /* 0x0F80 */ NPC_SEIRA2_HIO_CLASS* mpHIO;
+    /* 0x0F84 */ dCcD_Cyl mCyl1;
     /* 0x10C0 */ u8 mChkBottle;
     /* 0x10C1 */ u8 mType;
     /* 0x10C4 */ daNpcT_ActorMngr_c mActorMngr[1];
@@ -100,17 +128,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Seira2_c) == 0x10F4);
-
-struct daNpc_Seira2_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-};
-
-class daNpc_Seira2_Param_c {
-public:
-    virtual ~daNpc_Seira2_Param_c() {}
-
-    static const daNpc_Seira2_HIOParam m;
-};
-
 
 #endif /* D_A_NPC_SEIRA2_H */

--- a/include/d/actor/d_a_npc_seirei.h
+++ b/include/d/actor/d_a_npc_seirei.h
@@ -3,23 +3,10 @@
 
 #include "d/actor/d_a_npc.h"
 
-/**
- * @ingroup actors-npcs
- * @class daNpc_Seirei_c
- * @brief Light Spirit Ordona
- *
- * @details
- *
-*/
-
 struct daNpc_Seirei_HIOParam {
     /* 0x00 */ daNpcT_HIOParam common;
     /* 0x8C */ f32 force_talk_dist;     // 強制会話距離 - Force Talk Distance
     /* 0x90 */ f32 talk_dist;           // 会話距離 - Talk Distance
-};
-
-class daNpc_Seirei_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_Seirei_HIOParam param;
 };
 
 class daNpc_Seirei_Param_c {
@@ -29,6 +16,31 @@ public:
     static daNpc_Seirei_HIOParam const m;
 };
 
+#if DEBUG
+class daNpc_Seirei_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Seirei_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Seirei_HIOParam m;
+};
+
+#define NPC_SEIREI_HIO_CLASS daNpc_Seirei_HIO_c
+#else
+#define NPC_SEIREI_HIO_CLASS daNpc_Seirei_Param_c
+#endif
+
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_Seirei_c
+ * @brief Light Spirit Ordona
+ *
+ * @details
+ *
+*/
 class daNpc_Seirei_c : public daNpcT_c {
 public:
     typedef int (daNpc_Seirei_c::*actionFunc)(void*);
@@ -91,7 +103,7 @@ public:
     static cutFunc mCutList[2];
 
 private:
-    /* 0xE40 */ daNpc_Seirei_HIO_c* mHIO;
+    /* 0xE40 */ NPC_SEIREI_HIO_CLASS* mpHIO;
     /* 0xE44 */ u8 mType;
     /* 0xE45 */ u8 arg0;
     /* 0xE48 */ actionFunc mNextAction;

--- a/include/d/actor/d_a_npc_sola.h
+++ b/include/d/actor/d_a_npc_sola.h
@@ -3,6 +3,34 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_solA_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+class daNpc_solA_Param_c {
+public:
+    virtual ~daNpc_solA_Param_c() {}
+
+    static daNpc_solA_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_solA_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_solA_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_solA_HIOParam m;
+};
+
+#define NPC_SOLA_HIO_CLASS daNpc_solA_HIO_c
+#else
+#define NPC_SOLA_HIO_CLASS daNpc_solA_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_solA_c
@@ -11,7 +39,6 @@
  * @details
  *
  */
-
 class daNpc_solA_c : public daNpcT_c {
 public:
     typedef int (daNpc_solA_c::*cutFunc)(int);
@@ -88,7 +115,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_SOLA_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 field_0xf80;
     /* 0xF84 */ actionFunc mNextAction;
@@ -97,16 +124,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_solA_c) == 0xfa0);
-
-struct daNpc_solA_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-};
-
-class daNpc_solA_Param_c {
-public:
-    virtual ~daNpc_solA_Param_c() {}
-
-    static daNpc_solA_HIOParam const m;
-};
 
 #endif /* D_A_NPC_SOLA_H */

--- a/include/d/actor/d_a_npc_taro.h
+++ b/include/d/actor/d_a_npc_taro.h
@@ -5,63 +5,33 @@
 #include "d/actor/d_a_npc.h"
 
 struct daNpc_Taro_HIOParam {
-    /* 0x00 */ f32 mAttentionPosYOffset;
-    /* 0x04 */ f32 mGravity;
-    /* 0x08 */ f32 mScale;
-    /* 0x0C */ f32 field_0x0c;
-    /* 0x10 */ f32 mSttsWeight;
-    /* 0x14 */ f32 mCylH;
-    /* 0x18 */ f32 mWallH;
-    /* 0x1C */ f32 mWallR;
-    /* 0x20 */ f32 mBodyDownAngle;
-    /* 0x24 */ f32 mBodyUpAngle;
-    /* 0x28 */ f32 mBodyRightAngle;
-    /* 0x2C */ f32 mBodyLeftAngle;
-    /* 0x30 */ f32 mHeadDownAngle;
-    /* 0x34 */ f32 mHeadUpAngle;
-    /* 0x38 */ f32 mHeadRightAngle;
-    /* 0x3C */ f32 mHeadLeftAngle;
-    /* 0x40 */ f32 field_0x40;
-    /* 0x44 */ f32 mMorfFrames;
-    /* 0x48 */ s16 field_0x48;
-    /* 0x4A */ s16 field_0x4a;
-    /* 0x4C */ s16 field_0x4c;
-    /* 0x4E */ s16 field_0x4e;
-    /* 0x50 */ f32 mAttnFovY;
-    /* 0x54 */ f32 field_0x54;
-    /* 0x58 */ f32 field_0x58;
-    /* 0x5C */ f32 field_0x5c;
-    /* 0x60 */ s16 field_0x60;
-    /* 0x62 */ s16 field_0x62;
-    /* 0x64 */ f32 field_0x64;
-    /* 0x68 */ f32 field_0x68;
-    /* 0x6C */ f32 field_0x6c;
-    /* 0x70 */ f32 field_0x70;
-    /* 0x74 */ f32 field_0x74;
-    /* 0x78 */ f32 field_0x78;
-    /* 0x7C */ f32 field_0x7c;
-    /* 0x80 */ f32 field_0x80;
-    /* 0x84 */ f32 field_0x84;
-    /* 0x88 */ f32 field_0x88;
+    /* 0x00 */ daNpcT_HIOParam common;
     /* 0x8C */ s16 mChoccaiTimer;
     /* 0x8E */ s16 field_0x8e;
 };
 
 class daNpc_Taro_Param_c {
-    public:
-        virtual ~daNpc_Taro_Param_c() {}
-    
-        static daNpc_Taro_HIOParam const m;
-    };
-
-class daNpc_Taro_HIO_c 
-#if DEBUG
-: public mDoHIO_entry_c 
-#endif
-{
 public:
-    void genMessage(JORMContext*);
+    virtual ~daNpc_Taro_Param_c() {}
+
+    static daNpc_Taro_HIOParam const m;
 };
+
+#if DEBUG
+class daNpc_Taro_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Taro_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Taro_HIOParam m;
+};
+#define NPC_TARO_HIO_CLASS daNpc_Taro_HIO_c
+#else
+#define NPC_TARO_HIO_CLASS daNpc_Taro_Param_c
+#endif
 
 /**
  * @ingroup actors-npcs
@@ -191,7 +161,7 @@ public:
     static cutFunc mCutList[17];
 
 private:
-    /* 0x0E40 */ daNpc_Taro_HIO_c* field_0xe40;
+    /* 0x0E40 */ NPC_TARO_HIO_CLASS* mpHIO;
     /* 0x0E44 */ J3DModel* mModels[2];
     /* 0x0E4C */ dCcD_Cyl mCyl1;
     /* 0x0F88 */ dCcD_Cyl mCyl2;

--- a/include/d/actor/d_a_npc_tkj.h
+++ b/include/d/actor/d_a_npc_tkj.h
@@ -3,6 +3,34 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Tkj_HIOParam {
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+class daNpc_Tkj_Param_c {
+public:
+    virtual ~daNpc_Tkj_Param_c() {}
+
+    static const daNpc_Tkj_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Tkj_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Tkj_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Tkj_HIOParam m;
+};
+
+#define NPC_TKJ_HIO_CLASS daNpc_Tkj_HIO_c
+#else
+#define NPC_TKJ_HIO_CLASS daNpc_Tkj_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpcTkj_c
@@ -70,7 +98,7 @@ public:
     static int (daNpcTkj_c::*mCutList[])(int);
 
 private:
-    /* 0xE40 */ u8 field_0xE40[0xE44 - 0xE40];
+    /* 0xE40 */ NPC_TKJ_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCcCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ ActionFunc field_0xf84;
@@ -80,15 +108,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpcTkj_c) == 0xfa4);
-
-struct daNpc_Tkj_HIOParam {
-    /* 0x00 */ daNpcT_HIOParam common;
-};
-class daNpc_Tkj_Param_c {
-public:
-    virtual ~daNpc_Tkj_Param_c() {}
-
-    static const daNpc_Tkj_HIOParam m;
-};
 
 #endif /* D_A_NPC_TKJ_H */

--- a/include/d/actor/d_a_npc_tks.h
+++ b/include/d/actor/d_a_npc_tks.h
@@ -27,20 +27,29 @@ struct daNpcTks_HIOParam {
     /* 0x94 */ f32 run_spd;             // 走行速度 - Run Speed
 };
 
-class daNpcTks_HIO_c
-#if DEBUG
-: public mDoHIO_entry_c
-#endif
-{
-    /* 0x8 */ daNpcTks_HIOParam param;
-};
-
 class daNpcTks_Param_c {
 public:
     virtual ~daNpcTks_Param_c() {}
 
     static daNpcTks_HIOParam const m;
 };
+
+#if DEBUG
+class daNpcTks_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpcTks_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpcTks_HIOParam m;
+};
+
+#define NPC_TKS_HIO_CLASS daNpcTks_HIO_c
+#else
+#define NPC_TKS_HIO_CLASS daNpcTks_Param_c
+#endif
 
 class daNpcTksTsubo_c {
 public:
@@ -132,7 +141,7 @@ private:
     /* 0x1164 */ daNpcF_Lookat_c mLookat;
     /* 0x1200 */ daNpcF_ActorMngr_c mActorMngr[1];
     /* 0x1208 */ fopAc_ac_c* field_0x1208;
-    /* 0x120C */ daNpcTks_HIO_c* mHIO;
+    /* 0x120C */ NPC_TKS_HIO_CLASS* mpHIO;
     /* 0x1210 */ dCcD_Cyl mCyl;
     /* 0x134C */ actionFunc mAction;
     /* 0x1358 */ request_of_phase_process_class mPhases[2];

--- a/include/d/actor/d_a_npc_yelia.h
+++ b/include/d/actor/d_a_npc_yelia.h
@@ -3,6 +3,34 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Yelia_HIOParam {
+    daNpcT_HIOParam common;
+};
+
+class daNpc_Yelia_Param_c {
+public:
+    virtual ~daNpc_Yelia_Param_c() {}
+
+    static daNpc_Yelia_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_Yelia_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Yelia_HIO_c();
+
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+    void genMessage(JORMContext*);
+
+    daNpc_Yelia_HIOParam m;
+};
+
+#define NPC_YELIA_HIO_CLASS daNpc_Yelia_HIO_c
+#else
+#define NPC_YELIA_HIO_CLASS daNpc_Yelia_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Yelia_c
@@ -77,7 +105,7 @@ public:
     static char* mCutNameList[6];
     static int (daNpc_Yelia_c::*mCutList[6])(int);
 private:
-    /* 0xE40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_YELIA_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCcCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ daNpcT_ActorMngr_c mActorMngr[4];
@@ -90,55 +118,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Yelia_c) == 0xff0);
-
-class daNpc_Yelia_Param_c {
-public:
-    struct param {
-        /* 0x00 */ f32 mAttnOffsetY;
-        /* 0x04 */ f32 mGravity;
-        /* 0x08 */ f32 mScale;
-        /* 0x0C */ f32 mShadowDepth;
-        /* 0x10 */ f32 mCcWeight;
-        /* 0x14 */ f32 mCylH;
-        /* 0x18 */ f32 mWallH;
-        /* 0x1C */ f32 mWallR;
-        /* 0x20 */ f32 mBodyUpAngle;
-        /* 0x24 */ f32 mBodyDownAngle;
-        /* 0x28 */ f32 mBodyLeftAngle;
-        /* 0x2C */ f32 mBodyRightAngle;
-        /* 0x30 */ f32 mHeadUpAngle;
-        /* 0x34 */ f32 mHeadDownAngle;
-        /* 0x38 */ f32 mHeadLeftAngle;
-        /* 0x3C */ f32 mHeadRightAngle;
-        /* 0x40 */ f32 mNeckAngleScl;
-        /* 0x44 */ f32 mMorfFrames;
-        /* 0x48 */ s16 mSpeakDistIdx;
-        /* 0x4A */ s16 mSpeakAngleIdx;
-        /* 0x4C */ s16 mTalkDistIdx;
-        /* 0x4E */ s16 mTalkAngleIdx;
-        /* 0x50 */ f32 mAttnFovY;
-        /* 0x54 */ f32 mAttnRadius;
-        /* 0x58 */ f32 mAttnUpperY;
-        /* 0x5C */ f32 mAttnLowerY;
-        /* 0x60 */ s16 field_0x60;
-        /* 0x62 */ s16 mDamageTimer;
-        /* 0x64 */ s16 mTestExpression;
-        /* 0x66 */ s16 mTestMotion;
-        /* 0x68 */ s16 mTestLookMode;
-        /* 0x6A */ bool mTest;
-        /* 0x6C */ f32 field_0x6c;
-        /* 0x70 */ f32 field_0x70;
-        /* 0x74 */ f32 field_0x74;
-        /* 0x78 */ f32 field_0x78;
-        /* 0x7C */ f32 field_0x7c;
-        /* 0x80 */ f32 field_0x80;
-        /* 0x84 */ f32 field_0x84;
-        /* 0x88 */ f32 field_0x88;
-    };
-
-    virtual ~daNpc_Yelia_Param_c() {}
-
-    static param const m;
-};
 
 #endif /* D_A_NPC_YELIA_H */

--- a/include/d/actor/d_a_npc_zant.h
+++ b/include/d/actor/d_a_npc_zant.h
@@ -3,6 +3,33 @@
 
 #include "d/actor/d_a_npc.h"
 
+struct daNpc_Zant_HIOParam {
+    daNpcT_HIOParam common;
+};
+
+class daNpc_Zant_Param_c {
+public:
+    virtual ~daNpc_Zant_Param_c() {}
+
+    static const daNpc_Zant_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Zant_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Zant_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_Zant_HIOParam m;
+};
+#define NPC_ZANT_HIO_CLASS daNpc_Zant_HIO_c
+#else
+#define NPC_ZANT_HIO_CLASS daNpc_Zant_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_Zant_c
@@ -60,7 +87,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_ZANT_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF81 */ u8 field_0xf81[0xf84 - 0xf81];
@@ -70,61 +97,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Zant_c) == 0xfa0);
-
-class daNpc_Zant_Param_c {
-public:
-    virtual ~daNpc_Zant_Param_c() {}
-    struct Data {
-        /* 0x00 */ f32 field_0x0;
-        /* 0x04 */ f32 field_0x4;
-        /* 0x08 */ f32 field_0x8;
-        /* 0x0C */ f32 field_0xc;
-        /* 0x10 */ f32 field_0x10;
-        /* 0x14 */ f32 field_0x14;
-        /* 0x18 */ f32 field_0x18;
-        /* 0x1C */ f32 field_0x1c;
-        /* 0x20 */ f32 field_0x20;
-        /* 0x24 */ f32 field_0x24;
-        /* 0x28 */ f32 field_0x28;
-        /* 0x2C */ f32 field_0x2c;
-        /* 0x30 */ f32 field_0x30;
-        /* 0x34 */ f32 field_0x34;
-        /* 0x38 */ f32 field_0x38;
-        /* 0x3C */ f32 field_0x3c;
-        /* 0x40 */ f32 field_0x40;
-        /* 0x44 */ f32 field_0x44;
-        /* 0x48 */ s16 field_0x48;
-        /* 0x4A */ s16 field_0x4a;
-        /* 0x4C */ s16 field_0x4c;
-        /* 0x4E */ s16 field_0x4e;
-        /* 0x50 */ f32 field_0x50;
-        /* 0x54 */ f32 field_0x54;
-        /* 0x58 */ f32 field_0x58;
-        /* 0x5C */ f32 field_0x5c;
-        /* 0x60 */ s16 field_0x60;
-        /* 0x62 */ s16 field_0x62;
-        /* 0x64 */ int field_0x64;
-        /* 0x68 */ int field_0x68;
-        /* 0x6C */ f32 field_0x6c;
-        /* 0x70 */ f32 field_0x70;
-        /* 0x74 */ f32 field_0x74;
-        /* 0x78 */ f32 field_0x78;
-        /* 0x7C */ f32 field_0x7c;
-        /* 0x80 */ f32 field_0x80;
-        /* 0x84 */ f32 field_0x84;
-        /* 0x88 */ f32 field_0x88;
-    };
-
-    static const Data m;
-};
-
-class daNpc_Zant_HIO_c {
-public:
-    virtual ~daNpc_Zant_HIO_c() {}
-
-#if DEBUG
-    daNpc_Zant_Param_c::Data param;
-#endif
-};
 
 #endif /* D_A_NPC_ZANT_H */

--- a/include/d/actor/d_a_npc_zelR.h
+++ b/include/d/actor/d_a_npc_zelR.h
@@ -16,16 +16,29 @@ struct daNpc_ZelR_HIOParam {
     /* 0x0 */ daNpcT_HIOParam common;
 };
 
-class daNpc_ZelR_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_ZelR_HIOParam param;
-};
-
 class daNpc_ZelR_Param_c {
 public:
     virtual ~daNpc_ZelR_Param_c() {};
 
     static const daNpc_ZelR_HIOParam m;
 };
+
+#if DEBUG
+class daNpc_ZelR_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_ZelR_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_ZelR_HIOParam m;
+};
+
+#define NPC_ZELR_HIO_CLASS daNpc_ZelR_HIO_c
+#else
+#define NPC_ZELR_HIO_CLASS daNpc_ZelR_Param_c
+#endif
 
 class daNpc_ZelR_c : public daNpcT_c {
 public:
@@ -84,7 +97,7 @@ public:
     static EventFn mCutList[1];
 
 private:
-    /* 0xE40 */ u8 field_0xe40[0xe44 - 0xe40];
+    /* 0xE40 */ NPC_ZELR_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ ActionFn field_0xf84;

--- a/include/d/actor/d_a_npc_zelRo.h
+++ b/include/d/actor/d_a_npc_zelRo.h
@@ -16,16 +16,29 @@ struct daNpc_ZelRo_HIOParam {
     /* 0x0 */ daNpcT_HIOParam common;
 };
 
-class daNpc_ZelRo_HIO_c : public mDoHIO_entry_c {
-    /* 0x8 */ daNpc_ZelRo_HIOParam param;
-};
-
 class daNpc_ZelRo_Param_c {
 public:
     virtual ~daNpc_ZelRo_Param_c() {}
 
     static daNpc_ZelRo_HIOParam const m;
 };
+
+#if DEBUG
+class daNpc_ZelRo_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_ZelRo_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_ZelRo_HIOParam m;
+};
+
+#define NPC_ZELRO_HIO_CLASS daNpc_ZelRo_HIO_c
+#else
+#define NPC_ZELRO_HIO_CLASS daNpc_ZelRo_Param_c
+#endif
 
 class daNpc_ZelRo_c : public daNpcT_c {
 public:
@@ -138,7 +151,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ daNpc_ZelRo_HIO_c* mHIO;
+    /* 0xE40 */ NPC_ZELRO_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 mType;
     /* 0xF84 */ actionFunc mNextAction;

--- a/include/d/actor/d_a_npc_zelda.h
+++ b/include/d/actor/d_a_npc_zelda.h
@@ -3,8 +3,36 @@
 
 #include "d/actor/d_a_npc.h"
 
-class daNpc_Zelda_HIO_c;
-class daNpc_Zelda_c;
+class daNpc_Zelda_HIOParam {
+public:
+    /* 0x00 */ daNpcT_HIOParam common;
+};
+
+STATIC_ASSERT(sizeof(daNpc_Zelda_HIOParam) == 0x8c);
+
+class daNpc_Zelda_Param_c {
+public:
+    virtual ~daNpc_Zelda_Param_c() {}
+
+    static const daNpc_Zelda_HIOParam m;
+};
+
+#if DEBUG
+class daNpc_Zelda_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_Zelda_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext* ctx);
+
+    daNpc_Zelda_HIOParam m;
+};
+
+#define NPC_ZELDA_HIO_CLASS daNpc_Zelda_HIO_c
+#else
+#define NPC_ZELDA_HIO_CLASS daNpc_Zelda_Param_c
+#endif
 
 /**
  * @ingroup actors-npcs
@@ -76,7 +104,7 @@ public:
     static cutFunc mCutList[1];
 
 private:
-    /* 0xE40 */ daNpc_Zelda_HIO_c* mHIO;
+    /* 0xE40 */ NPC_ZELDA_HIO_CLASS* mpHIO;
     /* 0xE44 */ dCcD_Cyl mCyl;
     /* 0xF80 */ u8 field_0xf80;
     /* 0xF84 */ actionFunc mAction1;
@@ -85,35 +113,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_Zelda_c) == 0xfa0);
-
-class daNpc_Zelda_HIOParam {
-public:
-    /* 0x00 */ daNpcT_HIOParam common;
-};
-
-STATIC_ASSERT(sizeof(daNpc_Zelda_HIOParam) == 0x8c);
-
-class daNpc_Zelda_Param_c {
-public:
-    virtual ~daNpc_Zelda_Param_c() {}
-
-    static const daNpc_Zelda_HIOParam m;
-};
-
-class daNpc_Zelda_HIO_c
-#if DEBUG
-    : public mDoHIO_entry_c
-#endif
-{
-public:
-    daNpc_Zelda_HIO_c();
-
-    void genMessage(JORMContext* ctx);
-    void listenPropertyEvent(const JORPropertyEvent*);
-
-#if DEBUG
-    daNpc_Zelda_HIOParam param;
-#endif
-};
 
 #endif /* D_A_NPC_ZELDA_H */

--- a/include/d/actor/d_a_npc_zra.h
+++ b/include/d/actor/d_a_npc_zra.h
@@ -4,15 +4,53 @@
 #include "d/actor/d_a_npc4.h"
 #include "d/d_particle_copoly.h"
 
-class daNpc_zrA_HIO_c;
-/**
- * @ingroup actors-npcs
- * @class daNpc_zrA_Path_c
- * @brief Zora (Adult)
- *
- * @details
- *
-*/
+struct daNpc_zrA_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+    /* 0x6C */ f32 mSwimSpeed;
+    /* 0x70 */ f32 mMinSwimSpeedScale;
+    /* 0x74 */ s16 mSwimAngleSpeed;
+    /* 0x78 */ f32 mSwimAnmRate;
+    /* 0x7C */ f32 field_0x7c;
+    /* 0x80 */ f32 field_0x80;
+    /* 0x84 */ f32 mMaxScaleFactor;
+    /* 0x88 */ f32 mMinDepth;
+    /* 0x8C */ f32 field_0x8c;
+    /* 0x90 */ f32 field_0x90;
+    /* 0x94 */ f32 mWalkSpeed;
+    /* 0x98 */ s16 mWalkAngleSpeed;
+    /* 0x9A */ s16 mWalkAngleScale;
+    /* 0x9C */ f32 mWalkAnmRate;
+    /* 0xA0 */ f32 field_0xa0;
+    /* 0xA4 */ f32 field_0xa4;
+    /* 0xA8 */ f32 field_0xa8;
+    /* 0xAC */ f32 field_0xac;
+};
+
+STATIC_ASSERT(sizeof(daNpc_zrA_HIOParam) == 0xB0);
+
+class daNpc_zrA_Param_c {
+public:
+    virtual ~daNpc_zrA_Param_c() {}
+
+    static daNpc_zrA_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_zrA_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_zrA_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_zrA_HIOParam m;
+};
+
+#define NPC_ZRA_HIO_CLASS daNpc_zrA_HIO_c
+#else
+#define NPC_ZRA_HIO_CLASS daNpc_zrA_Param_c
+#endif
 
 class daNpc_zrA_Path_c : public daNpcF_Path_c {
 public:
@@ -28,6 +66,14 @@ public:
 
 STATIC_ASSERT(sizeof(daNpc_zrA_Path_c) == 0x630);
 
+/**
+ * @ingroup actors-npcs
+ * @class daNpc_zrA_Path_c
+ * @brief Zora (Adult)
+ *
+ * @details
+ *
+*/
 class daNpc_zrA_c : public daNpcF_c {
 public:
     typedef BOOL (daNpc_zrA_c::*ActionFn)(void*);
@@ -334,7 +380,7 @@ public:
     /* 0x1248 */ daNpcF_Lookat_c mLookat;
     /* 0x12E4 */ dPaPo_c mPaPo;
     /* 0x131C */ daNpcF_ActorMngr_c mActorMngr[3];
-    /* 0x1334 */ daNpc_zrA_HIO_c* mpHIO;
+    /* 0x1334 */ NPC_ZRA_HIO_CLASS* mpHIO;
     /* 0x1338 */ dCcD_Cyl mCcCyl;
     /* 0x1474 */ ActionFn mpNextActionFn;
     /* 0x1480 */ ActionFn mpActionFn;
@@ -402,67 +448,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daNpc_zrA_c) == 0x15C4);
-
-class daNpc_zrA_Param_c {
-public:
-    struct param {
-        /* 0x00 */ f32 mAttnOffsetY;
-        /* 0x04 */ f32 mGravity;
-        /* 0x08 */ f32 mScale;
-        /* 0x0C */ f32 mShadowDepth;
-        /* 0x10 */ f32 mCcWeight;
-        /* 0x14 */ f32 mCylH;
-        /* 0x18 */ f32 mWallH;
-        /* 0x1C */ f32 mWallR;
-        /* 0x20 */ f32 mBodyUpAngle;
-        /* 0x24 */ f32 mBodyDownAngle;
-        /* 0x28 */ f32 mBodyLeftAngle;
-        /* 0x2C */ f32 mBodyRightAngle;
-        /* 0x30 */ f32 mHeadUpAngle;
-        /* 0x34 */ f32 mHeadDownAngle;
-        /* 0x38 */ f32 mHeadLeftAngle;
-        /* 0x3C */ f32 mHeadRightAngle;
-        /* 0x40 */ f32 mNeckAngleScl;
-        /* 0x44 */ f32 mMorfFrames;
-        /* 0x48 */ s16 mSpeakDistIdx;
-        /* 0x4A */ s16 mSpeakAngleIdx;
-        /* 0x4C */ s16 mTalkDistIdx;
-        /* 0x4E */ s16 mTalkAngleIdx;
-        /* 0x50 */ f32 mAttnFovY;
-        /* 0x54 */ f32 mAttnRadius;
-        /* 0x58 */ f32 mAttnUpperY;
-        /* 0x5C */ f32 mAttnLowerY;
-        /* 0x60 */ s16 field_0x60;
-        /* 0x62 */ s16 mDamageTimer;
-        /* 0x64 */ s16 mTestExpression;
-        /* 0x66 */ s16 mTestMotion;
-        /* 0x68 */ s16 mTestLookMode;
-        /* 0x6A */ bool mTest;
-        /* 0x6C */ f32 mSwimSpeed;
-        /* 0x70 */ f32 mMinSwimSpeedScale;
-        /* 0x74 */ s16 mSwimAngleSpeed;
-        /* 0x78 */ f32 mSwimAnmRate;
-        /* 0x7C */ f32 field_0x7c;
-        /* 0x80 */ f32 field_0x80;
-        /* 0x84 */ f32 mMaxScaleFactor;
-        /* 0x88 */ f32 mMinDepth;
-        /* 0x8C */ f32 field_0x8c;
-        /* 0x90 */ f32 field_0x90;
-        /* 0x94 */ f32 mWalkSpeed;
-        /* 0x98 */ s16 mWalkAngleSpeed;
-        /* 0x9A */ s16 mWalkAngleScale;
-        /* 0x9C */ f32 mWalkAnmRate;
-        /* 0xA0 */ f32 field_0xa0;
-        /* 0xA4 */ f32 field_0xa4;
-        /* 0xA8 */ f32 field_0xa8;
-        /* 0xAC */ f32 field_0xac;
-     };
-
-    virtual ~daNpc_zrA_Param_c() {}
-
-    static param const m;
-};
-
-STATIC_ASSERT(sizeof(daNpc_zrA_Param_c::param) == 0xB0);
 
 #endif /* D_A_NPC_ZRA_H */

--- a/include/d/actor/d_a_npc_zrc.h
+++ b/include/d/actor/d_a_npc_zrc.h
@@ -3,6 +3,39 @@
 
 #include "d/actor/d_a_npc4.h"
 
+
+struct daNpc_zrC_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+    /* 0x6C */ f32 field_0x6c;
+    /* 0x70 */ f32 field_0x70;
+};
+
+STATIC_ASSERT(sizeof(daNpc_zrC_HIOParam) == 0x74);
+
+class daNpc_zrC_Param_c {
+public:
+    virtual ~daNpc_zrC_Param_c() {}
+
+    static daNpc_zrC_HIOParam const m;
+};
+
+#if DEBUG
+class daNpc_zrC_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_zrC_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_zrC_HIOParam m;
+};
+
+#define NPC_ZRC_HIO_CLASS daNpc_zrC_HIO_c
+#else
+#define NPC_ZRC_HIO_CLASS daNpc_zrC_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_zrC_c
@@ -68,7 +101,7 @@ private:
     /* 0xBD8 */ daNpcF_MatAnm_c* mpMatAnm;
     /* 0xBDC */ daNpcF_Lookat_c mLookat;
     /* 0xC78 */ daNpcF_ActorMngr_c mActorMngr[3];
-    /* 0xC90 */ u8 field_0xc90[4];
+    /* 0xC90 */ NPC_ZRC_HIO_CLASS* mpHIO;
     /* 0xC94 */ dCcD_Cyl mCcCyl;
     /* 0xDD0 */ ActionFn mpNextActionFn;
     /* 0xDDC */ ActionFn mpActionFn;
@@ -166,51 +199,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_zrC_c) == 0xe3c);
-
-class daNpc_zrC_Param_c {
-public:
-    struct param {
-        /* 0x00 */ f32 mAttnOffsetY;
-        /* 0x04 */ f32 mGravity;
-        /* 0x08 */ f32 mScale;
-        /* 0x0C */ f32 mShadowDepth;
-        /* 0x10 */ f32 mCcWeight;
-        /* 0x14 */ f32 mCylH;
-        /* 0x18 */ f32 mWallH;
-        /* 0x1C */ f32 mWallR;
-        /* 0x20 */ f32 mBodyUpAngle;
-        /* 0x24 */ f32 mBodyDownAngle;
-        /* 0x28 */ f32 mBodyLeftAngle;
-        /* 0x2C */ f32 mBodyRightAngle;
-        /* 0x30 */ f32 mHeadUpAngle;
-        /* 0x34 */ f32 mHeadDownAngle;
-        /* 0x38 */ f32 mHeadLeftAngle;
-        /* 0x3C */ f32 mHeadRightAngle;
-        /* 0x40 */ f32 mNeckAngleScl;
-        /* 0x44 */ f32 mMorfFrames;
-        /* 0x48 */ s16 mSpeakDistIdx;
-        /* 0x4A */ s16 mSpeakAngleIdx;
-        /* 0x4C */ s16 mTalkDistIdx;
-        /* 0x4E */ s16 mTalkAngleIdx;
-        /* 0x50 */ f32 mAttnFovY;
-        /* 0x54 */ f32 mAttnRadius;
-        /* 0x58 */ f32 mAttnUpperY;
-        /* 0x5C */ f32 mAttnLowerY;
-        /* 0x60 */ s16 field_0x60;
-        /* 0x62 */ s16 mDamageTimer;
-        /* 0x64 */ s16 mTestExpression;
-        /* 0x66 */ s16 mTestMotion;
-        /* 0x68 */ s16 mTestLookMode;
-        /* 0x6A */ bool mTest;
-        /* 0x6C */ f32 field_0x6c;
-        /* 0x70 */ f32 field_0x70;
-    };
-
-    virtual ~daNpc_zrC_Param_c() {}
-
-    static param const m;
-};
-
-STATIC_ASSERT(sizeof(daNpc_zrC_Param_c::param) == 0x74);
 
 #endif /* D_A_NPC_ZRC_H */

--- a/include/d/actor/d_a_npc_zrz.h
+++ b/include/d/actor/d_a_npc_zrz.h
@@ -6,6 +6,42 @@
 class daGraveStone_c;
 class daObjZraRock_c;
 
+struct daNpc_zrZ_HIOParam {
+    /* 0x00 */ daNpcF_HIOParam common;
+    /* 0x6C */ f32 field_0x6c;
+    /* 0x70 */ f32 mFollowDst;
+    /* 0x74 */ f32 mRestoreDst;
+    /* 0x78 */ f32 mMaxSpeed;
+    /* 0x7C */ f32 mClothesGetDst;
+    /* 0x80 */ f32 field_0x80;
+};
+
+class daNpc_zrZ_Param_c {
+public:
+    virtual ~daNpc_zrZ_Param_c() {}
+
+    static daNpc_zrZ_HIOParam const m;
+};
+
+STATIC_ASSERT(sizeof(daNpc_zrZ_HIOParam) == 0x84);
+
+#if DEBUG
+class daNpc_zrZ_HIO_c : public mDoHIO_entry_c {
+public:
+    daNpc_zrZ_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daNpc_zrZ_HIOParam m;
+};
+
+#define NPC_ZRZ_HIO_CLASS daNpc_zrZ_HIO_c
+#else
+#define NPC_ZRZ_HIO_CLASS daNpc_zrZ_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daNpc_zrZ_c
@@ -85,7 +121,7 @@ private:
     /* 0x0BE4 */ daNpcF_Lookat_c mLookat;
     /* 0x0C80 */ daNpcF_ActorMngr_c mActorMngr[2];
     /* 0x0C90 */ daNpcF_Path_c mPath;
-    /* 0x12C0 */ u8 field_0x12c0[4];
+    /* 0x12C0 */ NPC_ZRZ_HIO_CLASS* mpHIO;
     /* 0x12C4 */ dCcD_Cyl mCcCyl;
     /* 0x1400 */ ActionFn mpNextActionFn;
     /* 0x140C */ ActionFn mpActionFn;
@@ -165,55 +201,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daNpc_zrZ_c) == 0x14c8);
-
-class daNpc_zrZ_Param_c {
-public:
-    struct param {
-        /* 0x00 */ f32 mAttnOffsetY;
-        /* 0x04 */ f32 mGravity;
-        /* 0x08 */ f32 mScale;
-        /* 0x0C */ f32 mShadowDepth;
-        /* 0x10 */ f32 mCcWeight;
-        /* 0x14 */ f32 mCylH;
-        /* 0x18 */ f32 mWallH;
-        /* 0x1C */ f32 mWallR;
-        /* 0x20 */ f32 mBodyUpAngle;
-        /* 0x24 */ f32 mBodyDownAngle;
-        /* 0x28 */ f32 mBodyLeftAngle;
-        /* 0x2C */ f32 mBodyRightAngle;
-        /* 0x30 */ f32 mHeadUpAngle;
-        /* 0x34 */ f32 mHeadDownAngle;
-        /* 0x38 */ f32 mHeadLeftAngle;
-        /* 0x3C */ f32 mHeadRightAngle;
-        /* 0x40 */ f32 mNeckAngleScl;
-        /* 0x44 */ f32 mMorfFrames;
-        /* 0x48 */ s16 mSpeakDistIdx;
-        /* 0x4A */ s16 mSpeakAngleIdx;
-        /* 0x4C */ s16 mTalkDistIdx;
-        /* 0x4E */ s16 mTalkAngleIdx;
-        /* 0x50 */ f32 mAttnFovY;
-        /* 0x54 */ f32 mAttnRadius;
-        /* 0x58 */ f32 mAttnUpperY;
-        /* 0x5C */ f32 mAttnLowerY;
-        /* 0x60 */ s16 field_0x60;
-        /* 0x62 */ s16 mDamageTimer;
-        /* 0x64 */ s16 mTestExpression;
-        /* 0x66 */ s16 mTestMotion;
-        /* 0x68 */ s16 mTestLookMode;
-        /* 0x6A */ bool mTest;
-        /* 0x6C */ f32 field_0x6c;
-        /* 0x70 */ f32 mFollowDst;
-        /* 0x74 */ f32 mRestoreDst;
-        /* 0x78 */ f32 mMaxSpeed;
-        /* 0x7C */ f32 mClothesGetDst;
-        /* 0x80 */ f32 field_0x80;
-    };
-
-    virtual ~daNpc_zrZ_Param_c() {}
-
-    static param const m;
-};
-
-STATIC_ASSERT(sizeof(daNpc_zrZ_Param_c::param) == 0x84);
 
 #endif /* D_A_NPC_ZRZ_H */

--- a/include/d/actor/d_a_obj_automata.h
+++ b/include/d/actor/d_a_obj_automata.h
@@ -5,6 +5,36 @@
 #include "d/d_cc_d.h"
 #include "f_op/f_op_actor.h"
 
+struct daObj_AutoMata_HIOParam {
+    f32 field_0x0;
+    f32 field_0x4;
+    f32 field_0x8;
+};
+
+class daObj_AutoMata_Param_c {
+public:
+    virtual ~daObj_AutoMata_Param_c() {}
+
+    static daObj_AutoMata_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_AutoMata_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_AutoMata_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_AutoMata_HIOParam m;
+};
+
+#define OBJ_AUTOMATA_HIO_CLASS daObj_AutoMata_HIO_c
+#else
+#define OBJ_AUTOMATA_HIO_CLASS daObj_AutoMata_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_AutoMata_c
@@ -15,7 +45,7 @@
  */
 class daObj_AutoMata_c : public fopAc_ac_c {
 private:
-    /* 0x568 */ int field_0x568;
+    /* 0x568 */ OBJ_AUTOMATA_HIO_CLASS* mpHIO;
     /* 0x56C */ mDoExt_McaMorfSO* mpMorf;
     /* 0x570 */ Z2Creature mCreature;
     /* 0x600 */ mDoExt_btkAnm mBtk;
@@ -57,12 +87,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_AutoMata_c) == 0xb38);
-
-class daObj_AutoMata_Param_c {
-public:
-    virtual ~daObj_AutoMata_Param_c() {}
-
-    static f32 const m[3];
-};
 
 #endif /* D_A_OBJ_AUTOMATA_H */

--- a/include/d/actor/d_a_obj_bed.h
+++ b/include/d/actor/d_a_obj_bed.h
@@ -8,6 +8,36 @@
 
 class dBgW;
 
+struct daObj_Bed_HIOParam {
+    /* 0x0 */ f32 field_0x0;
+    /* 0x4 */ f32 field_0x4;
+    /* 0x8 */ f32 field_0x8;
+    /* 0xC */ f32 field_0xc;
+};
+
+class daObj_Bed_Param_c {
+public:
+    virtual ~daObj_Bed_Param_c() {}
+
+    static daObj_Bed_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_Bed_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Bed_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Bed_HIOParam m;
+};
+#define OBJ_BED_HIO_CLASS daObj_Bed_HIO_c
+#else
+#define OBJ_BED_HIO_CLASS daObj_Bed_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Bed_c
@@ -18,7 +48,7 @@ class dBgW;
  */
 class daObj_Bed_c : public fopAc_ac_c {
 public:
-    /* 0x568 */ u8 field_0x568[4];
+    /* 0x568 */ OBJ_BED_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class mPhase;
     /* 0x574 */ J3DModel* mpModel;
     /* 0x578 */ dBgS_ObjAcch mAcch;
@@ -49,19 +79,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_Bed_c) == 0x844);
-
-class daObj_Bed_Param_c {
-public:
-    virtual ~daObj_Bed_Param_c() {}
-
-    struct params {
-        /* 0x0 */ f32 field_0x0;
-        /* 0x4 */ f32 field_0x4;
-        /* 0x8 */ f32 field_0x8;
-        /* 0xC */ f32 field_0xc;
-    };
-
-    static daObj_Bed_Param_c::params const m;
-};
 
 #endif /* D_A_OBJ_BED_H */

--- a/include/d/actor/d_a_obj_boumato.h
+++ b/include/d/actor/d_a_obj_boumato.h
@@ -7,6 +7,40 @@
 #include "f_op/f_op_actor_mng.h"
 #include "d/d_cc_d.h"
 
+struct daObj_BouMato_HIOParam {
+    /* 0x00 */ f32 field_0x00;
+    /* 0x04 */ f32 field_0x04;
+    /* 0x08 */ f32 field_0x08;
+    /* 0x0C */ f32 field_0x0c;
+    /* 0x10 */ f32 field_0x10;
+    /* 0x14 */ f32 field_0x14;
+    /* 0x18 */ f32 field_0x18;
+};
+
+class daObj_BouMato_Param_c {
+public:
+    virtual ~daObj_BouMato_Param_c() {}
+
+    static daObj_BouMato_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_BouMato_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_BouMato_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_BouMato_HIOParam m;
+};
+
+#define OBJ_BOUMATO_HIO_CLASS daObj_BouMato_HIO_c
+#else
+#define OBJ_BOUMATO_HIO_CLASS daObj_BouMato_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_BouMato_c
@@ -17,7 +51,7 @@
  */
 class daObj_BouMato_c : public fopAc_ac_c {
 private:
-    /* 0x568 */ int field_0x568;
+    /* 0x568 */ OBJ_BOUMATO_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class mPhase;
     /* 0x574 */ J3DModel* mModel;
     /* 0x578 */ dBgS_ObjAcch mAcch;
@@ -92,13 +126,6 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_BouMato_c) == 0xa40);
-
-class daObj_BouMato_Param_c {
-public:
-    virtual ~daObj_BouMato_Param_c() {}
-
-    static f32 const m[7];
-};
 
 
 #endif /* D_A_OBJ_BOUMATO_H */

--- a/include/d/actor/d_a_obj_kago.h
+++ b/include/d/actor/d_a_obj_kago.h
@@ -6,6 +6,44 @@
 #include "d/d_cc_d.h"
 #include "f_op/f_op_actor_mng.h"
 
+struct daObj_Kago_HIOParam {
+    /* 0x00 */ f32 field_0x00;
+    /* 0x04 */ f32 mGravity;
+    /* 0x08 */ f32 field_0x08;
+    /* 0x0C */ f32 field_0x0c;
+    /* 0x10 */ f32 mWeight;
+    /* 0x14 */ f32 field_0x14;
+    /* 0x18 */ f32 mWallH;
+    /* 0x1C */ f32 mWallR;
+    /* 0x20 */ f32 field_0x20;
+    /* 0x24 */ f32 field_0x24;
+    /* 0x28 */ f32 field_0x28;
+};
+
+class daObj_Kago_Param_c {
+public:
+    virtual ~daObj_Kago_Param_c() {}
+
+    static const daObj_Kago_HIOParam m;
+};
+
+#if DEBUG
+class daObj_Kago_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Kago_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Kago_HIOParam m;
+};
+
+#define OBJ_KAGO_HIO_CLASS daObj_Kago_HIO_c
+#else
+#define OBJ_KAGO_HIO_CLASS daObj_Kago_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Kago_c
@@ -88,7 +126,7 @@ public:
     }
     
 private:
-    /* 0x568 */ u8 field_0x568[0x56c - 0x568];
+    /* 0x568 */ OBJ_KAGO_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class mPhase;
     /* 0x574 */ J3DModel* field_0x574;
     /* 0x578 */ dBgS_ObjAcch mObjAcch;
@@ -138,26 +176,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daObj_Kago_c) == 0xba8);
-
-class daObj_Kago_Param_c {
-public:
-    virtual ~daObj_Kago_Param_c() {}
-
-    struct Data {
-        /* 0x00 */ f32 field_0x00;
-        /* 0x04 */ f32 mGravity;
-        /* 0x08 */ f32 field_0x08;
-        /* 0x0C */ f32 field_0x0c;
-        /* 0x10 */ f32 mWeight;
-        /* 0x14 */ f32 field_0x14;
-        /* 0x18 */ f32 mWallH;
-        /* 0x1C */ f32 mWallR;
-        /* 0x20 */ f32 field_0x20;
-        /* 0x24 */ f32 field_0x24;
-        /* 0x28 */ f32 field_0x28;
-    };
-    static const Data m;
-};
-
 
 #endif /* D_A_OBJ_KAGO_H */

--- a/include/d/actor/d_a_obj_kbacket.h
+++ b/include/d/actor/d_a_obj_kbacket.h
@@ -8,10 +8,10 @@
 
 struct daObj_KBacket_HIOParam
 {
-    f32 field_0x0;
-    f32 field_0x4;
-    f32 field_0x8;
-    f32 field_0xc;
+    f32 field_0x00;
+    f32 field_0x04;
+    f32 field_0x08;
+    f32 field_0x0c;
     f32 field_0x10;
     f32 field_0x14;
     f32 field_0x18;
@@ -21,25 +21,29 @@ struct daObj_KBacket_HIOParam
     f32 field_0x28;
 };
 
-class daObj_KBacket_HIO_c
-#if DEBUG
-    : public mDoHIO_entry_c
-#endif
-{
-public:
-#if DEBUG
-    void genMessage(JORMContext*);
-
-    daObj_KBacket_HIOParam param;
-#endif
-};
-
 class daObj_KBacket_Param_c {
 public:
     virtual ~daObj_KBacket_Param_c() {}
 
     static const daObj_KBacket_HIOParam m;
 };
+
+#if DEBUG
+class daObj_KBacket_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_KBacket_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_KBacket_HIOParam m;
+};
+
+#define OBJ_KBACKET_HIO_CLASS daObj_KBacket_HIO_c
+#else
+#define OBJ_KBACKET_HIO_CLASS daObj_KBacket_Param_c
+#endif
 
 /**
  * @ingroup actors-objects
@@ -51,7 +55,7 @@ public:
  */
 class daObj_KBacket_c : public fopAc_ac_c {
 public:
-    /* 0x568 */ daObj_KBacket_HIO_c* mHIO;
+    /* 0x568 */ OBJ_KBACKET_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class field_0x56c;
     /* 0x574 */ J3DModel* mpModel;
     /* 0x578 */ dBgS_ObjAcch mObjAcch;

--- a/include/d/actor/d_a_obj_mie.h
+++ b/include/d/actor/d_a_obj_mie.h
@@ -20,26 +20,30 @@ struct daObj_Mie_HIOParam {
     /* 0x28 */ f32 floating_offset;
 };
 
-struct daObj_Mie_Param_c {
+class daObj_Mie_Param_c {
+public:
     virtual ~daObj_Mie_Param_c() {}
+
     static const daObj_Mie_HIOParam m;
 };
 
-class daObj_Mie_HIO_c 
 #if DEBUG
-: public mDoHIO_entry_c
-#endif
+class daObj_Mie_HIO_c : public mDoHIO_entry_c
 {
 public:
-    daObj_Mie_HIO_c() {
-        mParams = daObj_Mie_Param_c::m;
-    }
+    daObj_Mie_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
 
     void genMessage(JORMContext*);
-    virtual ~daObj_Mie_HIO_c() {}
 
-    daObj_Mie_HIOParam mParams;
+    daObj_Mie_HIOParam m;
 };
+
+#define OBJ_MIE_HIO_CLASS daObj_Mie_HIO_c
+#else
+#define OBJ_MIE_HIO_CLASS daObj_Mie_Param_c
+#endif
 
 /**
  * @ingroup actors-objects
@@ -51,7 +55,7 @@ public:
  */
 class daObj_Mie_c : public fopAc_ac_c {
 private:
-    /* 0x568 */ daObj_Mie_HIO_c* mHIO;
+    /* 0x568 */ OBJ_MIE_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class mPhase;
     /* 0x574 */ J3DModel* mModel;
     /* 0x578 */ dBgS_ObjAcch mAcch;

--- a/include/d/actor/d_a_obj_nougu.h
+++ b/include/d/actor/d_a_obj_nougu.h
@@ -5,6 +5,37 @@
 #include "d/d_bg_s_acch.h"
 #include "d/d_cc_d.h"
 
+struct daObj_Nougu_HIOParam {
+    /* 0x0 */ f32 attention_offset;
+    /* 0x4 */ f32 gravity;
+    /* 0x8 */ f32 scale;
+    /* 0xC */ f32 shadow_size;
+};
+
+class daObj_Nougu_Param_c {
+public:
+    virtual ~daObj_Nougu_Param_c() {}
+
+    static const daObj_Nougu_HIOParam m;
+};
+
+#if DEBUG
+class daObj_Nougu_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Nougu_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Nougu_HIOParam m;
+};
+
+#define OBJ_NOUGU_HIO_CLASS daObj_Nougu_HIO_c
+#else
+#define OBJ_NOUGU_HIO_CLASS daObj_Nougu_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Nougu_c
@@ -15,7 +46,7 @@
  */
 class daObj_Nougu_c : public fopAc_ac_c {
 public:
-    /* 0x568 */ u8 field_0x568[0x56C - 0x568];
+    /* 0x568 */ OBJ_NOUGU_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class mPhase;
     /* 0x574 */ J3DModel* mpModel;
     /* 0x578 */ dBgS_ObjAcch mAcch;
@@ -46,20 +77,6 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_Nougu_c) == 0xe30);
-
-struct daObj_Nougu_HIOParam {
-    /* 0x0 */ f32 attention_offset;
-    /* 0x4 */ f32 gravity;
-    /* 0x8 */ f32 scale;
-    /* 0xC */ f32 shadow_size;
-};
-
-class daObj_Nougu_Param_c {
-public:
-    virtual ~daObj_Nougu_Param_c() {}
-
-    static const daObj_Nougu_HIOParam m;
-};
 
 
 #endif /* D_A_OBJ_NOUGU_H */

--- a/include/d/actor/d_a_obj_pleaf.h
+++ b/include/d/actor/d_a_obj_pleaf.h
@@ -4,6 +4,37 @@
 #include "d/d_com_inf_game.h"
 #include "f_op/f_op_actor_mng.h"
 
+struct daObj_Pleaf_HIOParam {
+    f32 field_0x0;
+    f32 field_0x4;
+    f32 field_0x8;
+    f32 field_0xc;
+};
+
+class daObj_Pleaf_Param_c {
+public:
+    virtual ~daObj_Pleaf_Param_c() {}
+
+    static daObj_Pleaf_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_Pleaf_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Pleaf_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Pleaf_HIOParam m;
+};
+
+#define OBJ_PLEAF_HIO_CLASS daObj_Pleaf_HIO_c
+#else
+#define OBJ_PLEAF_HIO_CLASS daObj_Pleaf_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Pleaf_c
@@ -14,7 +45,7 @@
  */
 class daObj_Pleaf_c : public fopAc_ac_c {
 private:
-    /* 0x568*/ u8 field_0x568[0x56C - 0x568];
+    /* 0x568 */ OBJ_PLEAF_HIO_CLASS* mpHIO;
     /* 0x56C */ request_of_phase_process_class mPhaseReq;
     /* 0x574 */ J3DModel* mpModel;
     /* 0x578 */ dBgS_ObjAcch mObjAcch;
@@ -44,19 +75,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_Pleaf_c) == 0x950);
-
-class daObj_Pleaf_Param_c {
-public:
-    virtual ~daObj_Pleaf_Param_c() {}
-
-    struct params {
-        f32 field_0x0;
-        f32 field_0x4;
-        f32 field_0x8;
-        f32 field_0xc;
-    };
-
-    static daObj_Pleaf_Param_c::params const m;
-};
 
 #endif /* D_A_OBJ_PLEAF_H */

--- a/include/d/actor/d_a_obj_sekidoor.h
+++ b/include/d/actor/d_a_obj_sekidoor.h
@@ -6,6 +6,34 @@
 #include "d/d_com_inf_game.h"
 #include "f_op/f_op_actor_mng.h"
 
+struct daObj_SekiDoor_HIOParam {
+    /* 0x00 */ u8 field_0x0;
+};
+
+class daObj_SekiDoor_Param_c {
+public:
+    virtual ~daObj_SekiDoor_Param_c() {};
+
+    static daObj_SekiDoor_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_SekiDoor_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_SekiDoor_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_SekiDoor_HIOParam m;
+};
+
+#define OBJ_SEKIDOOR_HIO_CLASS daObj_SekiDoor_HIO_c
+#else
+#define OBJ_SEKIDOOR_HIO_CLASS daObj_SekiDoor_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_SekiDoor_c
@@ -32,7 +60,7 @@ public:
     bool chkDestroy() { return (mDestroyed == true); }
 
 private:
-    /* 0x5A0 */ s32 field_0x5A0;
+    /* 0x5A0 */ OBJ_SEKIDOOR_HIO_CLASS* mpHIO;
     /* 0x5A4 */ request_of_phase_process_class mPhaseReq;
     /* 0x5AC */ J3DModel* mpModel;
     /* 0x5B0 */ csXyz mRotation;
@@ -46,13 +74,6 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daObj_SekiDoor_c) == 0x5d8);
-
-class daObj_SekiDoor_Param_c {
-public:
-    virtual ~daObj_SekiDoor_Param_c() {};
-
-    static u8 const m;
-};
 
 
 #endif /* D_A_OBJ_SEKIDOOR_H */

--- a/include/d/actor/d_a_obj_sekizo.h
+++ b/include/d/actor/d_a_obj_sekizo.h
@@ -4,6 +4,32 @@
 #include "d/d_bg_s_movebg_actor.h"
 #include "f_op/f_op_actor_mng.h"
 
+struct daObj_Sekizo_HIOParam {
+};
+
+class daObj_Sekizo_Param_c {
+public:
+    virtual ~daObj_Sekizo_Param_c() {}
+    static daObj_Sekizo_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_Sekizo_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Sekizo_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Sekizo_HIOParam m;
+};
+
+#define OBJ_SEKIZO_HIO_CLASS daObj_Sekizo_HIO_c
+#else
+#define OBJ_SEKIZO_HIO_CLASS daObj_Sekizo_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Sekizo_c
@@ -25,7 +51,7 @@ public:
     void setBaseMtx();
 
 private:
-    /* 0x5A0 */ u32 field_0x5a0;
+    /* 0x5A0 */ OBJ_SEKIZO_HIO_CLASS* mpHIO;
     /* 0x5A4 */ request_of_phase_process_class mPhaseReq;
     /* 0x5AC */ J3DModel* mpModel;
     /* 0x5B0 */ u8 field_0x5b0;
@@ -34,10 +60,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daObj_Sekizo_c) == 0x5B4);
-
-class daObj_Sekizo_Param_c {
-public:
-    virtual ~daObj_Sekizo_Param_c() {}
-};
 
 #endif /* D_A_OBJ_SEKIZO_H */

--- a/include/d/actor/d_a_obj_sekizoa.h
+++ b/include/d/actor/d_a_obj_sekizoa.h
@@ -4,6 +4,79 @@
 #include "d/actor/d_a_npc.h"
 #include "d/actor/d_a_tag_evtarea.h"
 
+//TODO: this might be the same struct that's used in d_a_peru's HIO
+struct daObj_Sekizoa_HIOParam_inner {
+    /* 0x00 */ f32 field_0x00;
+    /* 0x04 */ f32 field_0x04;
+    /* 0x08 */ f32 field_0x08;
+    /* 0x0C */ f32 field_0x0C;
+    /* 0x10 */ f32 field_0x10;
+    /* 0x14 */ f32 field_0x14;
+    /* 0x18 */ f32 field_0x18;
+    /* 0x1C */ f32 field_0x1C;
+    /* 0x20 */ f32 field_0x20;
+    /* 0x24 */ f32 field_0x24;
+    /* 0x28 */ f32 field_0x28;
+    /* 0x2C */ f32 field_0x2C;
+    /* 0x30 */ f32 field_0x30;
+    /* 0x34 */ f32 field_0x34;
+    /* 0x38 */ f32 field_0x38;
+    /* 0x3C */ f32 field_0x3C;
+    /* 0x40 */ f32 field_0x40;
+    /* 0x44 */ f32 field_0x44;
+    /* 0x48 */ s16 field_0x48;
+    /* 0x4A */ s16 field_0x4A;
+    /* 0x4C */ s16 field_0x4C;
+    /* 0x4E */ s16 field_0x4E;
+    /* 0x50 */ f32 field_0x50;
+    /* 0x54 */ f32 field_0x54;
+    /* 0x58 */ f32 field_0x58;
+    /* 0x5C */ f32 field_0x5C;
+    /* 0x60 */ int field_0x60;
+    /* 0x64 */ f32 field_0x64;
+    /* 0x68 */ f32 field_0x68;
+    /* 0x6C */ f32 field_0x6C;
+    /* 0x70 */ f32 field_0x70;
+    /* 0x74 */ f32 field_0x74;
+    /* 0x78 */ f32 field_0x78;
+    /* 0x7C */ f32 field_0x7C;
+    /* 0x80 */ f32 field_0x80;
+    /* 0x84 */ f32 field_0x84;
+    /* 0x88 */ f32 field_0x88;
+};
+
+struct daObj_Sekizoa_HIOParam {
+    /* 0x00 */ daObj_Sekizoa_HIOParam_inner inner;
+    /* 0x8C */ f32 field_0x8C;
+    /* 0x90 */ f32 field_0x90;
+    /* 0x94 */ f32 field_0x94;
+    /* 0x98 */ s16 field_0x98;
+};
+
+class daObj_Sekizoa_Param_c {
+public:
+    virtual ~daObj_Sekizoa_Param_c() {}
+
+    static daObj_Sekizoa_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_Sekizoa_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Sekizoa_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Sekizoa_HIOParam m;
+};
+
+#define OBJ_SEKIZOA_HIO_CLASS daObj_Sekizoa_HIO_c
+#else
+#define OBJ_SEKIZOA_HIO_CLASS daObj_Sekizoa_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Sekizoa_c
@@ -211,7 +284,7 @@ public:
 
     /* 0x0E40 */ mDoExt_McaMorfSO* mpMcaMorf;
     /* 0x0E44 */ mDoExt_invisibleModel mInvModel;
-    /* 0x0E4C */ u8 field_0x0E4C[4];  // Padding
+    /* 0x0E4C */ OBJ_SEKIZOA_HIO_CLASS* mpHIO;
     /* 0x0E50 */ dCcD_Cyl mCyl;
     /* 0x0F8C */ dCcD_Cyl mCyl2;
     /* 0x10C8 */ u8 mType;
@@ -248,56 +321,6 @@ public:
     /* 0x117A */ u8 mReverseStatues;  // Flag if statue B is on goal tile A at end of puzzle
     /* 0x117B */ u8 field_0x117B;     // Padding
     /* 0x117C */ u8 field_0x117C;
-};
-
-struct daObj_Sekizoa_Param_c {
-    virtual ~daObj_Sekizoa_Param_c() {}
-
-    struct Data {
-        /* 0x00 */ f32 field_0x00;
-        /* 0x04 */ f32 field_0x04;
-        /* 0x08 */ f32 field_0x08;
-        /* 0x0C */ f32 field_0x0C;
-        /* 0x10 */ f32 field_0x10;
-        /* 0x14 */ f32 field_0x14;
-        /* 0x18 */ f32 field_0x18;
-        /* 0x1C */ f32 field_0x1C;
-        /* 0x20 */ f32 field_0x20;
-        /* 0x24 */ f32 field_0x24;
-        /* 0x28 */ f32 field_0x28;
-        /* 0x2C */ f32 field_0x2C;
-        /* 0x30 */ f32 field_0x30;
-        /* 0x34 */ f32 field_0x34;
-        /* 0x38 */ f32 field_0x38;
-        /* 0x3C */ f32 field_0x3C;
-        /* 0x40 */ f32 field_0x40;
-        /* 0x44 */ f32 field_0x44;
-        /* 0x48 */ s16 field_0x48;
-        /* 0x4A */ s16 field_0x4A;
-        /* 0x4C */ s16 field_0x4C;
-        /* 0x4E */ s16 field_0x4E;
-        /* 0x50 */ f32 field_0x50;
-        /* 0x54 */ f32 field_0x54;
-        /* 0x58 */ f32 field_0x58;
-        /* 0x5C */ f32 field_0x5C;
-        /* 0x60 */ int field_0x60;
-        /* 0x64 */ f32 field_0x64;
-        /* 0x68 */ f32 field_0x68;
-        /* 0x6C */ f32 field_0x6C;
-        /* 0x70 */ f32 field_0x70;
-        /* 0x74 */ f32 field_0x74;
-        /* 0x78 */ f32 field_0x78;
-        /* 0x7C */ f32 field_0x7C;
-        /* 0x80 */ f32 field_0x80;
-        /* 0x84 */ f32 field_0x84;
-        /* 0x88 */ f32 field_0x88;
-        /* 0x8C */ f32 field_0x8C;
-        /* 0x90 */ f32 field_0x90;
-        /* 0x94 */ f32 field_0x94;
-        /* 0x98 */ s16 field_0x98;
-    };
-
-    static Data const m;
 };
 
 #endif /* D_A_OBJ_SEKIZOA_H */

--- a/include/d/actor/d_a_obj_smtile.h
+++ b/include/d/actor/d_a_obj_smtile.h
@@ -3,6 +3,35 @@
 
 #include "f_op/f_op_actor_mng.h"
 
+struct daObj_SMTile_HIOParam {
+    /* 0x00 */ f32 field_0x0;
+    /* 0x04 */ f32 field_0x4;
+};
+
+class daObj_SMTile_Param_c {
+public:
+    virtual ~daObj_SMTile_Param_c() {}
+
+    static daObj_SMTile_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_SMTile_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_SMTile_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_SMTile_HIOParam m;
+};
+
+#define OBJ_SMTILE_HIO_CLASS daObj_SMTile_HIO_c
+#else
+#define OBJ_SMTILE_HIO_CLASS daObj_SMTile_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_SMTile_c
@@ -14,7 +43,7 @@
 class daObj_SMTile_c : public fopAc_ac_c {
 private:
     /* 0x568 */ mDoExt_brkAnm mBrk;
-    /* 0x580 */ int field_0x580;
+    /* 0x580 */ OBJ_SMTILE_HIO_CLASS* mpHIO;
     /* 0x584 */ request_of_phase_process_class mPhase;
     /* 0x58C */ J3DModel* mModel;
     /* 0x590 */ cXyz field_0x590[21];
@@ -51,13 +80,6 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_SMTile_c) == 0xb30);
-
-class daObj_SMTile_Param_c {
-public:
-    virtual ~daObj_SMTile_Param_c() {}
-
-    static f32 const m[2];
-};
 
 
 #endif /* D_A_OBJ_SMTILE_H */

--- a/include/d/actor/d_a_obj_stick.h
+++ b/include/d/actor/d_a_obj_stick.h
@@ -5,6 +5,37 @@
 #include "d/d_bg_s_acch.h"
 #include "d/d_cc_d.h"
 
+struct daObj_Stick_HIOParam {
+    f32 attention_offset;
+    f32 gravity;
+    f32 scale;
+    f32 real_shadow_size;
+};
+
+class daObj_Stick_Param_c {
+public:
+    virtual ~daObj_Stick_Param_c() {}
+
+    static const daObj_Stick_HIOParam m;
+};
+
+#if DEBUG
+class daObj_Stick_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_Stick_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_Stick_HIOParam m;
+};
+
+#define OBJ_STICK_HIO_CLASS daObj_Stick_HIO_c
+#else
+#define OBJ_STICK_HIO_CLASS daObj_Stick_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_Stick_c
@@ -15,7 +46,7 @@
  */
 class daObj_Stick_c : public fopAc_ac_c {
 private:
-    /* 0x568 */ mDoHIO_entry_c* field_0x568;
+    /* 0x568 */ OBJ_STICK_HIO_CLASS* mpHIO;
     /* 0x56c */ request_of_phase_process_class mPhase;
     /* 0x574 */ J3DModel* mpModel;
     /* 0x578 */ dBgS_ObjAcch mAcch;
@@ -46,19 +77,5 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_Stick_c) == 0x950);
-
-class daObj_Stick_Param_c {
-public:
-    virtual ~daObj_Stick_Param_c() {};
-
-    struct daObj_Stick_HIOParam {
-        f32 attention_offset;
-        f32 gravity;
-        f32 scale;
-        f32 real_shadow_size;
-    };
-    static const daObj_Stick_HIOParam m;
-};
-
 
 #endif /* D_A_OBJ_STICK_H */

--- a/include/d/actor/d_a_obj_tks.h
+++ b/include/d/actor/d_a_obj_tks.h
@@ -20,6 +20,23 @@ public:
     static const daObjTks_HIOParam m;
 };
 
+#if DEBUG
+class daObjTks_HIO_c : public mDoHIO_entry_c {
+
+public:
+    daObjTks_HIO_c();
+    virtual ~daObjTks_HIO_c() {}
+
+    void genMessage(JORMContext*);
+
+    daObjTks_HIOParam m;
+};
+
+#define OBJ_TKS_HIO_CLASS daObjTks_HIO_c
+#else
+#define OBJ_TKS_HIO_CLASS daObjTks_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObjTks_c
@@ -28,7 +45,6 @@ public:
  * @details
  *
 */
-
 class daObjTks_c : public daNpcF_c {
 public:
     daObjTks_c();
@@ -64,7 +80,8 @@ public:
     virtual inline void drawOtherMdls();
 
     void calcSpringF(f32* param_0, f32 param_1, f32* param_2) {
-        *param_2 = daObjTks_Param_c::m.spring_atten * (*param_2 + (daObjTks_Param_c::m.spring_factor * (*param_0 - param_1)));
+        f32 var_f31 = mpHIO->m.spring_factor * (*param_0 - param_1);
+        *param_2 = mpHIO->m.spring_atten * (*param_2 + var_f31);
         *param_0 += *param_2;
     }
 
@@ -89,7 +106,7 @@ public:
     /* 0xB48 */ Z2Creature mSound;
     /* 0xBD8 */ daNpcF_MatAnm_c* mpMatAnm;
     /* 0xBDC */ daNpcF_Lookat_c mLookat;
-    /* 0xC78 */ u8 field_0xC78[0xC7C - 0xC78];
+    /* 0xC78 */ OBJ_TKS_HIO_CLASS* mpHIO;
     /* 0xC7C */ dCcD_Cyl mCcCyl;
     /* 0xDB8 */ void (daObjTks_c::*mAction)();
     /* 0xDC4 */ request_of_phase_process_class mPhase;

--- a/include/d/actor/d_a_obj_yel_bag.h
+++ b/include/d/actor/d_a_obj_yel_bag.h
@@ -6,6 +6,44 @@
 #include "d/d_cc_d.h"
 #include "f_op/f_op_actor_mng.h"
 
+struct daObj_YBag_HIOParam {
+    /* 0x00 */ f32 field_0x00;
+    /* 0x04 */ f32 field_0x04;
+    /* 0x08 */ f32 field_0x08;
+    /* 0x0C */ f32 field_0x0c;
+    /* 0x10 */ f32 field_0x10;
+    /* 0x14 */ f32 field_0x14;
+    /* 0x18 */ f32 field_0x18;
+    /* 0x1C */ f32 field_0x1c;
+    /* 0x20 */ f32 field_0x20;
+    /* 0x24 */ f32 field_0x24;
+    /* 0x28 */ f32 field_0x28;
+};
+
+class daObj_YBag_Param_c {
+public:
+    virtual ~daObj_YBag_Param_c() {}
+
+    static daObj_YBag_HIOParam const m;
+};
+
+#if DEBUG
+class daObj_YBag_HIO_c : public mDoHIO_entry_c {
+public:
+    daObj_YBag_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daObj_YBag_HIOParam m;
+};
+
+#define OBJ_YBAG_HIO_CLASS daObj_YBag_HIO_c
+#else
+#define OBJ_YBAG_HIO_CLASS daObj_YBag_Param_c
+#endif
+
 /**
  * @ingroup actors-objects
  * @class daObj_YBag_c
@@ -18,7 +56,7 @@ class daObj_YBag_c : public fopAc_ac_c {
 private:
     /* 0x568 */ request_of_phase_process_class mPhases[3];
     /* 0x580 */ J3DModel* mModel;
-    /* 0x584 */ int field_0x584;
+    /* 0x584 */ OBJ_YBAG_HIO_CLASS* mpHIO;
     /* 0x588 */ dBgS_ObjAcch mAcch;
     /* 0x760 */ dCcD_Stts mStts;
     /* 0x79C */ dBgS_AcchCir mAcchCir;
@@ -76,13 +114,6 @@ public:
 };
 
 STATIC_ASSERT(sizeof(daObj_YBag_c) == 0xa3c);
-
-class daObj_YBag_Param_c {
-public:
-    virtual ~daObj_YBag_Param_c() {}
-
-    static f32 const m[11];
-};
 
 
 #endif /* D_A_OBJ_YEL_BAG_H */

--- a/include/d/actor/d_a_peru.h
+++ b/include/d/actor/d_a_peru.h
@@ -6,6 +6,79 @@
 #include "d/actor/d_a_npc.h"
 #include "SSystem/SComponent/c_counter.h"
 
+//TODO: this might be the same struct that's used in d_a_obj_sekizoa's HIO
+struct daPeru_HIO_inner {
+    /* 0x00 */ f32 field_0x00;
+    /* 0x04 */ f32 field_0x04;
+    /* 0x08 */ f32 field_0x08;
+    /* 0x0C */ f32 field_0x0C;
+    /* 0x10 */ f32 field_0x10;
+    /* 0x14 */ f32 field_0x14;
+    /* 0x18 */ f32 field_0x18;
+    /* 0x1C */ f32 field_0x1C;
+    /* 0x20 */ f32 field_0x20;
+    /* 0x24 */ f32 field_0x24;
+    /* 0x28 */ f32 field_0x28;
+    /* 0x2C */ f32 field_0x2C;
+    /* 0x30 */ f32 field_0x30;
+    /* 0x34 */ f32 field_0x34;
+    /* 0x38 */ f32 field_0x38;
+    /* 0x3C */ f32 field_0x3C;
+    /* 0x40 */ f32 field_0x40;
+    /* 0x44 */ f32 field_0x44;
+    /* 0x48 */ s16 field_0x48;
+    /* 0x4A */ s16 field_0x4A;
+    /* 0x4C */ s16 field_0x4C;
+    /* 0x4E */ s16 field_0x4E;
+    /* 0x50 */ f32 field_0x50;
+    /* 0x54 */ f32 field_0x54;
+    /* 0x58 */ f32 field_0x58;
+    /* 0x5C */ f32 field_0x5C;
+    /* 0x60 */ s16 field_0x60;
+    /* 0x62 */ s16 field_0x62;
+    /* 0x64 */ f32 field_0x64;
+    /* 0x68 */ f32 field_0x68;
+    /* 0x6C */ f32 field_0x6C;
+    /* 0x70 */ f32 field_0x70;
+    /* 0x74 */ f32 field_0x74;
+    /* 0x78 */ f32 field_0x78;
+    /* 0x7C */ f32 field_0x7C;
+    /* 0x80 */ f32 field_0x80;
+    /* 0x84 */ f32 field_0x84;
+    /* 0x88 */ f32 field_0x88;
+};
+
+struct daPeru_HIOParam {
+    /* 0x00 */ daPeru_HIO_inner inner;
+    /* 0x8C */ f32 field_0x8c;
+    /* 0x90 */ f32 field_0x90;
+    /* 0x94 */ f32 field_0x94;
+};
+
+class daPeru_Param_c {
+public:
+    virtual ~daPeru_Param_c() {}
+
+    static daPeru_HIOParam const m;
+};
+
+#if DEBUG
+class daPeru_HIO_c : public mDoHIO_entry_c {
+public:
+    daPeru_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daPeru_HIOParam m;
+};
+
+#define PERU_HIO_CLASS daPeru_HIO_c
+#else
+#define PERU_HIO_CLASS daPeru_Param_c
+#endif
+
 /**
  * @ingroup actors-npcs
  * @class daPeru_c
@@ -127,7 +200,7 @@ private:
     /* 0x0E70 */ u8 field_0xe70[0xe7c - 0xe70];
     /* 0x0E7C */ s8 field_0xe7c;
     /* 0x0E80 */ int field_0xe80;
-    /* 0x0E84 */ int field_0xe84;
+    /* 0x0E84 */ PERU_HIO_CLASS* mpHIO;
     /* 0x0E88 */ dCcD_Cyl mCyls[2];
     /* 0x1100 */ daNpcT_Path_c mPath;
     /* 0x1128 */ u8 mType;
@@ -135,20 +208,5 @@ private:
 };
 
 STATIC_ASSERT(sizeof(daPeru_c) == 0x112c);
-
-struct PeruParams {
-    f32 field_0x00[18];
-    s16 field_0x48[4];
-    f32 field_0x50[4];
-    s16 field_0x60[2];
-    f32 field_0x64[13];
-};
-
-class daPeru_Param_c {
-public:
-    virtual ~daPeru_Param_c() {}
-
-    static PeruParams const m;
-};
 
 #endif /* D_A_PERU_H */

--- a/include/d/actor/d_a_tag_lantern.h
+++ b/include/d/actor/d_a_tag_lantern.h
@@ -4,6 +4,34 @@
 #include "d/d_com_inf_game.h"
 #include "d/d_msg_flow.h"
 
+struct daTag_Lantern_HIOParam {
+    u8 field_0x0;
+};
+
+class daTag_Lantern_Param_c {
+public:
+    inline virtual ~daTag_Lantern_Param_c() {}
+
+    static daTag_Lantern_HIOParam const m;
+};
+
+#if DEBUG
+class daTag_Lantern_HIO_c : public mDoHIO_entry_c {
+public:
+    daTag_Lantern_HIO_c();
+
+    void listenPropertyEvent(const JORPropertyEvent*);
+
+    void genMessage(JORMContext*);
+
+    daTag_Lantern_HIOParam m;
+};
+
+#define TAG_LANTERN_HIO_CLASS daTag_Lantern_HIO_c
+#else
+#define TAG_LANTERN_HIO_CLASS daTag_Lantern_Param_c
+#endif
+
 class daTag_Lantern_c : public fopAc_ac_c {
 public:
     int create();
@@ -28,7 +56,7 @@ public:
 
     /* 0x568 */ dMsgFlow_c mMsgFlow;
     /* 0x5B4 */ cBgS_GndChk mGndChk;
-    /* 0x5F0 */ u32 field_0x5f0;
+    /* 0x5F0 */ TAG_LANTERN_HIO_CLASS* mpHIO;
     /* 0x5F4 */ f32 mGroundCross;
     /* 0x5F8 */ s32 field_0x5f8;
     /* 0x5FC */ u32 field_0x5fc;
@@ -37,10 +65,5 @@ public:
     
     virtual ~daTag_Lantern_c();
 }; // Size: 0x60C
-
-class daTag_Lantern_Param_c {
-public:
-    inline virtual ~daTag_Lantern_Param_c() {}
-};
 
 #endif /* D_A_TAG_LANTERN_H */

--- a/src/d/actor/d_a_bullet.cpp
+++ b/src/d/actor/d_a_bullet.cpp
@@ -12,7 +12,7 @@ static char* l_resFileNameList[] = {"Hanjo1"};
 
 static char* l_bmdFileNameList[] = {"hanjo_stone.bmd"};
 
-static daBullet_Param_c l_HIO;
+static BULLET_HIO_CLASS l_HIO;
 
 const dCcD_SrcGObjInf daBullet_c::mCcDObjInfo = {
     {0, {{0, 0, 0}, {0x0, 0x0}, {0x79}}},
@@ -28,8 +28,28 @@ dCcD_SrcSph daBullet_c::mCcDSph = {
     }  // mSphAttr
 };
 
+#if DEBUG
+daBullet_HIO_c::daBullet_HIO_c() {
+    m = daBullet_HIO_c::m;
+}
+
+void daBullet_HIO_c::listenPropertyEvent(const JORPropertyEvent*) {
+    // NONMATCHING
+}
+
+void daBullet_HIO_c::genMessage(JORMContext*) {
+    // NONMATCHING
+}
+#endif
+
 daBullet_c::~daBullet_c() {
     dComIfG_resDelete(&mPhase, getResName());
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 }
 
 int daBullet_c::create() {
@@ -71,7 +91,7 @@ daBullet_HIOParam const daBullet_Param_c::m = {
 };
 
 int daBullet_c::Execute() {
-    gravity = daBullet_Param_c::m.gravity;
+    gravity = mpHIO->m.gravity;
 
     if (field_0x957 == 0) {
         if (mProcess != NULL) {
@@ -155,10 +175,15 @@ void daBullet_c::initialize() {
     fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
     fopAcM_setCullSizeBox(this, -10.0f, -10.0f, -10.0f, 10.0f, 10.0f, 10.0f);
 
-    mAcchCir.SetWall(daBullet_Param_c::m.width, daBullet_Param_c::m.knee_height);
+#if DEBUG
+    mpHIO = &l_HIO;
+    mpHIO->entryHIO("弾");
+#endif
+
+    mAcchCir.SetWall(mpHIO->m.width, mpHIO->m.knee_height);
     mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
 
-    mCcStts.Init(daBullet_Param_c::m.weight, 0, this);
+    mCcStts.Init(mpHIO->m.weight, 0, this);
     mCcSph.Set(mCcDSph);
     mCcSph.SetStts(&mCcStts);
     mAcch.CrrPos(dComIfG_Bgsp());
@@ -166,7 +191,7 @@ void daBullet_c::initialize() {
     mGroundY = mAcch.GetGroundH();
 
     setProcess(&daBullet_c::wait);
-    mLifetime = daBullet_Param_c::m.lifetime;
+    mLifetime = mpHIO->m.lifetime;
     Execute();
 }
 

--- a/src/d/actor/d_a_npc_aru.cpp
+++ b/src/d/actor/d_a_npc_aru.cpp
@@ -257,14 +257,6 @@ daNpc_Aru_c::cutFunc daNpc_Aru_c::mCutList[7] = {
     &daNpc_Aru_c::cutNoEntrance,
 };
 
-daNpc_Aru_c::~daNpc_Aru_c() {
-    if (mpMorf[0] != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 const daNpc_Aru_HIOParam daNpc_Aru_Param_c::m = {
     220.0f,
     -3.0f,
@@ -315,6 +307,36 @@ const daNpc_Aru_HIOParam daNpc_Aru_Param_c::m = {
     45.0f,
 };
 
+static NPC_ARU_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Aru_HIO_c::daNpc_Aru_HIO_c() {
+    m = daNpc_Aru_Param_c::m;
+}
+
+void daNpc_Aru_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Aru_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Aru_c::~daNpc_Aru_c() {
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
+
 cPhs__Step daNpc_Aru_c::create() {
     daNpcT_ct(this, daNpc_Aru_c, l_faceMotionAnmData, l_motionAnmData,
                        l_faceMotionSequenceData, 4, l_motionSequenceData, 4, l_evtList, l_resNameList);
@@ -349,9 +371,14 @@ cPhs__Step daNpc_Aru_c::create() {
         mSound.init(&current.pos, &eyePos, 3, 1);
         field_0x9c0.init(&mAcch, 0.0f, 0.0f);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ファド");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Aru_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -482,14 +509,14 @@ BOOL daNpc_Aru_c::chkThrust(fopAc_ac_c* actor_p) {
             f32 fVar2 = fopAcM_searchActorDistance(this, actor_p);
             s16 sVar1 = cM_atan2s(actor_p->speed.x, actor_p->speed.z) - fopAcM_searchActorAngleY(actor_p, this);
 
-            if (fVar2 < daNpc_Aru_Param_c::m.warning_range) {
+            if (fVar2 < mpHIO->m.warning_range) {
                 if (abs(sVar1) < cM_deg2s(35.0f)) {
                     return TRUE;
                 }
             }
         }
 
-        if (fopAcM_GetName(actor_p) == PROC_ALINK && daPy_py_c::checkNowWolf() && actorDistance < daNpc_Aru_Param_c::m.warning_range) {
+        if (fopAcM_GetName(actor_p) == PROC_ALINK && daPy_py_c::checkNowWolf() && actorDistance < mpHIO->m.warning_range) {
             return TRUE;
         }
     }
@@ -701,10 +728,10 @@ void daNpc_Aru_c::setParam() {
     selectAction();
     srchActors();
     u32 attnFlag = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
-    s16 talk_distance = daNpc_Aru_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_Aru_Param_c::m.common.talk_angle;
-    s16 attention_distance = daNpc_Aru_Param_c::m.common.attention_distance;
-    s16 attention_angle = daNpc_Aru_Param_c::m.common.attention_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
+    s16 attention_distance = mpHIO->m.common.attention_distance;
+    s16 attention_angle = mpHIO->m.common.attention_angle;
 
     if (daPy_getPlayerActorClass()->checkHorseRide()) {
         if (talk_distance < 7) {
@@ -726,17 +753,17 @@ void daNpc_Aru_c::setParam() {
 
     attention_info.flags = attnFlag;
 
-    scale.set(daNpc_Aru_Param_c::m.common.scale, daNpc_Aru_Param_c::m.common.scale, daNpc_Aru_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Aru_Param_c::m.common.weight);
-    mCylH = daNpc_Aru_Param_c::m.common.height;
-    mWallR = daNpc_Aru_Param_c::m.common.width;
-    mAttnFovY = daNpc_Aru_Param_c::m.common.fov;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Aru_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Aru_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Aru_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Aru_Param_c::m.common.morf_frame;
-    gravity = daNpc_Aru_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Aru_c::checkChangeEvt() {
@@ -908,8 +935,6 @@ void daNpc_Aru_c::beforeMove() {
     }
 }
 
-static daNpc_Aru_Param_c l_HIO;
-
 void daNpc_Aru_c::setAttnPos() {
     cXyz sp40(-30.0f, 10.0f, 0.0f);
     cXyz sp4c(0.0f, 10.0f, 0.0f);
@@ -918,11 +943,11 @@ void daNpc_Aru_c::setAttnPos() {
     f32 rad = cM_s2rad((s16)(mCurAngle.y - field_0xd7e.y));
 
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp40, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-                     daNpc_Aru_Param_c::m.common.body_angleX_min, daNpc_Aru_Param_c::m.common.body_angleX_max,
-                     daNpc_Aru_Param_c::m.common.body_angleY_min, daNpc_Aru_Param_c::m.common.body_angleY_max,
-                     daNpc_Aru_Param_c::m.common.head_angleX_min, daNpc_Aru_Param_c::m.common.head_angleX_max,
-                     daNpc_Aru_Param_c::m.common.head_angleY_min, daNpc_Aru_Param_c::m.common.head_angleY_max,
-                     daNpc_Aru_Param_c::m.common.neck_rotation_ratio, rad, &sp4c);
+                     mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+                     mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+                     mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+                     mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+                     mpHIO->m.common.neck_rotation_ratio, rad, &sp4c);
     mJntAnm.calcJntRad(0.2f, 1.0f, rad);
     
     setMtx();
@@ -932,7 +957,7 @@ void daNpc_Aru_c::setAttnPos() {
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y + field_0xd8a.y, TRUE, 1.0f, 0);
 
     sp40.set(0.0f, 0.0f, 20.0f);
-    sp40.y = daNpc_Aru_Param_c::m.common.attention_offset;
+    sp40.y = mpHIO->m.common.attention_offset;
     mDoMtx_stack_c::YrotS(mCurAngle.y);
     mDoMtx_stack_c::multVec(&sp40, &sp40);
     attention_info.position = current.pos + sp40;
@@ -1080,7 +1105,7 @@ s16 daNpc_Aru_c::srchActorDirection(fopAc_ac_c* actor_p) {
     s16 rv;
     s16 sVar1 = fopAcM_searchActorAngleY(this, actor_p) - mCurAngle.y;
     s16 sVar2 = abs(sVar1);
-    s16 sVar3 = cM_deg2s(daNpc_Aru_Param_c::m.forward_visibility);
+    s16 sVar3 = cM_deg2s(mpHIO->m.forward_visibility);
     
     if (sVar2 < sVar3) {
         if (sVar1 > 0) {
@@ -1112,7 +1137,7 @@ void daNpc_Aru_c::adjustMoveDir() {
     s16 sVar3[3];
 
     sp84 = current.pos;
-    sp84.y += daNpc_Aru_Param_c::m.common.knee_length;
+    sp84.y += mpHIO->m.common.knee_length;
 
     for (int i = 0; i < 3; i++) {
         bVar1[i] = 0;
@@ -1144,7 +1169,7 @@ void daNpc_Aru_c::adjustMoveDir() {
     }
 
     if (bVar1[1] != 0 && bVar1[2] != 0) {
-        mTimer = daNpc_Aru_Param_c::m.no_turn_time;
+        mTimer = mpHIO->m.no_turn_time;
 
         switch (field_0xfca) {
             case 1:
@@ -1198,7 +1223,7 @@ void daNpc_Aru_c::adjustMoveDir() {
             case 1:
             case 7:
                 field_0xfca = 6;
-                mTimer = daNpc_Aru_Param_c::m.no_turn_time;
+                mTimer = mpHIO->m.no_turn_time;
                 break;
             
             case 2:
@@ -1218,7 +1243,7 @@ void daNpc_Aru_c::adjustMoveDir() {
             case 1:
             case 7:
                 field_0xfca = 2;
-                mTimer = daNpc_Aru_Param_c::m.no_turn_time;
+                mTimer = mpHIO->m.no_turn_time;
                 break;
 
             case 6:
@@ -1260,7 +1285,7 @@ void daNpc_Aru_c::adjustMoveDir() {
 
 int daNpc_Aru_c::duck(int param_1) {
     fopAc_ac_c* cow_p;
-    int iVar1 = daNpc_Aru_Param_c::m.avoid_time;
+    int iVar1 = mpHIO->m.avoid_time;
     cow_p = getCowP(param_1);
 
     if (cow_p != NULL) {
@@ -1307,7 +1332,7 @@ int daNpc_Aru_c::duck(int param_1) {
             cLib_addCalcAngleS2(&current.angle.y, sVar1, MREG_S(0) + 6, MREG_S(1) + 0x800);
             shape_angle.y = current.angle.y;
             mCurAngle.y = shape_angle.y;
-            cLib_chaseF(&speedF, daNpc_Aru_Param_c::m.run_speed, 1.5f);
+            cLib_chaseF(&speedF, mpHIO->m.run_speed, 1.5f);
             speedF *= cM_scos(mGroundAngle);
 
             if (mGroundAngle < 0) {
@@ -2027,8 +2052,8 @@ int daNpc_Aru_c::test(void* param_1) {
         mMode = 2;
         // fallthrough
     case 2:
-        mFaceMotionSeqMngr.setNo(mHIO->param.common.face_expression, -1.0f, 0, 0);
-        mMotionSeqMngr.setNo(mHIO->param.common.motion, -1.0f, 0, 0);
+        mFaceMotionSeqMngr.setNo(mpHIO->m.common.face_expression, -1.0f, 0, 0);
+        mMotionSeqMngr.setNo(mpHIO->m.common.motion, -1.0f, 0, 0);
         mJntAnm.lookNone(0);
         attention_info.flags = 0;
         break;

--- a/src/d/actor/d_a_npc_besu.cpp
+++ b/src/d/actor/d_a_npc_besu.cpp
@@ -527,6 +527,22 @@ daNpc_Besu_c::cutFunc daNpc_Besu_c::mCutList[15] = {
     &daNpc_Besu_c::cutThankYou,
 };
 
+static NPC_BESU_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Besu_HIO_c::daNpc_Besu_HIO_c() {
+    m = daNpc_Besu_Param_c::m;
+}
+
+void daNpc_Besu_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Besu_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daNpc_Besu_c::~daNpc_Besu_c() {
     // "Destruct":
     OS_REPORT("|%06d:%x|daNpc_Besu_c -> デストラクト\n", g_Counter.mCounter0, this);
@@ -538,11 +554,11 @@ daNpc_Besu_c::~daNpc_Besu_c() {
         mpCupModelMorf->stopZelAnime();
     }
 
-// #if DEBUG
-//     if (field_0xe40 != NULL) {
-//         field_0xe40->removeHIO();
-//     }
-// #endif
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 
     deleteRes((l_loadResPtrnList)[mType], (const char**)l_resNameList);
 }
@@ -631,16 +647,16 @@ int daNpc_Besu_c::create() {
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-// #if DEBUG
-//         field_0xe40 = &l_HIO;
-//         // "Beth":
-//         field_0xe40->entryHIO("ベス");
-// #endif
+#if DEBUG
+         mpHIO = &l_HIO;
+         // "Beth":
+         mpHIO->entryHIO("ベス");
+ #endif
 
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                             &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Besu_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -993,10 +1009,10 @@ void daNpc_Besu_c::setParam() {
     srchActors();
 
     u32 att_flags = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    s16 talk_dist = daNpc_Besu_Param_c::m.common.talk_distance;
-    s16 talk_ang = daNpc_Besu_Param_c::m.common.talk_angle;
-    s16 att_dist = daNpc_Besu_Param_c::m.common.attention_distance;
-    s16 att_ang = daNpc_Besu_Param_c::m.common.attention_angle;
+    s16 talk_dist = mpHIO->m.common.talk_distance;
+    s16 talk_ang = mpHIO->m.common.talk_angle;
+    s16 att_dist = mpHIO->m.common.attention_distance;
+    s16 att_ang = mpHIO->m.common.attention_angle;
     if (daNpcKakashi_chkSwdTutorialStage() & 0xFF) {
         talk_dist = 11;
         talk_ang = 6;
@@ -1038,11 +1054,11 @@ void daNpc_Besu_c::setParam() {
     attention_info.distances[3] = daNpcT_getDistTableIdx(talk_dist, talk_ang);
     attention_info.flags = att_flags;
 
-    scale.set(daNpc_Besu_Param_c::m.common.scale, daNpc_Besu_Param_c::m.common.scale,
-            daNpc_Besu_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Besu_Param_c::m.common.weight);
-    mCylH = daNpc_Besu_Param_c::m.common.height;
-    mWallR = daNpc_Besu_Param_c::m.common.width;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+            mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     if (mTwilight) {
         mCylH = 110.0f;
     } else if (mType == 5) {
@@ -1050,21 +1066,21 @@ void daNpc_Besu_c::setParam() {
         mWallR = 60.0f;
     }
 
-    mAttnFovY = daNpc_Besu_Param_c::m.common.fov;
+    mAttnFovY = mpHIO->m.common.fov;
     if (mType == 3 || mType == 4) {
         mAttnFovY = 180.0f;
     }
 
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Besu_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Besu_Param_c::m.common.real_shadow_size;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
     if (chkNurse()) {
         mRealShadowSize = 500.0f;
     }
 
-    mExpressionMorfFrame = daNpc_Besu_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Besu_Param_c::m.common.morf_frame;
-    gravity = daNpc_Besu_Param_c::m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Besu_c::checkChangeEvt() {
@@ -1330,22 +1346,22 @@ void daNpc_Besu_c::setAttnPos() {
     if (chkNurse()) {
         mJntAnm.setParam(
             this, mpMorf[0]->getModel(), &eyeOffset, getBackboneJointNo(), getNeckJointNo(),
-            getHeadJointNo(), daNpc_Besu_Param_c::m.common.body_angleX_min, 0.0f,
-            0.0f, 0.0f, -10.0f, daNpc_Besu_Param_c::m.common.head_angleX_max,
-            daNpc_Besu_Param_c::m.common.head_angleY_min, daNpc_Besu_Param_c::m.common.head_angleY_max,
-            daNpc_Besu_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+            getHeadJointNo(), mpHIO->m.common.body_angleX_min, 0.0f,
+            0.0f, 0.0f, -10.0f, mpHIO->m.common.head_angleX_max,
+            mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+            mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     } else {
         mJntAnm.setParam(
             this, mpMorf[0]->getModel(), &eyeOffset, getBackboneJointNo(), getNeckJointNo(),
-            getHeadJointNo(), daNpc_Besu_Param_c::m.common.body_angleX_min, daNpc_Besu_Param_c::m.common.body_angleX_max,
-            daNpc_Besu_Param_c::m.common.body_angleY_min, daNpc_Besu_Param_c::m.common.body_angleY_max,
-            daNpc_Besu_Param_c::m.common.head_angleX_min, daNpc_Besu_Param_c::m.common.head_angleX_max,
-            daNpc_Besu_Param_c::m.common.head_angleY_min, daNpc_Besu_Param_c::m.common.head_angleY_max,
-            daNpc_Besu_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+            getHeadJointNo(), mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+            mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+            mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+            mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+            mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     }
 
     mJntAnm.calcJntRad(0.2f, 1.0f, rad_val);
-    mpMorf[0]->setPlaySpeed(daNpc_Besu_Param_c::m.field_0x8c);
+    mpMorf[0]->setPlaySpeed(mpHIO->m.field_0x8c);
     setMtx();
     if (mpCupModelMorf != NULL) {
         mpCupModelMorf->play(0, 0);
@@ -1379,7 +1395,7 @@ void daNpc_Besu_c::setAttnPos() {
         mDoMtx_stack_c::multVec(&eyeOffset, &attention_info.position);
     } else {
         eyeOffset.set(0.0f, 0.0f, 0.0f);
-        eyeOffset.y = daNpc_Besu_Param_c::m.common.attention_offset;
+        eyeOffset.y = mpHIO->m.common.attention_offset;
         mDoMtx_stack_c::YrotS(mCurAngle.y);
         mDoMtx_stack_c::multVec(&eyeOffset, &eyeOffset);
         attention_info.position = current.pos + eyeOffset;
@@ -2612,10 +2628,10 @@ int daNpc_Besu_c::wait(void* param_0) {
                     actor_p = (daNpc_Len_c*) mActorMngr[3].getActorP();
                     if (actor_p != NULL &&
                         ((daNpc_Len_c*) actor_p)->checkStartDemo13StbEvt(
-                            this, daNpc_Besu_Param_c::m.common.box_min_x, daNpc_Besu_Param_c::m.common.box_min_y,
-                            daNpc_Besu_Param_c::m.common.box_min_z, daNpc_Besu_Param_c::m.common.box_max_x,
-                            daNpc_Besu_Param_c::m.common.box_max_y, daNpc_Besu_Param_c::m.common.box_max_z,
-                            daNpc_Besu_Param_c::m.common.box_offset))
+                            this, mpHIO->m.common.box_min_x, mpHIO->m.common.box_min_y,
+                            mpHIO->m.common.box_min_z, mpHIO->m.common.box_max_x,
+                            mpHIO->m.common.box_max_y, mpHIO->m.common.box_max_z,
+                            mpHIO->m.common.box_offset))
                     {
                         mEvtNo = EVENT_DEMO13_STB;
                         field_0x112f = 1;
@@ -2993,9 +3009,6 @@ static int daNpc_Besu_Draw(void* i_this) {
 static int daNpc_Besu_IsDelete(void*) {
     return true;
 }
-
-static daNpc_Besu_Param_c l_HIO;
-
 
 static actor_method_class daNpc_Besu_MethodTable = {
     (process_method_func)daNpc_Besu_Create,

--- a/src/d/actor/d_a_npc_blue_ns.cpp
+++ b/src/d/actor/d_a_npc_blue_ns.cpp
@@ -37,7 +37,7 @@ static char* l_evtNames[7] = {
 
 static char* l_myName = "Blue_NS";
 
-static daNpcBlueNS_Param_c l_HIO;
+static NPC_BLUE_NS_HIO_CLASS l_HIO;
 
 daNpcBlueNS_c::EventFn daNpcBlueNS_c::mEvtSeqList[] = {
     NULL,
@@ -49,6 +49,16 @@ daNpcBlueNS_c::EventFn daNpcBlueNS_c::mEvtSeqList[] = {
     &daNpcBlueNS_c::_Evt_ChgYami_STNoppo,
 };
 
+#if DEBUG
+daNpcBlueNS_HIO_c::daNpcBlueNS_HIO_c() {
+    m = daNpcBlueNS_Param_c::m;
+}
+
+void daNpcBlueNS_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daNpcBlueNS_c::daNpcBlueNS_c() {}
 
 daNpcBlueNS_c::~daNpcBlueNS_c() {
@@ -59,6 +69,12 @@ daNpcBlueNS_c::~daNpcBlueNS_c() {
     if (heap != NULL) {
         mAnm_p->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 }
 
 const static dCcD_SrcCyl l_cyl_src = {
@@ -143,18 +159,23 @@ int daNpcBlueNS_c::Create() {
         fopAcM_SetMtx(this, mAnm_p->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeFar(this, 3.0f);
         fopAcM_setCullSizeBox(this, -120.0f, -10.0f, -120.0f, 120.0f, 220.0f, 120.0f);
-        
+
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-        mAcchCir.SetWall(daNpcBlueNS_Param_c::m.common.width, daNpcBlueNS_Param_c::m.common.knee_length);
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("青のナイトストーカー");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
 
-        mCcStts.Init(daNpcBlueNS_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(l_cyl_src);
         mCyl.SetStts(&mCcStts);
-        mCyl.SetH(daNpcBlueNS_Param_c::m.common.height);
-        mCyl.SetR(daNpcBlueNS_Param_c::m.common.width);
+        mCyl.SetH(mpHIO->m.common.height);
+        mCyl.SetR(mpHIO->m.common.width);
         mGndChk = mAcch.m_gnd;
         mGroundH = mAcch.GetGroundH();
 
@@ -353,7 +374,7 @@ BOOL daNpcBlueNS_c::holyball_check_main(fopAc_ac_c* i_actor) {
         break;
     default:
         dist = fopAcM_searchActorDistanceXZ(this, i_actor);
-        range = daNpcBlueNS_Param_c::m.field_0x6c;
+        range = mpHIO->m.field_0x6c;
     }
 
     return dist <= range;
@@ -384,7 +405,7 @@ int daNpcBlueNS_c::Draw() {
         mAnm_p->entryDL();
     }
 
-    mShadowKey = dComIfGd_setShadow(mShadowKey, 1, mdl_p, &current.pos, daNpcBlueNS_Param_c::m.common.real_shadow_size, 20.0f + tREG_F(3), current.pos.y, mGroundH, mGndChk, &tevStr, 0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
+    mShadowKey = dComIfGd_setShadow(mShadowKey, 1, mdl_p, &current.pos, mpHIO->m.common.real_shadow_size, 20.0f + tREG_F(3), current.pos.y, mGroundH, mGndChk, &tevStr, 0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
     return 1;
 }
 
@@ -409,7 +430,7 @@ int daNpcBlueNS_c::ctrlJoint(J3DJoint* param_0, J3DModel* i_model) {
     case 1:
     case 3:
     case 4:
-        setLookatMtx(jnt_no, spC, daNpcBlueNS_Param_c::m.common.neck_rotation_ratio);
+        setLookatMtx(jnt_no, spC, mpHIO->m.common.neck_rotation_ratio);
     }
 
     i_model->setAnmMtx(jnt_no, mDoMtx_stack_c::get());
@@ -436,16 +457,16 @@ int daNpcBlueNS_c::ctrlJointCallBack(J3DJoint* i_joint, int param_1) {
 void daNpcBlueNS_c::setParam() {
     srchActor();
 
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(daNpcBlueNS_Param_c::m.common.attention_distance, daNpcBlueNS_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcBlueNS_Param_c::m.common.talk_distance, daNpcBlueNS_Param_c::m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
     attention_info.flags = 0;
 
     #if !PLATFORM_GCN
-    scale.set(daNpcBlueNS_Param_c::m.common.scale, daNpcBlueNS_Param_c::m.common.scale, daNpcBlueNS_Param_c::m.common.scale);
-    mAcchCir.SetWallR(daNpcBlueNS_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpcBlueNS_Param_c::m.common.height);
-    gravity = daNpcBlueNS_Param_c::m.common.gravity;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.height);
+    gravity = mpHIO->m.common.gravity;
     #endif
 }
 
@@ -590,7 +611,7 @@ void daNpcBlueNS_c::setAttnPos() {
     mHeadAngle.x = cLib_targetAngleX(&mHeadPos, &sp20);
     mHeadAngle.y = cLib_targetAngleY(&mHeadPos, &sp20);
 
-    attention_info.position.set(mHeadPos.x, mHeadPos.y + daNpcBlueNS_Param_c::m.common.attention_offset, mHeadPos.z);
+    attention_info.position.set(mHeadPos.x, mHeadPos.y + mpHIO->m.common.attention_offset, mHeadPos.z);
 
     cXyz cyl_center;
     mDoMtx_stack_c::copy(mAnm_p->getModel()->getAnmMtx(1));
@@ -691,13 +712,13 @@ void daNpcBlueNS_c::playMotion() {
     daNpcF_anmPlayData anm5_phase1 = {5, 0.0f, 0};
     daNpcF_anmPlayData* anm5[] = {&anm5_phase1};
 
-    daNpcF_anmPlayData anm6_phase1 = {6, daNpcBlueNS_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm6_phase1 = {6, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm6[] = {&anm6_phase1};
 
-    daNpcF_anmPlayData anm7_phase1 = {7, daNpcBlueNS_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm7_phase1 = {7, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm7[] = {&anm7_phase1};
 
-    daNpcF_anmPlayData anm8_phase1 = {8, daNpcBlueNS_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm8_phase1 = {8, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm8[] = {&anm8_phase1};
 
     daNpcF_anmPlayData** anmData_p[] = {
@@ -741,14 +762,14 @@ void daNpcBlueNS_c::lookat() {
     J3DModel* model_p = mAnm_p->getModel();
 
     int var_r28 = 0;
-    f32 body_angleX_min = daNpcBlueNS_Param_c::m.common.body_angleX_min;
-    f32 body_angleX_max = daNpcBlueNS_Param_c::m.common.body_angleX_max;
-    f32 body_angleY_min = daNpcBlueNS_Param_c::m.common.body_angleY_min;
-    f32 body_angleY_max = daNpcBlueNS_Param_c::m.common.body_angleY_max;
-    f32 head_angleX_min = daNpcBlueNS_Param_c::m.common.head_angleX_min;
-    f32 head_angleX_max = daNpcBlueNS_Param_c::m.common.head_angleX_max;
-    f32 head_angleY_min = daNpcBlueNS_Param_c::m.common.head_angleY_min;
-    f32 head_angleY_max = daNpcBlueNS_Param_c::m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
 
     s16 temp_r26 = mCurAngle.y - mOldAngle.y;
     cXyz sp30[] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
@@ -814,7 +835,7 @@ BOOL daNpcBlueNS_c::step(s16 i_angY, int param_1) {
 }
 
 BOOL daNpcBlueNS_c::chkFindPlayer() {
-    if (!chkActorInSight(daPy_getPlayerActorClass(), daNpcBlueNS_Param_c::m.common.fov)) {
+    if (!chkActorInSight(daPy_getPlayerActorClass(), mpHIO->m.common.fov)) {
         mActorMngr[0].remove();
         return false;
     }

--- a/src/d/actor/d_a_npc_bou.cpp
+++ b/src/d/actor/d_a_npc_bou.cpp
@@ -146,16 +146,42 @@ daNpc_Bou_c::~daNpc_Bou_c() {
     if (mpMorf[0] != 0) {
         mpMorf[0]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
 }
 
-daNpc_Bou_Param_c::Data const daNpc_Bou_Param_c::m= {
-    210.0f, -3.0f, 1.0f, 600.0f, 255.0f, 200.0f, 35.0f, 40.0f,
-    0.0f, 0.0f, 10.0f, -10.0f, 30.0f, -10.0f, 45.0f, -45.0f,
-    0.6f, 12.0f, 3, 6, 5, 6, 110.0f, 500.0f, 300.0f, -300.0f,
-    60, 8, 0.0f, 0.0f, 4.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-    0.0f, 0.0f, 16.0f, 1000.0f, 500.0f, -500.0f,
+daNpc_Bou_HIOParam const daNpc_Bou_Param_c::m = {
+    {
+        210.0f, -3.0f, 1.0f, 600.0f, 255.0f, 200.0f, 35.0f, 40.0f,
+       0.0f, 0.0f, 10.0f, -10.0f, 30.0f, -10.0f, 45.0f, -45.0f,
+       0.6f, 12.0f, 3, 6, 5, 6, 110.0f, 500.0f, 300.0f, -300.0f,
+       60, 8, 0, 0, 0, 0, 0, 4.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+       0.0f, 0.0f,
+    },
+    16.0f, 1000.0f, 500.0f, -500.0f,
 };
+
+static NPC_BOU_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Bou_HIO_c::daNpc_Bou_HIO_c() {
+    m = daNpc_Bou_Param_c::m;
+}
+
+void daNpc_Bou_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Bou_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
 
 int daNpc_Bou_c::create() {
     static int const heapSize[6] = {15696, 15696, 15696, 15696, 15696, 0};
@@ -180,11 +206,17 @@ int daNpc_Bou_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ボウ");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                         &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                         fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Bou_Param_c::m.field_0x10, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -394,10 +426,10 @@ void daNpc_Bou_c::setParam() {
     selectAction();
     srchActors();
     u32 uVar7 = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    s16 sVar10 = daNpc_Bou_Param_c::m.field_0x48;
-    s16 sVar9 = daNpc_Bou_Param_c::m.field_0x4a;
-    s16 sVar8 = daNpc_Bou_Param_c::m.field_0x4c;
-    s16 sVar7 = daNpc_Bou_Param_c::m.field_0x4e;
+    s16 sVar10 = mpHIO->m.common.talk_distance;
+    s16 sVar9 = mpHIO->m.common.talk_angle;
+    s16 sVar8 = mpHIO->m.common.attention_distance;
+    s16 sVar7 = mpHIO->m.common.attention_angle;
     if (mType == TYPE_1) {
         field_0xfe0 = 3;
         field_0xfe4 = 6;
@@ -433,18 +465,18 @@ void daNpc_Bou_c::setParam() {
     }
 
     attention_info.flags = uVar7;
-    scale.set(daNpc_Bou_Param_c::m.field_0x08, daNpc_Bou_Param_c::m.field_0x08,
-            daNpc_Bou_Param_c::m.field_0x08);
-    mCcStts.SetWeight(daNpc_Bou_Param_c::m.field_0x10);
-    mCylH = daNpc_Bou_Param_c::m.field_0x14;
-    mWallR = daNpc_Bou_Param_c::m.field_0x1c;
-    mAttnFovY = daNpc_Bou_Param_c::m.field_0x50;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+            mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Bou_Param_c::m.field_0x18);
-    mRealShadowSize = daNpc_Bou_Param_c::m.field_0x0c;
-    mExpressionMorfFrame = daNpc_Bou_Param_c::m.field_0x6c;
-    mMorfFrames = daNpc_Bou_Param_c::m.field_0x44;
-    gravity = daNpc_Bou_Param_c::m.field_0x04;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Bou_c::checkChangeEvt() {
@@ -606,7 +638,7 @@ void daNpc_Bou_c::action() {
         switch (((daTag_Push_c*) hit_actor)->getId()) {
             case 7: {
                 mEvtNo = 8;
-                if (daNpc_Bou_Param_c::m.field_0x54 < current.pos.absXZ(daPy_getPlayerActorClass()->current.pos)) {
+                if (mpHIO->m.common.search_distance < current.pos.absXZ(daPy_getPlayerActorClass()->current.pos)) {
                     if (daPy_getPlayerActorClass()->checkHorseRide()) {
                         mEvtNo = 9;
                     }
@@ -635,11 +667,12 @@ void daNpc_Bou_c::setAttnPos() {
     f32 dVar8 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     J3DModel* model = mpMorf[0]->getModel();
     mJntAnm.setParam(this, model, &cStack_3c, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_Bou_Param_c::m.field_0x24, daNpc_Bou_Param_c::m.field_0x20,
-        daNpc_Bou_Param_c::m.field_0x2c, daNpc_Bou_Param_c::m.field_0x28,
-        daNpc_Bou_Param_c::m.field_0x34, daNpc_Bou_Param_c::m.field_0x30,
-        daNpc_Bou_Param_c::m.field_0x3c, daNpc_Bou_Param_c::m.field_0x38,
-        daNpc_Bou_Param_c::m.field_0x40, dVar8, NULL);
+        getHeadJointNo(),
+        mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, dVar8, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, dVar8);
     setMtx();
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(getHeadJointNo()));
@@ -647,7 +680,7 @@ void daNpc_Bou_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 1, 1.0f, 0);
     cStack_3c.set(0.0f, 0.0f, 10.0f);
-    cStack_3c.y = daNpc_Bou_Param_c::m.field_0x00;
+    cStack_3c.y = mpHIO->m.common.attention_offset;
     mDoMtx_stack_c::YrotS(mCurAngle.y);
     mDoMtx_stack_c::multVec(&cStack_3c, &cStack_3c);
     attention_info.position = current.pos + cStack_3c;
@@ -1213,7 +1246,7 @@ int daNpc_Bou_c::cutFindWolf(int arg) {
             cLib_chaseS(&shape_angle.y, current.angle.y, 0x800);
             mCurAngle.y = shape_angle.y;
             field_0xd7e.y = mCurAngle.y;
-            cLib_chaseF(&speedF, daNpc_Bou_Param_c::m.field_0x8c, 0.5f);
+            cLib_chaseF(&speedF, mpHIO->m.field_0x8c, 0.5f);
             mAcch.SetWallNone();
             if (!cLib_calcTimer(&mEventTimer)) {
                 ret_val = 1;
@@ -1548,8 +1581,8 @@ int daNpc_Bou_c::talk(void* param_0) {
                     daNpcT_offTmpBit(0x59);
                     daHorse_c* horse_p = dComIfGp_getHorseActor();
                     if (horse_p && !horse_p->checkHorseCallWait()) {
-                        if (chkPointInArea(horse_p->current.pos, current.pos, daNpc_Bou_Param_c::m.field_0x90,
-                                           daNpc_Bou_Param_c::m.field_0x94, daNpc_Bou_Param_c::m.field_0x98, 0)) {
+                        if (chkPointInArea(horse_p->current.pos, current.pos, mpHIO->m.field_0x90,
+                                           mpHIO->m.field_0x94, mpHIO->m.field_0x98, 0)) {
                             daNpcT_onTmpBit(0x59);
                         }
                     }
@@ -1655,5 +1688,3 @@ actor_process_profile_definition g_profile_NPC_BOU = {
   fopAc_NPC_e,            // mActorType
   fopAc_CULLBOX_CUSTOM_e, // cullType
 };
-
-static daNpc_Bou_Param_c l_HIO;

--- a/src/d/actor/d_a_npc_chat.cpp
+++ b/src/d/actor/d_a_npc_chat.cpp
@@ -2180,21 +2180,11 @@ static char* l_evtNames[1] = {
 
 static char* l_myName = "Chat";
 
-static daNpcChat_Param_c l_HIO;
+static NPC_CHAT_HIO_CLASS l_HIO;
 
 daNpcChat_c::eventFunc daNpcChat_c::mEvtSeqList[1] = {
     NULL,
 };
-
-daNpcChat_c::daNpcChat_c() {}
-
-daNpcChat_c::~daNpcChat_c() {
-    removeResrc(mType, mObjNum);
-
-    if (heap != NULL) {
-        mAnm_p->stopZelAnime();
-    }
-}
 
 static anmTblPrm const l_objTbl[13] = {
     {"object", BMDR_B_TUBO},
@@ -2263,6 +2253,32 @@ daNpcChat_HIOParam const daNpcChat_Param_c::m = {
     false,
     false,
 };
+
+#if DEBUG
+daNpcChat_HIO_c::daNpcChat_HIO_c() {
+    m = daNpcChat_Param_c::m;
+}
+
+void daNpcChat_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpcChat_c::daNpcChat_c() {}
+
+daNpcChat_c::~daNpcChat_c() {
+    removeResrc(mType, mObjNum);
+
+    if (heap != NULL) {
+        mAnm_p->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
 
 BOOL daNpcChat_c::NpcCreate(int type) {
     J3DModelData* a_mdlData_p = getNpcMdlDataP(type);
@@ -2698,15 +2714,15 @@ cPhs__Step daNpcChat_c::Create() {
         mSound.setMdlType(mType, false, mTwilight & 0xFF);
 
         #if DEBUG
-        // mHIO = l_HIO;
-        mHIO->entryHIO("多人数会話NPC");
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("多人数会話NPC");
         #endif
 
         mAcchCir.SetWall(ChkWallH(mType), ChkWallR(mType));
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
-        mCcStts.Init(daNpcChat_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgType(0);
@@ -2789,7 +2805,7 @@ int daNpcChat_c::Execute() {
 }
 
 int daNpcChat_c::Draw() {
-    draw(0, 0, daNpcChat_Param_c::m.common.real_shadow_size, NULL, 0);
+    draw(0, 0, mpHIO->m.common.real_shadow_size, NULL, 0);
     return 1;
 }
 
@@ -3063,10 +3079,10 @@ void daNpcChat_c::setParam() {
     }
 
     #if DEBUG
-    scale.set(daNpcChat_Param_c::m.common.scale, daNpcChat_Param_c::m.common.scale, daNpcChat_Param_c::m.common.scale);
-    mAcchCir.SetWallR(daNpcChat_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpcChat_Param_c::m.common.knee_length);
-    gravity = daNpcChat_Param_c::m.common.gravity;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    gravity = mpHIO->m.common.gravity;
     #endif
 }
 
@@ -3577,153 +3593,153 @@ void daNpcChat_c::reset() {
 }
 
 void daNpcChat_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_TALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1 = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1 = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[1] = {&dat1};
-    daNpcF_anmPlayData dat2 = {ANM_WAIT_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_WAIT_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3 = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3 = {ANM_TALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[1] = {&dat3};
-    daNpcF_anmPlayData dat4 = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat4 = {ANM_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat4[1] = {&dat4};
-    daNpcF_anmPlayData dat5a = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat5b = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat5c = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat5d = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat5e = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat5f = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat5a = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5b = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5c = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5d = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5e = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5f = {ANM_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[6] = {&dat5a, &dat5b, &dat5c, &dat5d, &dat5e, &dat5f};
-    daNpcF_anmPlayData dat6 = {ANM_TALK_C, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat6 = {ANM_TALK_C, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat6[1] = {&dat6};
-    daNpcF_anmPlayData dat7a = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat7b = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat7c = {ANM_TALK_C, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat7d = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat7a = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat7b = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat7c = {ANM_TALK_C, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat7d = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[4] = {&dat7a, &dat7b, &dat7c, &dat7d};
-    daNpcF_anmPlayData dat8a = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat8b = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat8c = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat8d = {ANM_WAIT_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat8e = {ANM_TALK_C, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat8a = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat8b = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat8c = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat8d = {ANM_WAIT_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat8e = {ANM_TALK_C, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat8[5] = {&dat8a, &dat8b, &dat8c, &dat8d, &dat8e};
-    daNpcF_anmPlayData dat9a = {ANM_BROWSE_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat9b = {ANM_BROWSE_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat9a = {ANM_BROWSE_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat9b = {ANM_BROWSE_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[2] = {&dat9a, &dat9b};
-    daNpcF_anmPlayData dat10a = {ANM_BROWSE_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat10b = {ANM_BROWSE_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat10c = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat10d = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat10e = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat10a = {ANM_BROWSE_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat10b = {ANM_BROWSE_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat10c = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat10d = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat10e = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat10[5] = {&dat10a, &dat10b, &dat10c, &dat10d, &dat10e};
-    daNpcF_anmPlayData dat11a = {ANM_BROWSE_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11b = {ANM_BROWSE_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11c = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11d = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11e = {ANM_TALK_C, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11f = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat11a = {ANM_BROWSE_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11b = {ANM_BROWSE_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11c = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11d = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11e = {ANM_TALK_C, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11f = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat11[6] = {&dat11a, &dat11b, &dat11c, &dat11d, &dat11e, &dat11f};
-    daNpcF_anmPlayData dat12a = {ANM_2LADYTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat12b = {ANM_2NORMALTALK_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat12a = {ANM_2LADYTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat12b = {ANM_2NORMALTALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat12[2] = {&dat12a, &dat12b};
-    daNpcF_anmPlayData dat13a = {ANM_2LADYTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat13b = {ANM_2NORMALTALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat13a = {ANM_2LADYTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat13b = {ANM_2NORMALTALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat13[2] = {&dat13a, &dat13b};
-    daNpcF_anmPlayData dat14a = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat14b = {ANM_2LADYTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat14c = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat14d = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat14e = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat14a = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat14b = {ANM_2LADYTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat14c = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat14d = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat14e = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat14[5] = {&dat14a, &dat14b, &dat14c, &dat14d, &dat14e};
-    daNpcF_anmPlayData dat15a = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat15b = {ANM_2LADYTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat15c = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat15d = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat15e = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat15a = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat15b = {ANM_2LADYTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat15c = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat15d = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat15e = {ANM_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat15[5] = {&dat15a, &dat15b, &dat15c, &dat15d, &dat15e};
-    daNpcF_anmPlayData dat16a = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat16b = {ANM_2LADYTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat16c = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat16d = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat16e = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat16f = {ANM_2NORMALTALK_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat16a = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat16b = {ANM_2LADYTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat16c = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat16d = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat16e = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat16f = {ANM_2NORMALTALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat16[6] = {&dat16a, &dat16b, &dat16c, &dat16d, &dat16e, &dat16f};
-    daNpcF_anmPlayData dat17a = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat17b = {ANM_2LADYTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat17c = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat17d = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat17e = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat17f = {ANM_2NORMALTALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat17a = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat17b = {ANM_2LADYTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat17c = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat17d = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat17e = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat17f = {ANM_2NORMALTALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat17[6] = {&dat17a, &dat17b, &dat17c, &dat17d, &dat17e, &dat17f};
-    daNpcF_anmPlayData dat18a = {ANM_TALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18b = {ANM_2LADYTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18c = {ANM_2LADYTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18d = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18e = {ANM_TALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18f = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18g = {ANM_2NORMALTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat18h = {ANM_2NORMALTALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat18a = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18b = {ANM_2LADYTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18c = {ANM_2LADYTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18d = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18e = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18f = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18g = {ANM_2NORMALTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat18h = {ANM_2NORMALTALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat18[8] = {&dat18a, &dat18b, &dat18c, &dat18d, &dat18e, &dat18f, &dat18g, &dat18h};
-    daNpcF_anmPlayData dat19 = {ANM_LOOK_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat19 = {ANM_LOOK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat19[1] = {&dat19};
-    daNpcF_anmPlayData dat20 = {ANM_LOOK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat20 = {ANM_LOOK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat20[1] = {&dat20};
-    daNpcF_anmPlayData dat21a = {ANM_LOOK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat21b = {ANM_LOOK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat21c = {ANM_WAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat21a = {ANM_LOOK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat21b = {ANM_LOOK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat21c = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat21[3] = {&dat21a, &dat21b, &dat21c};
-    daNpcF_anmPlayData dat22 = {ANM_WAIT_WALL, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat22 = {ANM_WAIT_WALL, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat22[1] = {&dat22};
-    daNpcF_anmPlayData dat23a = {ANM_TALK_WALL, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat23b = {ANM_WAIT_WALL, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat23c = {ANM_TALK_B_WALL, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat23d = {ANM_WAIT_WALL, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat23e = {ANM_TALK_WALL, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat23f = {ANM_TALK_B_WALL, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat23a = {ANM_TALK_WALL, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat23b = {ANM_WAIT_WALL, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat23c = {ANM_TALK_B_WALL, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat23d = {ANM_WAIT_WALL, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat23e = {ANM_TALK_WALL, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat23f = {ANM_TALK_B_WALL, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat23[6] = {&dat23a, &dat23b, &dat23c, &dat23d, &dat23e, &dat23f};
-    daNpcF_anmPlayData dat24 = {ANM_SITWAIT_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat24 = {ANM_SITWAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat24[1] = {&dat24};
-    daNpcF_anmPlayData dat25a = {ANM_SITTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat25b = {ANM_SITWAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat25c = {ANM_SITTALK_A_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat25d = {ANM_SITWAIT_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat25e = {ANM_SITTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat25f = {ANM_SITTALK_A_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat25a = {ANM_SITTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat25b = {ANM_SITWAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat25c = {ANM_SITTALK_A_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat25d = {ANM_SITWAIT_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat25e = {ANM_SITTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat25f = {ANM_SITTALK_A_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat25[6] = {&dat25a, &dat25b, &dat25c, &dat25d, &dat25e, &dat25f};
-    daNpcF_anmPlayData dat26 = {ANM_SITWAIT_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat26 = {ANM_SITWAIT_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat26[1] = {&dat26};
-    daNpcF_anmPlayData dat27a = {ANM_SITTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat27b = {ANM_SITWAIT_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat27c = {ANM_SITTALK_B_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat27d = {ANM_SITWAIT_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat27e = {ANM_SITTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat27f = {ANM_SITTALK_B_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat27a = {ANM_SITTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat27b = {ANM_SITWAIT_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat27c = {ANM_SITTALK_B_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat27d = {ANM_SITWAIT_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat27e = {ANM_SITTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat27f = {ANM_SITTALK_B_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat27[6] = {&dat27a, &dat27b, &dat27c, &dat27d, &dat27e, &dat27f};
-    daNpcF_anmPlayData dat28 = {ANM_SING, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat28 = {ANM_SING, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat28[1] = {&dat28};
-    daNpcF_anmPlayData dat29 = {ANM_SITTALK_A, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat29 = {ANM_SITTALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat29[1] = {&dat29};
-    daNpcF_anmPlayData dat30 = {ANM_SITTALK_A_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat30 = {ANM_SITTALK_A_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat30[1] = {&dat30};
-    daNpcF_anmPlayData dat31a = {ANM_SITTALK_A, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat31b = {ANM_SITTALK_A_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat31a = {ANM_SITTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat31b = {ANM_SITTALK_A_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat31[2] = {&dat31a, &dat31b};
-    daNpcF_anmPlayData dat32 = {ANM_SITTALK_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat32 = {ANM_SITTALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat32[1] = {&dat32};
-    daNpcF_anmPlayData dat33 = {ANM_SITTALK_B_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat33 = {ANM_SITTALK_B_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat33[1] = {&dat33};
-    daNpcF_anmPlayData dat34a = {ANM_SITTALK_B, daNpcChat_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat34b = {ANM_SITTALK_B_B, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat34a = {ANM_SITTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat34b = {ANM_SITTALK_B_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat34[2] = {&dat34a, &dat34b};
-    daNpcF_anmPlayData dat35 = {ANM_KAMAE, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat35 = {ANM_KAMAE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat35[1] = {&dat35};
-    daNpcF_anmPlayData dat36 = {ANM_KAMAE_C, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat36 = {ANM_KAMAE_C, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat36[1] = {&dat36};
-    daNpcF_anmPlayData dat37 = {ANM_KAMAE_STEP, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat37 = {ANM_KAMAE_STEP, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat37[1] = {&dat37};
-    daNpcF_anmPlayData dat38 = {ANM_SURPRISE, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat38 = {ANM_SURPRISE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat38[1] = {&dat38};
-    daNpcF_anmPlayData dat39 = {ANM_TO_WOLF, daNpcChat_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat39 = {ANM_TO_WOLF, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat39[1] = {&dat39};
 
     daNpcF_anmPlayData** ppDat[40] = {

--- a/src/d/actor/d_a_npc_doorboy.cpp
+++ b/src/d/actor/d_a_npc_doorboy.cpp
@@ -115,23 +115,11 @@ static char* l_evtNames[1] = {NULL};
 
 static char* l_myName = "DoorBoy";
 
-static daNpcDoorBoy_Param_c l_HIO;
+static NPC_DOORBOY_HIO_CLASS l_HIO;
 
 daNpcDoorBoy_c::EventFn daNpcDoorBoy_c::mEvtSeqList[1] = {
     NULL
 };
-
-daNpcDoorBoy_c::daNpcDoorBoy_c() {}
-
-daNpcDoorBoy_c::~daNpcDoorBoy_c() {
-    for (int i = 0; i < 2; i++) {
-        dComIfG_resDelete(&mPhases[i], l_arcNames[i]);
-    }
-
-    if (heap != NULL) {
-        mAnm_p->stopZelAnime();
-    }
-}
 
 daNpcDoorBoy_HIOParam const daNpcDoorBoy_Param_c::m = {
     55.0f,
@@ -169,6 +157,34 @@ daNpcDoorBoy_HIOParam const daNpcDoorBoy_Param_c::m = {
     false,
 };
 
+#if DEBUG
+daNpcDoorBoy_HIO_c::daNpcDoorBoy_HIO_c() {
+    m = daNpcDoorBoy_Param_c::m;
+}
+
+void daNpcDoorBoy_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpcDoorBoy_c::daNpcDoorBoy_c() {}
+
+daNpcDoorBoy_c::~daNpcDoorBoy_c() {
+    for (int i = 0; i < 2; i++) {
+        dComIfG_resDelete(&mPhases[i], l_arcNames[i]);
+    }
+
+    if (heap != NULL) {
+        mAnm_p->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
+
 cPhs__Step daNpcDoorBoy_c::Create() {
     fopAcM_ct(this, daNpcDoorBoy_c);
 
@@ -193,18 +209,23 @@ cPhs__Step daNpcDoorBoy_c::Create() {
         mSound.init(&current.pos, &eyePos, 3, 1);
         mSound.setMdlType(5, false, dKy_darkworld_check());
 
-        mAcchCir.SetWall(daNpcDoorBoy_Param_c::m.common.width, daNpcDoorBoy_Param_c::m.common.knee_length);
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ドアボーイ");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                 fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
-        mCcStts.Init(daNpcDoorBoy_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
 
         field_0xc98.Set(mCcDCyl);
         field_0xc98.SetStts(&mCcStts);
         field_0xc98.SetTgType(0);
         field_0xc98.SetTgSPrm(0);
-        field_0xc98.SetH(daNpcDoorBoy_Param_c::m.common.height);
-        field_0xc98.SetR(daNpcDoorBoy_Param_c::m.common.width);
+        field_0xc98.SetH(mpHIO->m.common.height);
+        field_0xc98.SetR(mpHIO->m.common.width);
 
         mGndChk = mAcch.m_gnd;
         mGroundH = mAcch.GetGroundH();
@@ -257,7 +278,7 @@ int daNpcDoorBoy_c::Execute() {
 }
 
 int daNpcDoorBoy_c::Draw() {
-    draw(FALSE, FALSE, daNpcDoorBoy_Param_c::m.common.real_shadow_size, NULL, FALSE);
+    draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, FALSE);
     dComIfGd_setSimpleShadow(&current.pos, mAcch.GetGroundH(), 50.0f, mAcch.m_gnd, 0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
     return 1;
 }
@@ -281,7 +302,7 @@ int daNpcDoorBoy_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
         case JNT_BACKBONE:
         case JNT_NECK:
         case JNT_HEAD:
-            setLookatMtx(jointNo, i_jointList, daNpcDoorBoy_Param_c::m.common.neck_rotation_ratio);
+            setLookatMtx(jointNo, i_jointList, mpHIO->m.common.neck_rotation_ratio);
     }
 
     i_model->setAnmMtx(jointNo, mDoMtx_stack_c::get());
@@ -374,17 +395,17 @@ BOOL daNpcDoorBoy_c::setAction(actionFunc action) {
 }
 
 inline void daNpcDoorBoy_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {ANM_WAIT_A, daNpcDoorBoy_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1 = {ANM_SING, daNpcDoorBoy_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1 = {ANM_SING, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[1] = {&dat1};
-    daNpcF_anmPlayData dat2 = {ANM_TALK_B, daNpcDoorBoy_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3 = {ANM_TALK_A, daNpcDoorBoy_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3 = {ANM_TALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[1] = {&dat3};
-    daNpcF_anmPlayData dat4 = {ANM_TALK_C, daNpcDoorBoy_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat4 = {ANM_TALK_C, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat4[1] = {&dat4};
-    daNpcF_anmPlayData dat5 = {ANM_SIT_TO_WOLF_A, daNpcDoorBoy_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat5 = {ANM_SIT_TO_WOLF_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[1] = {&dat5};
     daNpcF_anmPlayData** ppDat[12] = {
         pDat0,
@@ -412,14 +433,14 @@ inline void daNpcDoorBoy_c::lookat() {
     J3DModel* model_p = mAnm_p->getModel();
 
     int iVar1 = 0;
-    f32 body_angleX_min = daNpcDoorBoy_Param_c::m.common.body_angleX_min;
-    f32 body_angleX_max = daNpcDoorBoy_Param_c::m.common.body_angleX_max;
-    f32 body_angleY_min = daNpcDoorBoy_Param_c::m.common.body_angleY_min;
-    f32 body_angleY_max = daNpcDoorBoy_Param_c::m.common.body_angleY_max;
-    f32 head_angleX_min = daNpcDoorBoy_Param_c::m.common.head_angleX_min;
-    f32 head_angleX_max = daNpcDoorBoy_Param_c::m.common.head_angleX_max;
-    f32 head_angleY_min = daNpcDoorBoy_Param_c::m.common.head_angleY_min;
-    f32 head_angleY_max = daNpcDoorBoy_Param_c::m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
 
     s16 temp_r26 = mCurAngle.y - mOldAngle.y;
     cXyz sp30[] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
@@ -460,7 +481,7 @@ inline void daNpcDoorBoy_c::lookat() {
 
 inline bool daNpcDoorBoy_c::chkFindPlayer() {
     bool rv;
-    if (!chkActorInSight(daPy_getPlayerActorClass(), daNpcDoorBoy_Param_c::m.common.fov)) {
+    if (!chkActorInSight(daPy_getPlayerActorClass(), mpHIO->m.common.fov)) {
         mActorMngr[0].remove();
         return false;
     }
@@ -786,16 +807,16 @@ static int daNpcDoorBoy_IsDelete(void* a_this) {
 }
 
 void daNpcDoorBoy_c::setParam() {
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(daNpcDoorBoy_Param_c::m.common.attention_distance,
-                                                                  daNpcDoorBoy_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance,
+                                                                  mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcDoorBoy_Param_c::m.common.talk_distance,
-                                                                   daNpcDoorBoy_Param_c::m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance,
+                                                                   mpHIO->m.common.talk_angle);
     attention_info.flags = daPy_py_c::checkNowWolf() ? 0 : (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    scale.setall(daNpcDoorBoy_Param_c::m.common.scale);
-    mAcchCir.SetWallR(daNpcDoorBoy_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpcDoorBoy_Param_c::m.common.knee_length);
-    gravity = daNpcDoorBoy_Param_c::m.common.gravity;
+    scale.setall(mpHIO->m.common.scale);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpcDoorBoy_c::main() {
@@ -835,8 +856,8 @@ void daNpcDoorBoy_c::setAttnPos() {
     
     field_0xc98.SetC(sp28);
     #if DEBUG
-    field_0xc98.SetH(daNpcDoorBoy_Param_c::m.common.height);
-    field_0xc98.SetR(daNpcDoorBoy_Param_c::m.common.width);
+    field_0xc98.SetH(mpHIO->m.common.height);
+    field_0xc98.SetR(mpHIO->m.common.width);
     #endif
     dComIfG_Ccsp()->Set(&field_0xc98);
 }

--- a/src/d/actor/d_a_npc_drainSol.cpp
+++ b/src/d/actor/d_a_npc_drainSol.cpp
@@ -23,16 +23,6 @@ static char* l_arcNames[2] = {
     "DrainSol2",
 };
 
-daNpcDrSol_c::daNpcDrSol_c() {}
-
-daNpcDrSol_c::~daNpcDrSol_c() {
-    dComIfG_resDelete(&mPhase, l_arcNames[mType]);
-
-    if (heap != NULL) {
-        mAnm_p->stopZelAnime();
-    }
-}
-
 const daNpcDrSol_HIOParam daNpcDrSol_Param_c::m = {
     40.0f,
     0.0f,
@@ -69,6 +59,34 @@ const daNpcDrSol_HIOParam daNpcDrSol_Param_c::m = {
     0,
 };
 
+static NPC_DRSOL_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpcDrSol_HIO_c::daNpcDrSol_HIO_c() {
+    m = daNpcDrSol_Param_c::m;
+}
+
+void daNpcDrSol_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpcDrSol_c::daNpcDrSol_c() {}
+
+daNpcDrSol_c::~daNpcDrSol_c() {
+    dComIfG_resDelete(&mPhase, l_arcNames[mType]);
+
+    if (heap != NULL) {
+        mAnm_p->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
+
 int daNpcDrSol_c::Create() {
     fopAcM_ct(this, daNpcDrSol_c);
 
@@ -91,7 +109,12 @@ int daNpcDrSol_c::Create() {
         fopAcM_setCullSizeBox(this, -60.0f, -10.0f, -60.0f, 60.0f, 200.0f, 60.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-        mAcchCir.SetWall(daNpcDrSol_Param_c::m.common.width, daNpcDrSol_Param_c::m.common.knee_length);
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("下水道の兵士");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                   &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -167,7 +190,7 @@ int daNpcDrSol_c::Execute() {
 }
 
 int daNpcDrSol_c::Draw() {
-    draw(FALSE, FALSE, daNpcDrSol_Param_c::m.common.real_shadow_size, NULL, 0);
+    draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, 0);
     return 1;
 }
 
@@ -185,17 +208,17 @@ int daNpcDrSol_c::createHeapCallBack(fopAc_ac_c* actor) {
 }
 
 void daNpcDrSol_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {0, daNpcDrSol_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {0, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[] = {&dat0};
 
-    daNpcF_anmPlayData dat1 = {1, daNpcDrSol_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1 = {1, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[] = {&dat1};
 
-    daNpcF_anmPlayData dat2a = {2, daNpcDrSol_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat2a = {2, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat2b = {1, 0.0f, 0};
     daNpcF_anmPlayData* pDat2[] = {&dat2a, &dat2b};
 
-    daNpcF_anmPlayData dat3a = {0, daNpcDrSol_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3a = {0, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[] = {&dat3a};
 
     daNpcF_anmPlayData** ppDat[5] = {
@@ -236,9 +259,9 @@ void daNpcDrSol_c::reset() {
 
     mTwilight = dKy_darkworld_check();
 
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(daNpcDrSol_Param_c::m.common.attention_distance, daNpcDrSol_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcDrSol_Param_c::m.common.talk_distance, daNpcDrSol_Param_c::m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
 
     setAction(&daNpcDrSol_c::wait);
 }
@@ -373,12 +396,12 @@ void daNpcDrSol_c::setParam() {
     }
 
     #if PLATFORM_SHIELD
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(daNpcDrSol_Param_c::m.common.attention_distance, daNpcDrSol_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcDrSol_Param_c::m.common.talk_distance, daNpcDrSol_Param_c::m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
 
-    mAcchCir.SetWallR(daNpcDrSol_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpcDrSol_Param_c::m.common.knee_length);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
     #endif
 }
 
@@ -400,7 +423,7 @@ void daNpcDrSol_c::setAttnPos() {
     mDoMtx_stack_c::multVecZero(&mHeadPos);
     mDoMtx_stack_c::multVec(&sp14, &eyePos);
 
-    attention_info.position.set(mHeadPos.x, mHeadPos.y + daNpcDrSol_Param_c::m.common.attention_offset, mHeadPos.z);
+    attention_info.position.set(mHeadPos.x, mHeadPos.y + mpHIO->m.common.attention_offset, mHeadPos.z);
 
     cXyz sp8;
     mDoMtx_stack_c::copy(mAnm_p->getModel()->getAnmMtx(2));
@@ -408,8 +431,8 @@ void daNpcDrSol_c::setAttnPos() {
     sp8.y = current.pos.y;
 
     mCyl.SetC(sp8);
-    mCyl.SetH(daNpcDrSol_Param_c::m.common.height);
-    mCyl.SetR(daNpcDrSol_Param_c::m.common.width);
+    mCyl.SetH(mpHIO->m.common.height);
+    mCyl.SetR(mpHIO->m.common.width);
     dComIfG_Ccsp()->Set(&mCyl);
 }
 
@@ -429,8 +452,6 @@ void daNpcDrSol_c::setMotionAnm(int i_index, f32 i_morf) {
 BOOL daNpcDrSol_c::drawDbgInfo() {
     return false;
 }
-
-static daNpcDrSol_Param_c l_HIO;
 
 static char* dummyString() {
     return "Shoe";

--- a/src/d/actor/d_a_npc_fairy_seirei.cpp
+++ b/src/d/actor/d_a_npc_fairy_seirei.cpp
@@ -60,18 +60,37 @@ daNpc_FairySeirei_c::cutFunc daNpc_FairySeirei_c::mCutList[1] = {
     NULL,
 };
 
+
+const daNpc_FairySeirei_HIOParam daNpc_FairySeirei_Param_c::m = {
+    600.0f, 0.0f, 1.0f, 4000.0f, 255.0f, 200.0f, 0.0f, 60.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+    0.0f,   0.0f, 0.0f, 0.0f,    0,      0,      0,    0,     0.0f, 0.0f, 0.0f, 0.0f, 0,    0,
+    0,      0,    0,    0,       0,      0.0f,   0.0f, 0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+    600.0f,
+};
+
+static NPC_FAIRY_SEIREI_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_FairySeirei_HIO_c::daNpc_FairySeirei_HIO_c() {
+    m = daNpc_FairySeirei_Param_c::m;
+}
+
+void daNpc_FairySeirei_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daNpc_FairySeirei_c::~daNpc_FairySeirei_c() {
     if (heap != NULL) {
         mpMorf[0]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 }
-
-
-const f32 daNpc_FairySeirei_Param_c::m[37] = {
-    600.0f, 0.0f, 1.0f, 4000.0f, 255.0f, 200.0f, 0.0f, 60.0f, 0.0f, 0.0f, 0.0f,   0.0f, 0.0f,
-    0.0f,   0.0f, 0.0f, 0.0f,    0.0f,   0.0f,   0.0f, 0.0f,  0.0f, 0.0f, 0.0f,   0.0f, 0.0f,
-    0.0f,   0.0f, 0.0f, 0.0f,    0.0f,   0.0f,   0.0f, 0.0f,  0.0f, 0.0f, 600.0f,
-};
 
 int daNpc_FairySeirei_c::create() {
     daNpcT_ct(this, daNpc_FairySeirei_c, &l_faceMotionAnmData, l_motionAnmData,
@@ -83,9 +102,15 @@ int daNpc_FairySeirei_c::create() {
     if (isDelete()) {
         return cPhs_ERROR_e;
     }
+
+#if DEBUG
+    mpHIO = &l_HIO;
+    mpHIO->entryHIO("大妖精の残留思念");
+#endif
+
     mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
               fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-    mCcStts.Init(daNpc_FairySeirei_Param_c::m[4], 0, this);
+    mCcStts.Init(mpHIO->m.common.weight, 0, this);
     mCyl.Set(mCcDCyl);
     mCyl.SetStts(&mCcStts);
     mAcch.CrrPos(dComIfG_Bgsp());
@@ -140,24 +165,24 @@ void daNpc_FairySeirei_c::reset() {
 void daNpc_FairySeirei_c::setParam() {
     selectAction();
     srchActors();
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = daNpc_FairySeirei_Param_c::m[36];
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = daNpc_FairySeirei_Param_c::m[36];
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = daNpc_FairySeirei_Param_c::m[36];
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = daNpc_FairySeirei_Param_c::m[36];
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.field_0x90;
     attention_info.distances[fopAc_attn_LOCK_e] = 0x27;
     attention_info.distances[fopAc_attn_TALK_e] = 0x27;
     attention_info.distances[fopAc_attn_SPEAK_e] = 0x27;
     attention_info.flags = fopAc_AttnFlag_SPEAK_e;
-    mCcStts.SetWeight(daNpc_FairySeirei_Param_c::m[4]);
-    mCylH = daNpc_FairySeirei_Param_c::m[5];
-    mWallR = daNpc_FairySeirei_Param_c::m[7];
-    mAttnFovY = daNpc_FairySeirei_Param_c::m[20];
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_FairySeirei_Param_c::m[6]);
-    mRealShadowSize = daNpc_FairySeirei_Param_c::m[3];
-    mExpressionMorfFrame = daNpc_FairySeirei_Param_c::m[27];
-    mMorfFrames = daNpc_FairySeirei_Param_c::m[17];
-    gravity = daNpc_FairySeirei_Param_c::m[1];
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 void daNpc_FairySeirei_c::srchActors() {
@@ -245,7 +270,7 @@ void daNpc_FairySeirei_c::setCollision() {
 
 void daNpc_FairySeirei_c::setAttnPos() {
     attention_info.position = current.pos;
-    attention_info.position.y += daNpc_FairySeirei_Param_c::m[0] - 350.0f;
+    attention_info.position.y += mpHIO->m.common.attention_offset - 350.0f;
     eyePos = attention_info.position;
     setPrtcls();
     ptcl_se();
@@ -385,9 +410,6 @@ static int daNpc_FairySeirei_Draw(void* i_this) {
 static int daNpc_FairySeirei_IsDelete(void* i_this) {
     return 1;
 }
-
-
-static daNpc_FairySeirei_Param_c l_HIO;
 
 static actor_method_class daNpc_FairySeirei_MethodTable = {
     daNpc_FairySeirei_Create,   daNpc_FairySeirei_Delete, daNpc_FairySeirei_Execute,

--- a/src/d/actor/d_a_npc_gra.cpp
+++ b/src/d/actor/d_a_npc_gra.cpp
@@ -26,12 +26,6 @@ const daNpc_grA_HIOParam daNpc_grA_Param_c::m = {
     1.35f,
 };
 
-#if DEBUG
-#define GET_HIO(x) mpHio->mHioParams.x
-#else
-#define GET_HIO(x) daNpc_grA_Param_c::m.x
-#endif
-
 static int l_bmdGetParamList[][2] = {
     3, 1,
     3, 2,
@@ -131,7 +125,7 @@ static int l_evtGetParamList[][2] = {
 
 #if DEBUG
 daNpc_grA_HIO_c::daNpc_grA_HIO_c() {
-    mHioParams = daNpc_grA_Param_c::m;
+    m = daNpc_grA_Param_c::m;
 }
 #endif
 
@@ -256,20 +250,20 @@ void daNpc_grA_HIO_c::listenPropertyEvent(const JORPropertyEvent* i_event) {
         if (file.open(6, "すべてのファイル(*.*)\0*.*\0", NULL, NULL, NULL)) {
             memset(buff, 0, sizeof(buff));
             len = 0;
-            daNpcF_commonListenPropertyEvent(buff, &len, &this->mHioParams.mNpcFParams);
-            sprintf(buff + len, "%d,   \t//  お辞儀タイマー\n", this->mHioParams.mBowTimer);
+            daNpcF_commonListenPropertyEvent(buff, &len, &m.common);
+            sprintf(buff + len, "%d,   \t//  お辞儀タイマー\n", m.mBowTimer);
             len = strlen(buff);
-            sprintf(buff + len, "%3.3f,   \t//  回転移動速度係数\n", this->mHioParams.mRotationalSpeed);
+            sprintf(buff + len, "%3.3f,   \t//  回転移動速度係数\n", m.mRotationalSpeed);
             len = strlen(buff);
-            sprintf(buff + len, "%3.3f,   \t//  歩き移動速度\n", this->mHioParams.mWalkingSpeed);
+            sprintf(buff + len, "%3.3f,   \t//  歩き移動速度\n", m.mWalkingSpeed);
             len = strlen(buff);
-            sprintf(buff + len, "%3.3f,   \t//  歩きアニメ速度\n", this->mHioParams.mWalkingAnimationSpeed);
+            sprintf(buff + len, "%3.3f,   \t//  歩きアニメ速度\n", m.mWalkingAnimationSpeed);
             len = strlen(buff);
-            sprintf(buff + len, "%d,   \t//  歩行回転速度\n", this->mHioParams.mWalkingRotationSpeed);
+            sprintf(buff + len, "%d,   \t//  歩行回転速度\n", m.mWalkingRotationSpeed);
             len = strlen(buff);
-            sprintf(buff + len, "%d,   \t//  歩行回転分割数\n", this->mHioParams.mWalkingRotationDivisions);
+            sprintf(buff + len, "%d,   \t//  歩行回転分割数\n", m.mWalkingRotationDivisions);
             len = strlen(buff);
-            sprintf(buff + len, "%3.3f,   \t//  パーティクルサイズ\n", this->mHioParams.mParticleSize);
+            sprintf(buff + len, "%3.3f,   \t//  パーティクルサイズ\n", m.mParticleSize);
             // @BUG: should update len here, otherwise the final length won't include the final sprintf
             file.writeData(buff, len);
             file.close();
@@ -281,14 +275,14 @@ void daNpc_grA_HIO_c::listenPropertyEvent(const JORPropertyEvent* i_event) {
 }
 
 void daNpc_grA_HIO_c::genMessage(JORMContext* context) {
-    daNpcF_commonGenMessage(context, &mHioParams.mNpcFParams);
-    context->genSlider("お辞儀タイマー  ", &mHioParams.mBowTimer, 0, 1000, 0, NULL, -1, -1, 0x200, 0x18);
-    context->genSlider("回転移動速度係数", &mHioParams.mRotationalSpeed, 0.0f, 100.0f, 0, NULL, -1, -1, 0x200, 0x18);
-    context->genSlider("歩き移動速度    ", &mHioParams.mWalkingSpeed, 0.0f, 100.0f, 0, NULL, -1, -1, 0x200, 0x18);
-    context->genSlider("歩きアニメ速度  ", &mHioParams.mWalkingAnimationSpeed, 0.0f, 10.0f, 0, NULL, -1, -1, 0x200, 0x18);
-    context->genSlider("歩行回転角度    ", &mHioParams.mWalkingRotationSpeed, 0, 0x7fff, 0, NULL, -1, -1, 0x200, 0x18);
-    context->genSlider("歩行回転分割数  ", &mHioParams.mWalkingRotationDivisions, 0, 0x100, 0, NULL, -1, -1, 0x200, 0x18);
-    context->genSlider("エフェクトサイズ", &mHioParams.mParticleSize, 0.0f, 10.0f, 0, NULL, -1, -1, 0x200, 0x18);
+    daNpcF_commonGenMessage(context, &m.common);
+    context->genSlider("お辞儀タイマー  ", &m.mBowTimer, 0, 1000, 0, NULL, -1, -1, 0x200, 0x18);
+    context->genSlider("回転移動速度係数", &m.mRotationalSpeed, 0.0f, 100.0f, 0, NULL, -1, -1, 0x200, 0x18);
+    context->genSlider("歩き移動速度    ", &m.mWalkingSpeed, 0.0f, 100.0f, 0, NULL, -1, -1, 0x200, 0x18);
+    context->genSlider("歩きアニメ速度  ", &m.mWalkingAnimationSpeed, 0.0f, 10.0f, 0, NULL, -1, -1, 0x200, 0x18);
+    context->genSlider("歩行回転角度    ", &m.mWalkingRotationSpeed, 0, 0x7fff, 0, NULL, -1, -1, 0x200, 0x18);
+    context->genSlider("歩行回転分割数  ", &m.mWalkingRotationDivisions, 0, 0x100, 0, NULL, -1, -1, 0x200, 0x18);
+    context->genSlider("エフェクトサイズ", &m.mParticleSize, 0.0f, 10.0f, 0, NULL, -1, -1, 0x200, 0x18);
     context->genButton("ファイル書き出し", 0x40000002, 0, NULL, -1, -1, 0x200, 0x18);
 }
 #endif
@@ -336,8 +330,8 @@ daNpc_grA_c::~daNpc_grA_c() {
     }
 
 #if DEBUG
-    if (mpHio != NULL) {
-        mpHio->removeHIO();
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
     }
 #endif
 }
@@ -381,21 +375,21 @@ BOOL daNpc_grA_c::create() {
         mCreature.init(&current.pos, &eyePos, 3, 1);
 
 #if DEBUG
-        mpHio = &l_HIO;
-        mpHio->entryHIO("ゴロン一般");
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ゴロン一般");
 #endif
 
         f32 v;
         if (mType == 2) {
             v = 120.0f;
         } else {
-            v = GET_HIO(mNpcFParams.width);
+            v = mpHIO->m.common.width;
         }
-        mAcchCir.SetWall(v, GET_HIO(mNpcFParams.knee_length));
+        mAcchCir.SetWall(v, mpHIO->m.common.knee_length);
 
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(GET_HIO(mNpcFParams.weight), 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
 
         field_0xC98.Set(mCcDCyl);
         field_0xC98.SetStts(&mCcStts);
@@ -503,7 +497,7 @@ BOOL daNpc_grA_c::Execute() {
 }
 
 BOOL daNpc_grA_c::Draw() {
-    return draw(chkAction(&daNpc_grA_c::test), 0, GET_HIO(mNpcFParams.real_shadow_size), NULL, 0);
+    return draw(chkAction(&daNpc_grA_c::test), 0, mpHIO->m.common.real_shadow_size, NULL, 0);
 }
 
 BOOL daNpc_grA_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
@@ -525,7 +519,7 @@ BOOL daNpc_grA_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
     case 1:
     case 3:
     case 4:
-        setLookatMtx(jntNo, arr, GET_HIO(mNpcFParams.neck_rotation_ratio));
+        setLookatMtx(jntNo, arr, mpHIO->m.common.neck_rotation_ratio);
     }
 
     if (jntNo == 1) {
@@ -719,10 +713,10 @@ void daNpc_grA_c::setParam() {
     } else {
         field_0x145C = 0;
         field_0x1460 = 0;
-        talkDistance = GET_HIO(mNpcFParams.talk_distance);
-        talkAngle = GET_HIO(mNpcFParams.talk_angle);
-        attnDistance = GET_HIO(mNpcFParams.attention_distance);
-        attnAngle = GET_HIO(mNpcFParams.attention_angle);
+        talkDistance = mpHIO->m.common.talk_distance;
+        talkAngle = mpHIO->m.common.talk_angle;
+        attnDistance = mpHIO->m.common.attention_distance;
+        attnAngle = mpHIO->m.common.attention_angle;
     }
 
     if (mType == 5)
@@ -745,17 +739,17 @@ void daNpc_grA_c::setParam() {
             attention_info.flags = flags;
         }
     }
-    scale.set(GET_HIO(mNpcFParams.scale), GET_HIO(mNpcFParams.scale), GET_HIO(mNpcFParams.scale));
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
     f32 width;
     if (mType == 2) {
         width = 120.0f;
     } else {
-        width = GET_HIO(mNpcFParams.width);
+        width = mpHIO->m.common.width;
     }
     mAcchCir.SetWallR(width);
-    mAcchCir.SetWallH(GET_HIO(mNpcFParams.knee_length));
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
     if (mType != 6) {
-        gravity = GET_HIO(mNpcFParams.gravity);
+        gravity = mpHIO->m.common.gravity;
     }
 }
 
@@ -764,7 +758,7 @@ BOOL daNpc_grA_c::main() {
     JUT_ASSERT(1367, mAnm_p != NULL); // TODO: update "mAnm_p" to "mAnm_p"
     if (doEvent() == 0) {
         if (hitChk2(&field_0xC98, TRUE, FALSE)) {
-            setDamage(GET_HIO(mNpcFParams.damage_time), 0x17, 0);
+            setDamage(mpHIO->m.common.damage_time, 0x17, 0);
             setLookMode(1);
         } else if (mIsDamaged && mDamageTimer == 0) {
             field_0x1472 = 0;
@@ -783,7 +777,7 @@ BOOL daNpc_grA_c::main() {
     if (checkHide()) {
         attention_info.flags = 0;
     }
-    if (GET_HIO(mNpcFParams.debug_mode_ON) == 0 &&
+    if (mpHIO->m.common.debug_mode_ON == 0 &&
         (!dComIfGp_event_runCheck() || (mOrderNewEvt && dComIfGp_getEvent()->isOrderOK())))
     {
         u16 j = 1;
@@ -820,7 +814,7 @@ void daNpc_grA_c::setAttnPos() {
     cXyz viewVector, offset, o_pos;
     f32 attnOffset = 0.0f;
     if (mOrderEvtNo != 1) {
-        attnOffset = GET_HIO(mNpcFParams.attention_offset);
+        attnOffset = mpHIO->m.common.attention_offset;
     }
     mDoMtx_stack_c::YrotS(field_0x990);
     cLib_addCalc2(&field_0x984[0], 0.0f, 0.1f, 125.0f);
@@ -893,12 +887,12 @@ void daNpc_grA_c::setAttnPos() {
             }
         }
         f32 width = 0.0f;
-        f32 height = GET_HIO(mNpcFParams.height);
+        f32 height = mpHIO->m.common.height;
         if (mType == 2) {
             width = 120.0f;
             height = 215.0f;
         } else {
-            width = GET_HIO(mNpcFParams.width);
+            width = mpHIO->m.common.width;
         }
         if (chkAction(&daNpc_grA_c::waitSpaWater)) {
             cXyz center(0.0f, 0.0f, -80.0f);
@@ -1179,7 +1173,7 @@ void daNpc_grA_c::setMotion(int i_motion, f32 i_MorfOverride, int param_2) {
 
 BOOL daNpc_grA_c::drawDbgInfo() {
 #if DEBUG
-    if (GET_HIO(mNpcFParams.debug_info_ON) != 0) {
+    if (mpHIO->m.common.debug_info_ON != 0) {
         cXyz o_pos;
         f32 maxSpeakDist = dComIfGp_getAttention()->getDistTable(attention_info.distances[fopAc_attn_SPEAK_e]).mDistMax;
         f32 maxTalkDist = dComIfGp_getAttention()->getDistTable(attention_info.distances[fopAc_attn_TALK_e]).mDistMax;
@@ -1191,23 +1185,23 @@ BOOL daNpc_grA_c::drawDbgInfo() {
         dDbVw_drawCircleOpa(attention_info.position, maxTalkDist, (GXColor){0xc8, 0, 0, 0xff}, 1,
                             12);
 
-        if (GET_HIO(mNpcFParams.fov) != 180.0f) {
-            cXyz offset(0.0f, 0.0f, GET_HIO(mNpcFParams.search_distance));
+        if (mpHIO->m.common.fov != 180.0f) {
+            cXyz offset(0.0f, 0.0f, mpHIO->m.common.search_distance);
             mDoMtx_stack_c::transS(attention_info.position);
             mDoMtx_stack_c::YrotM(mHeadAngle.y);
-            mDoMtx_stack_c::YrotM(cM_deg2s(-GET_HIO(mNpcFParams.fov)));
+            mDoMtx_stack_c::YrotM(cM_deg2s(-mpHIO->m.common.fov));
             mDoMtx_stack_c::multVec(&offset, &o_pos);
 
             dDbVw_drawLineOpa(attention_info.position, o_pos, (GXColor){0, 0, 0xc8, 0xff}, 1, 12);
 
             mDoMtx_stack_c::transS(attention_info.position);
             mDoMtx_stack_c::YrotM(mHeadAngle.y);
-            mDoMtx_stack_c::YrotM(cM_deg2s(GET_HIO(mNpcFParams.fov)));
+            mDoMtx_stack_c::YrotM(cM_deg2s(mpHIO->m.common.fov));
             mDoMtx_stack_c::multVec(&offset, &o_pos);
 
             dDbVw_drawLineOpa(attention_info.position, o_pos, (GXColor){0, 0, 0xc8, 0xff}, 1, 12);
         }
-        dDbVw_drawCircleOpa(attention_info.position, GET_HIO(mNpcFParams.search_distance),
+        dDbVw_drawCircleOpa(attention_info.position, mpHIO->m.common.search_distance,
                             (GXColor){0, 0, 0xc8, 0xff}, 1, 12);
 
         dDbVw_drawSphereXlu(eyePos, 18.f, (GXColor){0x80, 0x80, 0x80, 0xA0}, 1);
@@ -1456,82 +1450,82 @@ void daNpc_grA_c::reset() {
 }
 
 void daNpc_grA_c::playExpression() {
-    daNpcF_anmPlayData dat0 = {1, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat0_ = {0, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat0 = {1, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat0_ = {0, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[] = {&dat0, &dat0_};
  
-    daNpcF_anmPlayData dat1 = {2, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat1_ = {0, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat1 = {2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat1_ = {0, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[] = {&dat1, &dat1_};
  
-    daNpcF_anmPlayData dat2 = {7, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat2_ = {6, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat2 = {7, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat2_ = {6, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[] = {&dat2, &dat2_ };
     
-    daNpcF_anmPlayData dat3 = {5, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat3_ = {4, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat3 = {5, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat3_ = {4, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[] = {&dat3, &dat3_};
  
-    daNpcF_anmPlayData dat5 = {15, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat5_ = {12, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat5 = {15, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5_ = {12, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[] = {&dat5, &dat5_};
     
-    daNpcF_anmPlayData dat6 = {13, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat6_ = {14, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat6 = {13, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat6_ = {14, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat6[] = {&dat6, &dat6_};
  
-    daNpcF_anmPlayData dat7 = {0x13, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat7_ = {0x17, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat7 = {0x13, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat7_ = {0x17, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[] = {&dat7, &dat7_};
     
-    daNpcF_anmPlayData dat8 = {0x14, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat8_ = {0x17, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat8 = {0x14, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat8_ = {0x17, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat8[] = {&dat8, &dat8_};
  
-    daNpcF_anmPlayData dat9 = {0x15, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat9_ = {0xe, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat9 = {0x15, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat9_ = {0xe, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[] = {&dat9, &dat9_};
 
-    daNpcF_anmPlayData dat11 = {8, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat11 = {8, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat11[] = {&dat11};
 
-    daNpcF_anmPlayData dat12 = {9, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat12_ = {8, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat12 = {9, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat12_ = {8, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat12[] = {&dat12, &dat12_};
 
-    daNpcF_anmPlayData dat13 = {10, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat13 = {10, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat13[] = {&dat13};
 
-    daNpcF_anmPlayData dat14 = {0xb, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat14_ = {0xa, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat14 = {0xb, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat14_ = {0xa, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat14[] = {&dat14, &dat14_};
 
-    daNpcF_anmPlayData dat15 = {6, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat15 = {6, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat15[] = {&dat15};
 
-    daNpcF_anmPlayData dat16 = {4, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat16 = {4, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat16[] = {&dat16};
 
-    daNpcF_anmPlayData dat17 = {0xc, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat17 = {0xc, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat17[] = {&dat17};
 
-    daNpcF_anmPlayData dat18 = {0xe, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat18 = {0xe, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat18[] = {&dat18};
 
-    daNpcF_anmPlayData dat19 = {16, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat19 = {16, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat19[] = {&dat19};
 
-    daNpcF_anmPlayData dat20 = {17, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat20 = {17, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat20[] = {&dat20};
 
-    daNpcF_anmPlayData dat21 = {18, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat21 = {18, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat21_ = {0xe, 0.0f, 0};
     daNpcF_anmPlayData* pDat21[] = {&dat21, &dat21_};
     
-    daNpcF_anmPlayData dat22 = {12, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat22 = {12, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat22[] = {&dat22};
 
-    daNpcF_anmPlayData dat23 = {0, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat23 = {0, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat23[] = {&dat23};
     
     daNpcF_anmPlayData** ppDat[24] = {  
@@ -1567,81 +1561,81 @@ void daNpc_grA_c::playExpression() {
 }
 
 void daNpc_grA_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {0x16, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat0 = {0x16, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[] = {&dat0};
 
-    daNpcF_anmPlayData dat1 = {0x18, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat1 = {0x18, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[] = {&dat1};
 
-    daNpcF_anmPlayData dat2 = {0x27, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat2 = {0x27, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[] = {&dat2};
 
-    daNpcF_anmPlayData dat3 = {0x1D, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat3 = {0x1D, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat3_ = {0x16, 0.0f, 0};
     daNpcF_anmPlayData* pDat3[] = {&dat3, &dat3_};
 
-    daNpcF_anmPlayData dat4 = {0x1e, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat4 = {0x1e, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat4_ = {0x16, 0.0f, 0};
     daNpcF_anmPlayData* pDat4[] = {&dat4, &dat4_};
 
-    daNpcF_anmPlayData dat5 = {0x17, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat5 = {0x17, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[] = {&dat5};
 
-    daNpcF_anmPlayData dat6 = {0x28, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat6 = {0x28, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat6_ = {0x29, 0.0f, 0};
     daNpcF_anmPlayData* pDat6[] = {&dat6, &dat6_};
 
-    daNpcF_anmPlayData dat7 = {0x29, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat7 = {0x29, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[] = {&dat7};
 
-    daNpcF_anmPlayData dat8 = {0x2a, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat8 = {0x2a, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat8_ = {0x2b, 0.0f, 0};
     daNpcF_anmPlayData* pDat8[] = {&dat8, &dat8_};
 
-    daNpcF_anmPlayData dat9 = {0x2b, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat9 = {0x2b, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[] = {&dat9};
 
-    daNpcF_anmPlayData dat10 = {0x2f, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat10 = {0x2f, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat10_ = {0x16, 0.0f, 0};
     daNpcF_anmPlayData* pDat10[] = {&dat10, &dat10_};
 
-    daNpcF_anmPlayData dat11 = {0x22, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat11 = {0x22, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat11[] = {&dat11};
 
-    daNpcF_anmPlayData dat12 = {0x23, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat12_ = {0x22, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat12 = {0x23, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat12_ = {0x22, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat12[] = {&dat12, &dat12_};
 
-    daNpcF_anmPlayData dat13 = {0x24, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat13 = {0x24, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat13[] = {&dat13};
 
-    daNpcF_anmPlayData dat14 = {0x25, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat14_ = {0x24, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat14 = {0x25, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat14_ = {0x24, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat14[] = {&dat14, &dat14_};
 
-    daNpcF_anmPlayData dat15 = {0x32, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat15 = {0x32, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat15_ = {0x30, 0.0f, 0};
     daNpcF_anmPlayData* pDat15[] = {&dat15, &dat15_};
 
-    daNpcF_anmPlayData dat16 = {0x30, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat16 = {0x30, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat16[] = {&dat16};
 
-    daNpcF_anmPlayData dat17 = {0x31, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat17 = {0x31, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat17_ = {0x30, 0.0f, 0};
     daNpcF_anmPlayData* pDat17[] = {&dat17, &dat17_};
 
-    daNpcF_anmPlayData dat18 = {0x1b, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat18 = {0x1b, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat18[] = {&dat18};
 
-    daNpcF_anmPlayData dat19 = {0x1a, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat19 = {0x1a, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat19[] = {&dat19};
 
-    daNpcF_anmPlayData dat20 = {0x19, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat20_ = {0x16, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat20 = {0x19, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat20_ = {0x16, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat20[] = {&dat20, &dat20_};
 
-    daNpcF_anmPlayData dat21 = {0x1f, GET_HIO(mNpcFParams.morf_frame), 1};
-    daNpcF_anmPlayData dat21_ = {0x16, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat21 = {0x1f, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat21_ = {0x16, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat21[] = {&dat21, &dat21_};
 
     daNpcF_anmPlayData dat22 = {0x1c, 4.0f, 0};
@@ -1653,17 +1647,17 @@ void daNpc_grA_c::playMotion() {
     daNpcF_anmPlayData dat24 = {0x21, 2.0f, 0};
     daNpcF_anmPlayData* pDat24[] = {&dat24};
 
-    daNpcF_anmPlayData dat25 = {0x2c, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat25 = {0x2c, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat25[] = {&dat25};
 
-    daNpcF_anmPlayData dat26 = {0x2d, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat26 = {0x2d, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat26[] = {&dat26};
 
-    daNpcF_anmPlayData dat27 = {0x2e, GET_HIO(mNpcFParams.morf_frame), 1};
+    daNpcF_anmPlayData dat27 = {0x2e, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat27_ = {0x29, 0.0f, 0};
     daNpcF_anmPlayData* pDat27[] = {&dat27, &dat27_};
 
-    daNpcF_anmPlayData dat28 = {38, GET_HIO(mNpcFParams.morf_frame), 0};
+    daNpcF_anmPlayData dat28 = {38, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat28[] = {&dat28};
 
     daNpcF_anmPlayData** ppDat[29] = {  
@@ -1722,7 +1716,7 @@ BOOL daNpc_grA_c::setAction(daNpc_grA_c_Action i_action) {
 
 BOOL daNpc_grA_c::selectAction() {
     mAction2 = NULL;
-    if (GET_HIO(mNpcFParams.debug_mode_ON)) {
+    if (mpHIO->m.common.debug_mode_ON) {
         mAction2 = &daNpc_grA_c::test;
     } else {
         switch (mType) {
@@ -1906,14 +1900,14 @@ void daNpc_grA_c::lookat() {
     fopAc_ac_c* player = NULL;
     J3DModel* model = mAnm_p->getModel();
     BOOL r27 = FALSE;
-    f32 bodyAngleXMin = GET_HIO(mNpcFParams.body_angleX_min);
-    f32 bodyAngleXMax = GET_HIO(mNpcFParams.body_angleX_max);
-    f32 bodyAngleYMin = GET_HIO(mNpcFParams.body_angleY_min);
-    f32 bodyAngleYMax = GET_HIO(mNpcFParams.body_angleY_max);
-    f32 headAngleXMin = GET_HIO(mNpcFParams.head_angleX_min);
-    f32 headAngleXMan = GET_HIO(mNpcFParams.head_angleX_max);
-    f32 headAnglyMin = GET_HIO(mNpcFParams.head_angleY_min);
-    f32 headAngleYMax = GET_HIO(mNpcFParams.head_angleY_max);
+    f32 bodyAngleXMin = mpHIO->m.common.body_angleX_min;
+    f32 bodyAngleXMax = mpHIO->m.common.body_angleX_max;
+    f32 bodyAngleYMin = mpHIO->m.common.body_angleY_min;
+    f32 bodyAngleYMax = mpHIO->m.common.body_angleY_max;
+    f32 headAngleXMin = mpHIO->m.common.head_angleX_min;
+    f32 headAngleXMan = mpHIO->m.common.head_angleX_max;
+    f32 headAnglyMin = mpHIO->m.common.head_angleY_min;
+    f32 headAngleYMax = mpHIO->m.common.head_angleY_max;
     s16 diffInAngle = mCurAngle.y - mOldAngle.y;
     cXyz pLookPositions[] = {
         mLookatPos[0],
@@ -2233,7 +2227,7 @@ BOOL daNpc_grA_c::ECut_grDSRoll(int i_staffID) {
             break;
         case 0x50:
             setLookMode(2);
-            mEventTimer = GET_HIO(mBowTimer);
+            mEventTimer = mpHIO->m.mBowTimer;
             break;
         case 0x2d:
             break;
@@ -2282,7 +2276,7 @@ BOOL daNpc_grA_c::ECut_grDSRoll(int i_staffID) {
                 field_0x14D4 += 0.2f;
             }
             mAnm_p->setPlaySpeed(field_0x14D4);
-            speedF = field_0x14D4 * GET_HIO(mRotationalSpeed);
+            speedF = field_0x14D4 * mpHIO->m.mRotationalSpeed;
         }
         r28 = 1;
         break;
@@ -2291,7 +2285,7 @@ BOOL daNpc_grA_c::ECut_grDSRoll(int i_staffID) {
             if (field_0x14D4 > 1.0f) {
                 field_0x14D4 -= 0.25f;
                 mAnm_p->setPlaySpeed(field_0x14D4);
-                speedF = field_0x14D4 * GET_HIO(mRotationalSpeed);
+                speedF = field_0x14D4 * mpHIO->m.mRotationalSpeed;
             } else {
                 if (mAnm_p->getFrame() >= 0.0f && mAnm_p->getFrame() <= 5.0f) {
                     setMotion(0x14, -1.0f, 0);
@@ -2550,8 +2544,8 @@ BOOL daNpc_grA_c::ECut_kickOut(int i_staffID) {
         case 0x14:
             setExpression(0x17, -1.0f);
             setMotion(1, -1.0f, 0);
-            speedF = GET_HIO(mWalkingSpeed);
-            mAnm_p->setPlaySpeed(GET_HIO(mWalkingSpeed) * GET_HIO(mWalkingAnimationSpeed));
+            speedF = mpHIO->m.mWalkingSpeed;
+            mAnm_p->setPlaySpeed(mpHIO->m.mWalkingSpeed * mpHIO->m.mWalkingAnimationSpeed);
             break;
         case 0x1e:
             Z2GetAudioMgr()->seStart(0x600b2, &current.pos, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
@@ -2574,8 +2568,8 @@ BOOL daNpc_grA_c::ECut_kickOut(int i_staffID) {
         }
         break;
     case 0x14:
-        speedF = GET_HIO(mWalkingSpeed);
-        mAnm_p->setPlaySpeed(GET_HIO(mWalkingSpeed) * GET_HIO(mWalkingAnimationSpeed));
+        speedF = mpHIO->m.mWalkingSpeed;
+        mAnm_p->setPlaySpeed(mpHIO->m.mWalkingSpeed * mpHIO->m.mWalkingAnimationSpeed);
         r28 = 1;
         break;
     case 0x1e:
@@ -3128,7 +3122,7 @@ BOOL daNpc_grA_c::ECut_rollRockCrash(int i_staffID) {
         if (field_0x14D4 >= 1.0f) {
             f32 f31 = 1.0f;
             if (sp24 >= 0x3c) {
-                f31 = GET_HIO(mParticleSize);
+                f31 = mpHIO->m.mParticleSize;
             }
             setRollPrtcl(current.pos, f31);
         }
@@ -3454,7 +3448,7 @@ BOOL daNpc_grA_c::waitKickOut(void*) {
         {
             mOrderEvtNo = 3;
         } else if (daPy_getPlayerActorClass()->checkWolfRopeHang() &&
-                   chkActorInSight(daPy_getPlayerActorClass(), GET_HIO(mNpcFParams.fov)))
+                   chkActorInSight(daPy_getPlayerActorClass(), mpHIO->m.common.fov))
         {
             mOrderEvtNo = 3;
         } else if (field_0xDD4.getPathInfo() != NULL) {
@@ -3472,9 +3466,9 @@ BOOL daNpc_grA_c::waitKickOut(void*) {
                 } else {
                     s16 r27 = cLib_targetAngleY(&current.pos, &c);
                     speedF = 5.0f;
-                    mAnm_p->setPlaySpeed(speedF * GET_HIO(mWalkingAnimationSpeed));
-                    cLib_addCalcAngleS2(&current.angle.y, r27, GET_HIO(mWalkingRotationDivisions),
-                                        GET_HIO(mWalkingRotationSpeed));
+                    mAnm_p->setPlaySpeed(speedF * mpHIO->m.mWalkingAnimationSpeed);
+                    cLib_addCalcAngleS2(&current.angle.y, r27, mpHIO->m.mWalkingRotationDivisions,
+                                        mpHIO->m.mWalkingRotationSpeed);
                     setAngle(current.angle.y);
                 }
             } else if (cLib_calcTimer(&field_0x1694) == 0) {
@@ -3860,7 +3854,7 @@ BOOL daNpc_grA_c::crashRollWait(void*) {
                 mDoMtx_stack_c::YrotS(shape_angle.y);
                 mDoMtx_stack_c::multVec(&c, &c);
                 c += current.pos;
-                setRollPrtcl(c, GET_HIO(mParticleSize));
+                setRollPrtcl(c, mpHIO->m.mParticleSize);
             }
             f32 a = cLib_minMaxLimit(fabsf(field_0x14D4) * 20.0f, 1.0f, 127.0f);
             u32 b = a;
@@ -4069,11 +4063,11 @@ BOOL daNpc_grA_c::test(void*) {
         // fallthrough
 
     case 2:
-        if (GET_HIO(mNpcFParams.face_expression) != mExpression) {
-            setExpression(GET_HIO(mNpcFParams.face_expression), GET_HIO(mNpcFParams.morf_frame));
+        if (mpHIO->m.common.face_expression != mExpression) {
+            setExpression(mpHIO->m.common.face_expression, mpHIO->m.common.morf_frame);
         }
-        setMotion(GET_HIO(mNpcFParams.motion), GET_HIO(mNpcFParams.morf_frame), 0);
-        setLookMode(GET_HIO(mNpcFParams.look_mode));
+        setMotion(mpHIO->m.common.motion, mpHIO->m.common.morf_frame, 0);
+        setLookMode(mpHIO->m.common.look_mode);
         mOrderEvtNo = 0;
         attention_info.flags = 0;
     case 1:

--- a/src/d/actor/d_a_npc_grm.cpp
+++ b/src/d/actor/d_a_npc_grm.cpp
@@ -131,6 +131,28 @@ daNpc_grM_c::cutFunc daNpc_grM_c::mCutList[2] = {
     &daNpc_grM_c::cutTalkSpa,
 };
 
+static NPC_GRM_HIO_CLASS l_HIO;
+
+daNpc_grM_HIOParam const daNpc_grM_Param_c::m = {
+    300.0f, -3.0f,  1.0f,   600.0f, 255.0f, 260.0f, 35.0f, 70.0f, 0.0f, 0.0f,  30.0f,
+    -30.0f, 30.0f,  -10.0f, 20.0f,  -20.0f, 0.6f,   12.0f, 8,     6,    8,     6,
+    0.0f,   0.0f,   0.0f,   0.0f,   60,     8,      0,     0,     0,    false, false,
+    4.0f,   -20.0f, 0.0f,   -20.0f, 20.0f,  40.0f,  20.0f, 110.0f};
+
+#if DEBUG
+daNpc_grM_HIO_c::daNpc_grM_HIO_c() {
+    m = daNpc_grM_Param_c::m;
+}
+
+void daNpc_grM_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_grM_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daNpc_grM_c::~daNpc_grM_c() {
     deleteObject();
 
@@ -138,14 +160,14 @@ daNpc_grM_c::~daNpc_grM_c() {
         mpMorf[0]->stopZelAnime();
     }
 
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
 }
-
-daNpc_grM_HIOParam const daNpc_grM_Param_c::m = {
-    300.0f, -3.0f,  1.0f,   600.0f, 255.0f, 260.0f, 35.0f, 70.0f, 0.0f, 0.0f,  30.0f,
-    -30.0f, 30.0f,  -10.0f, 20.0f,  -20.0f, 0.6f,   12.0f, 8,     6,    8,     6,
-    0.0f,   0.0f,   0.0f,   0.0f,   60,     8,      0,     0,     0,    false, false,
-    4.0f,   -20.0f, 0.0f,   -20.0f, 20.0f,  40.0f,  20.0f, 110.0f};
 
 cPhs__Step daNpc_grM_c::create() {
     daNpcT_ct(this, daNpc_grM_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4,
@@ -176,6 +198,11 @@ cPhs__Step daNpc_grM_c::create() {
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("店ゴロン");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -184,7 +211,7 @@ cPhs__Step daNpc_grM_c::create() {
 
         setEnvTevColor();
         setRoomNo();
-        mCcStts.Init(daNpc_grM_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -344,10 +371,10 @@ void daNpc_grM_c::setParam() {
     selectAction();
 
     srchActors();
-    s16 talk_distance = daNpc_grM_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_grM_Param_c::m.common.talk_angle;
-    s16 attention_distance = daNpc_grM_Param_c::m.common.attention_distance;
-    s16 attention_angle = daNpc_grM_Param_c::m.common.attention_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
+    s16 attention_distance = mpHIO->m.common.attention_distance;
+    s16 attention_angle = mpHIO->m.common.attention_angle;
 
     attention_info.distances[fopAc_attn_LOCK_e] =
         daNpcT_getDistTableIdx(attention_distance, attention_angle);
@@ -356,17 +383,17 @@ void daNpc_grM_c::setParam() {
         daNpcT_getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = uVar1;
 
-    scale.set(daNpc_grM_Param_c::m.common.scale, daNpc_grM_Param_c::m.common.scale,
-              daNpc_grM_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_grM_Param_c::m.common.weight);
-    mCylH = daNpc_grM_Param_c::m.common.height;
-    mWallR = daNpc_grM_Param_c::m.common.width;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+              mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_grM_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_grM_Param_c::m.common.real_shadow_size;
-    gravity = daNpc_grM_Param_c::m.common.gravity;
-    mExpressionMorfFrame = daNpc_grM_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_grM_Param_c::m.common.morf_frame;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_grM_c::setAfterTalkMotion() {
@@ -521,12 +548,12 @@ void daNpc_grM_c::setAttnPos() {
     mStagger.calc(FALSE);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &sp48, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_grM_Param_c::m.common.body_angleX_min,
-        daNpc_grM_Param_c::m.common.body_angleX_max, daNpc_grM_Param_c::m.common.body_angleY_min,
-        daNpc_grM_Param_c::m.common.body_angleY_max, daNpc_grM_Param_c::m.common.head_angleX_min,
-        daNpc_grM_Param_c::m.common.head_angleX_max, daNpc_grM_Param_c::m.common.head_angleY_min,
-        daNpc_grM_Param_c::m.common.head_angleY_max,
-        daNpc_grM_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+        getHeadJointNo(), mpHIO->m.common.body_angleX_min,
+        mpHIO->m.common.body_angleX_max, mpHIO->m.common.body_angleY_min,
+        mpHIO->m.common.body_angleY_max, mpHIO->m.common.head_angleX_min,
+        mpHIO->m.common.head_angleX_max, mpHIO->m.common.head_angleY_min,
+        mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, cM_s2rad((s16)(mCurAngle.y - field_0xd7e.y)));
 
     J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
@@ -540,7 +567,7 @@ void daNpc_grM_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, FALSE, 1.0f, 0);
     attention_info.position = current.pos;
-    attention_info.position.y += daNpc_grM_Param_c::m.common.attention_offset;
+    attention_info.position.y += mpHIO->m.common.attention_offset;
 }
 
 void daNpc_grM_c::setCollision() {
@@ -783,8 +810,6 @@ static int daNpc_grM_Draw(void* param_0) {
 static BOOL daNpc_grM_IsDelete(void* param_0) {
     return TRUE;
 }
-
-static daNpc_grM_Param_c l_HIO;
 
 static actor_method_class daNpc_grM_MethodTable = {
     (process_method_func)daNpc_grM_Create,  (process_method_func)daNpc_grM_Delete,

--- a/src/d/actor/d_a_npc_grmc.cpp
+++ b/src/d/actor/d_a_npc_grmc.cpp
@@ -161,6 +161,12 @@ daNpc_grMC_c::~daNpc_grMC_c() {
         mpMorf[0]->stopZelAnime();
     }
 
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
 }
 
@@ -208,6 +214,22 @@ daNpc_grMC_HIOParam const daNpc_grMC_Param_c::m = {
     110.0f
 };
 
+static NPC_GRMC_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_grMC_HIO_c::daNpc_grMC_HIO_c() {
+    m = daNpc_grMC_Param_c::m;
+}
+
+void daNpc_grMC_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_grMC_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 cPhs__Step daNpc_grMC_c::create() {
     daNpcT_ct(this, daNpc_grMC_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4,
                        l_motionSequenceData, 4, l_evtList, l_resNameList);
@@ -237,6 +259,11 @@ cPhs__Step daNpc_grMC_c::create() {
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("店チビゴロン");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -245,7 +272,7 @@ cPhs__Step daNpc_grMC_c::create() {
 
         setEnvTevColor();
         setRoomNo();
-        mCcStts.Init(daNpc_grMC_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -413,26 +440,26 @@ void daNpc_grMC_c::setParam() {
     }
 
     srchActors();
-    s16 talk_distance = daNpc_grMC_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_grMC_Param_c::m.common.talk_angle;
-    s16 attention_distance = daNpc_grMC_Param_c::m.common.attention_distance;
-    s16 attention_angle = daNpc_grMC_Param_c::m.common.attention_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
+    s16 attention_distance = mpHIO->m.common.attention_distance;
+    s16 attention_angle = mpHIO->m.common.attention_angle;
 
     attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(attention_distance, attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = uVar1;
 
-    scale.set(daNpc_grMC_Param_c::m.common.scale, daNpc_grMC_Param_c::m.common.scale, daNpc_grMC_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_grMC_Param_c::m.common.weight);
-    mCylH = daNpc_grMC_Param_c::m.common.height;
-    mWallR = daNpc_grMC_Param_c::m.common.width;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_grMC_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_grMC_Param_c::m.common.real_shadow_size;
-    gravity = daNpc_grMC_Param_c::m.common.gravity;
-    mExpressionMorfFrame = daNpc_grMC_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_grMC_Param_c::m.common.morf_frame;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_grMC_c::setAfterTalkMotion() {
@@ -533,11 +560,11 @@ void daNpc_grMC_c::setAttnPos() {
     
     mStagger.calc(FALSE);
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp48, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-                     daNpc_grMC_Param_c::m.common.body_angleX_min, daNpc_grMC_Param_c::m.common.body_angleX_max,
-                     daNpc_grMC_Param_c::m.common.body_angleY_min, daNpc_grMC_Param_c::m.common.body_angleY_max,
-                     daNpc_grMC_Param_c::m.common.head_angleX_min, daNpc_grMC_Param_c::m.common.head_angleX_max,
-                     daNpc_grMC_Param_c::m.common.head_angleY_min, daNpc_grMC_Param_c::m.common.head_angleY_max,
-                     daNpc_grMC_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+                     mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+                     mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+                     mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+                     mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+                     mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, cM_s2rad((s16)(mCurAngle.y - field_0xd7e.y)));
 
     J3DModelData* modelData = mpMorf[0]->getModel()->getModelData();
@@ -551,7 +578,7 @@ void daNpc_grMC_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, FALSE, 1.0f, 0);
     attention_info.position = current.pos;
-    attention_info.position.y += daNpc_grMC_Param_c::m.common.attention_offset;
+    attention_info.position.y += mpHIO->m.common.attention_offset;
 }
 
 void daNpc_grMC_c::setCollision() {
@@ -748,8 +775,8 @@ int daNpc_grMC_c::test(void* param_1) {
             mMode = 2;
             // fallthrough
         case 2:
-            mFaceMotionSeqMngr.setNo(mHIO->m.common.face_expression, -1.0f, FALSE, 0);
-            mMotionSeqMngr.setNo(mHIO->m.common.motion, -1.0f, FALSE, 0);
+            mFaceMotionSeqMngr.setNo(mpHIO->m.common.face_expression, -1.0f, FALSE, 0);
+            mMotionSeqMngr.setNo(mpHIO->m.common.motion, -1.0f, FALSE, 0);
             mJntAnm.lookNone(0);
             attention_info.flags = 0;
             break;
@@ -780,8 +807,6 @@ static int daNpc_grMC_Draw(void* a_this) {
 static int daNpc_grMC_IsDelete(void* a_this) {
     return 1;
 }
-
-static daNpc_grMC_Param_c l_HIO;
 
 static actor_method_class daNpc_grMC_MethodTable = {
     (process_method_func)daNpc_grMC_Create,

--- a/src/d/actor/d_a_npc_grr.cpp
+++ b/src/d/actor/d_a_npc_grr.cpp
@@ -121,7 +121,7 @@ enum Event_Cut_Nums {
     /* 0x1 */ NUM_EVT_CUTS_e = 0x1,
 };
 
-static daNpc_grR_Param_c l_HIO;
+static NPC_GRR_HIO_CLASS l_HIO;
 
 static int l_bmdGetParamList[1][2] = {
     {BMDR_GRR, GRR},
@@ -204,24 +204,6 @@ daNpc_grR_c::cutFunc daNpc_grR_c::mEvtCutList[1] = {
     NULL,
 };
 
-daNpc_grR_c::daNpc_grR_c() {}
-
-daNpc_grR_c::~daNpc_grR_c() {
-    for (int i = 0; l_loadRes_list[mType][i] >= 0; i++) {
-        dComIfG_resDelete(&mPhases[i], l_resNames[l_loadRes_list[mType][i]]);
-    }
-
-    if (heap != NULL) {
-        mAnm_p->stopZelAnime();
-    }
-
-    #if DEBUG
-    if (mHIO != NULL) {
-        mHIO->removeHIO();
-    }
-    #endif
-}
-
 daNpc_grR_HIOParam const daNpc_grR_Param_c::m = {
     60.0f,
     -3.0f,
@@ -257,6 +239,24 @@ daNpc_grR_HIOParam const daNpc_grR_Param_c::m = {
     false,
     false
 };
+
+daNpc_grR_c::daNpc_grR_c() {}
+
+daNpc_grR_c::~daNpc_grR_c() {
+    for (int i = 0; l_loadRes_list[mType][i] >= 0; i++) {
+        dComIfG_resDelete(&mPhases[i], l_resNames[l_loadRes_list[mType][i]]);
+    }
+
+    if (heap != NULL) {
+        mAnm_p->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
 
 cPhs__Step daNpc_grR_c::create() {
     fopAcM_ct(this, daNpc_grR_c);
@@ -300,10 +300,15 @@ cPhs__Step daNpc_grR_c::create() {
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-        mAcchCir.SetWall(daNpc_grR_Param_c::m.common.width, daNpc_grR_Param_c::m.common.knee_length);
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ラスタ長老ゴロン");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                 fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_grR_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -372,7 +377,7 @@ int daNpc_grR_c::Execute() {
 
 int daNpc_grR_c::Draw() {
     mAnm_p->getModel()->getModelData()->getMaterialNodePointer(1)->setMaterialAnm(mpMatAnm);
-    return draw(chkAction(&daNpc_grR_c::test), FALSE, daNpc_grR_Param_c::m.common.real_shadow_size, NULL, FALSE);
+    return draw(chkAction(&daNpc_grR_c::test), FALSE, mpHIO->m.common.real_shadow_size, NULL, FALSE);
 }
 
 int daNpc_grR_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
@@ -394,7 +399,7 @@ int daNpc_grR_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
         case 1:
         case 3:
         case 4:
-            setLookatMtx(jntNo, i_jointList, daNpc_grR_Param_c::m.common.neck_rotation_ratio);
+            setLookatMtx(jntNo, i_jointList, mpHIO->m.common.neck_rotation_ratio);
             break;
     }
 
@@ -453,16 +458,16 @@ void daNpc_grR_c::setParam() {
     field_0xdf8 = 0;
     field_0xdfc = 0;
 
-    s16 talk_distance = daNpc_grR_Param_c::m.common.talk_distance;
-    s16 attention_distance = daNpc_grR_Param_c::m.common.attention_distance;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 attention_distance = mpHIO->m.common.attention_distance;
     s16 attention_angle;
     s16 talk_angle;
     if (mType == TYPE_MARO) {
         talk_angle = 6;
         attention_angle = 6;
     } else {
-        talk_angle = daNpc_grR_Param_c::m.common.talk_angle;
-        attention_angle = daNpc_grR_Param_c::m.common.attention_angle;
+        talk_angle = mpHIO->m.common.talk_angle;
+        attention_angle = mpHIO->m.common.attention_angle;
 
         if (mAnm != ANM_AGURA_WAIT && !field_0xe18) {
             uVar1 = 0;
@@ -474,10 +479,10 @@ void daNpc_grR_c::setParam() {
     attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = uVar1;
 
-    scale.set(daNpc_grR_Param_c::m.common.scale, daNpc_grR_Param_c::m.common.scale, daNpc_grR_Param_c::m.common.scale);
-    mAcchCir.SetWallR(daNpc_grR_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpc_grR_Param_c::m.common.knee_length);
-    gravity = daNpc_grR_Param_c::m.common.gravity;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_grR_c::main() {
@@ -489,7 +494,7 @@ BOOL daNpc_grR_c::main() {
         attention_info.flags = 0;
     }
 
-    if (!daNpc_grR_Param_c::m.common.debug_mode_ON && (!dComIfGp_event_runCheck() || (mOrderNewEvt && dComIfGp_getEvent()->isOrderOK()))) {
+    if (!mpHIO->m.common.debug_mode_ON && (!dComIfGp_event_runCheck() || (mOrderNewEvt && dComIfGp_getEvent()->isOrderOK()))) {
         if (mOrderEvtNo != 0) {
             eventInfo.setArchiveName(l_resNames[l_evtGetParamList[mOrderEvtNo].arcIdx]);
         }
@@ -535,7 +540,7 @@ void daNpc_grR_c::setAttnPos() {
     static cXyz eyeOffset(24.0f, 30.0f, 0.0f);
 
     cXyz sp7c, sp88, sp94, spa0;
-    f32 attention_offset = daNpc_grR_Param_c::m.common.attention_offset;
+    f32 attention_offset = mpHIO->m.common.attention_offset;
 
     mDoMtx_stack_c::YrotS(field_0x990);
     cLib_addCalc2(&field_0x984[0], 0.0f, 0.1f, 125.0f);
@@ -600,8 +605,8 @@ void daNpc_grR_c::setAttnPos() {
         }
 
         mCyl.SetC(sp7c);
-        mCyl.SetH(daNpc_grR_Param_c::m.common.height + fVar1);
-        mCyl.SetR(daNpc_grR_Param_c::m.common.width + fVar2);
+        mCyl.SetH(mpHIO->m.common.height + fVar1);
+        mCyl.SetR(mpHIO->m.common.width + fVar2);
         dComIfG_Ccsp()->Set(&mCyl);
     }
 
@@ -887,24 +892,24 @@ void daNpc_grR_c::reset() {
 }
 
 void daNpc_grR_c::playExpression() {
-    daNpcF_anmPlayData dat0 = {ANM_F_TALK_A, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_F_TALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1a = {ANM_F_LAUGH, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat1a = {ANM_F_LAUGH, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat1b = {ANM_FH_LAUGH, 0.0f, 0};
     daNpcF_anmPlayData* pDat1[2] = {&dat1a, &dat1b};
-    daNpcF_anmPlayData dat2 = {ANM_F_SWING, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_F_SWING, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3a = {ANM_F_KEEE, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat3a = {ANM_F_KEEE, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat3b = {ANM_FH_KEEE, 0.0f, 0};
     daNpcF_anmPlayData* pDat3[2] = {&dat3a, &dat3b};
-    daNpcF_anmPlayData dat4a = {ANM_F_KEEETALK, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat4a = {ANM_F_KEEETALK, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat4b = {ANM_FH_KEEE, 0.0f, 0};
     daNpcF_anmPlayData* pDat4[2] = {&dat4a, &dat4b};
-    daNpcF_anmPlayData dat5 = {ANM_FH_LAUGH, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat5 = {ANM_FH_LAUGH, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[1] = {&dat5};
-    daNpcF_anmPlayData dat6 = {ANM_FH_KEEE, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat6 = {ANM_FH_KEEE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat6[1] = {&dat6};
-    daNpcF_anmPlayData dat7 = {ANM_NONE, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat7 = {ANM_NONE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[1] = {&dat7};
 
     daNpcF_anmPlayData** ppDat[8] = {
@@ -924,33 +929,33 @@ void daNpc_grR_c::playExpression() {
 }
 
 void daNpc_grR_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {ANM_WAIT_A, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1a = {ANM_TALK_A, daNpc_grR_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat1b = {ANM_WAIT_A, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1a = {ANM_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat1b = {ANM_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[2] = {&dat1a, &dat1b};
-    daNpcF_anmPlayData dat2 = {ANM_SWING, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_SWING, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3 = {ANM_AGURA_WAIT, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3 = {ANM_AGURA_WAIT, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[1] = {&dat3};
-    daNpcF_anmPlayData dat4a = {ANM_AGURA_TALK, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat4a = {ANM_AGURA_TALK, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat4b = {ANM_AGURA_WAIT, 0.0f, 0};
     daNpcF_anmPlayData* pDat4[2] = {&dat4a, &dat4b};
-    daNpcF_anmPlayData dat5a = {ANM_TO_AGURA, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat5a = {ANM_TO_AGURA, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat5b = {ANM_AGURA_WAIT, 0.0f, 0};
     daNpcF_anmPlayData* pDat5[2] = {&dat5a, &dat5b};
-    daNpcF_anmPlayData dat6a = {ANM_AGURA_GETUP, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat6a = {ANM_AGURA_GETUP, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat6b = {ANM_WAIT_A, 0.0f, 0};
     daNpcF_anmPlayData* pDat6[2] = {&dat6a, &dat6b};
-    daNpcF_anmPlayData dat7a = {ANM_LAUGH, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat7a = {ANM_LAUGH, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat7b = {ANM_WAIT_A, 0.0f, 0};
     daNpcF_anmPlayData* pDat7[2] = {&dat7a, &dat7b};
-    daNpcF_anmPlayData dat8a = {ANM_TALK_B, daNpc_grR_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat8a = {ANM_TALK_B, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData dat8b = {ANM_WAIT_B, 0.0f, 0};
     daNpcF_anmPlayData* pDat8[2] = {&dat8a, &dat8b};
-    daNpcF_anmPlayData dat9 = {ANM_WAIT_B, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat9 = {ANM_WAIT_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[1] = {&dat9};
-    daNpcF_anmPlayData dat10 = {ANM_STEP, daNpc_grR_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat10 = {ANM_STEP, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat10[1] = {&dat10};
 
     daNpcF_anmPlayData** ppDat[11] = {
@@ -1000,7 +1005,7 @@ BOOL daNpc_grR_c::setAction(actionFunc action) {
 BOOL daNpc_grR_c::selectAction() {
     mNextAction = NULL;
 
-    if (daNpc_grR_Param_c::m.common.debug_mode_ON) {
+    if (mpHIO->m.common.debug_mode_ON) {
         mNextAction = &daNpc_grR_c::test;
     } else {
         switch (mType) {
@@ -1024,7 +1029,7 @@ void daNpc_grR_c::doNormalAction(int param_1) {
         if (mCutType == daPy_py_c::CUT_TYPE_TURN_RIGHT) {
             i_timer = 20;
         } else {
-            i_timer = daNpc_grR_Param_c::m.common.damage_time;
+            i_timer = mpHIO->m.common.damage_time;
         }
 
         setDamage(i_timer, 7, 0);
@@ -1124,14 +1129,14 @@ void daNpc_grR_c::lookat() {
     daPy_py_c* player = NULL;
     J3DModel* model = mAnm_p->getModel();
     BOOL i_snap = FALSE;
-    f32 body_angleX_min = daNpc_grR_Param_c::m.common.body_angleX_min;
-    f32 body_angleX_max = daNpc_grR_Param_c::m.common.body_angleX_max;
-    f32 body_angleY_min = daNpc_grR_Param_c::m.common.body_angleY_min;
-    f32 body_angleY_max = daNpc_grR_Param_c::m.common.body_angleY_max;
-    f32 head_angleX_min = daNpc_grR_Param_c::m.common.head_angleX_min;
-    f32 head_angleX_max = daNpc_grR_Param_c::m.common.head_angleX_max;
-    f32 head_angleY_min = daNpc_grR_Param_c::m.common.head_angleY_min;
-    f32 head_angleY_max = daNpc_grR_Param_c::m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
     s16 angle_delta = mCurAngle.y - mOldAngle.y;
     cXyz lookatPos[3] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
     csXyz* lookatAngle[3] = {&mLookatAngle[0], &mLookatAngle[1], &mLookatAngle[2]};
@@ -1386,12 +1391,12 @@ int daNpc_grR_c::test(void* param_1) {
             mMode = 2;
             // fallthrough
         case 2:
-            if (daNpc_grR_Param_c::m.common.face_expression != mExpression) {
-                setExpression(daNpc_grR_Param_c::m.common.face_expression, daNpc_grR_Param_c::m.common.morf_frame);
+            if (mpHIO->m.common.face_expression != mExpression) {
+                setExpression(mpHIO->m.common.face_expression, mpHIO->m.common.morf_frame);
             }
 
-            setMotion(daNpc_grR_Param_c::m.common.motion, daNpc_grR_Param_c::m.common.morf_frame, 0);
-            setLookMode(daNpc_grR_Param_c::m.common.look_mode);
+            setMotion(mpHIO->m.common.motion, mpHIO->m.common.morf_frame, 0);
+            setLookMode(mpHIO->m.common.look_mode);
             mOrderEvtNo = 0;
             attention_info.flags = 0;
             break;

--- a/src/d/actor/d_a_npc_hanjo.cpp
+++ b/src/d/actor/d_a_npc_hanjo.cpp
@@ -140,19 +140,10 @@ dCcD_SrcSph daNpc_Hanjo_c::mStoneCcDSph = {
     daNpc_Hanjo_c::mStoneCcDObjInfo, {}
 };
 
-
-daNpc_Hanjo_c::~daNpc_Hanjo_c() {
-    OS_REPORT("|%06d:%x|daNpc_Hanjo_c -> デストラクト\n", g_Counter.mCounter0, this);
-    if (mpMorf[0] != 0) {
-        mpMorf[0]->stopZelAnime();
-    }
-    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
-}
-
-daNpc_Hanjo_Param_c::Data const daNpc_Hanjo_Param_c::m = {
+daNpc_Hanjo_HIOParam const daNpc_Hanjo_Param_c::m = {
     160.0f, -3.0f, 1.0f, 400.0f, 
     255.0f, 160.0f, 35.0f, 30.0f, 0.0f, 0.0f, 10.0f, -10.0f, 30.0f, -10.0f, 45.0f,
-    -45.0f, 0.6f, 12.0f, 3, 6, 5, 6, 110.0f, 500.0f, 300.0f, -300.0f, 60, 8, 0, 0, 
+    -45.0f, 0.6f, 12.0f, 3, 6, 5, 6, 110.0f, 500.0f, 300.0f, -300.0f, 60, 8, 0, 0, 0, 0, 0,
     4.0f, 0.0f, 0.0f,
     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 24.0f, 16.0f, 4.0f,
      80.0f, 65.0f, 4.0f, 600.0f, 136.0f, 0x500, 90, 90, 2,
@@ -164,6 +155,38 @@ dCcD_SrcGObjInf const daNpc_Hanjo_c::mStoneCcDObjInfo = {
     {0, 0, 0, 0, {0}},
     {{0}},
 };
+
+static NPC_HANJO_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Hanjo_HIO_c::daNpc_Hanjo_HIO_c() {
+    m = daNpc_Hanjo_Param_c::m;
+}
+
+void daNpc_Hanjo_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Hanjo_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+
+daNpc_Hanjo_c::~daNpc_Hanjo_c() {
+    OS_REPORT("|%06d:%x|daNpc_Hanjo_c -> デストラクト\n", g_Counter.mCounter0, this);
+    if (mpMorf[0] != 0) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
+}
 
 int daNpc_Hanjo_c::create() {
     static int const heapSize[5] = {0x61B0, 0x41D0, 0x39D0, 0x39C0, 0};
@@ -191,11 +214,17 @@ int daNpc_Hanjo_c::create() {
         fopAcM_setCullSizeBox2(this, modelData);
         mSound.init(&current.pos, &eyePos, 3, 1);
         field_0x9c0.init(&mAcch, 60.0f, 0.0f);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ハンジョ－");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                         &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                         fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Hanjo_Param_c::m.field_0x10, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -414,10 +443,10 @@ void daNpc_Hanjo_c::afterJntAnm(int param_1) {
 void daNpc_Hanjo_c::setParam() {
     selectAction();
     srchActors();
-    s16 sVar6 = daNpc_Hanjo_Param_c::m.field_0x48;
-    s16 sVar5 = daNpc_Hanjo_Param_c::m.field_0x4a;
-    s16 sVar4 = daNpc_Hanjo_Param_c::m.field_0x4c;
-    s16 sVar1 = daNpc_Hanjo_Param_c::m.field_0x4e;
+    s16 sVar6 = mpHIO->m.common.talk_distance;
+    s16 sVar5 = mpHIO->m.common.talk_angle;
+    s16 sVar4 = mpHIO->m.common.attention_distance;
+    s16 sVar1 = mpHIO->m.common.attention_angle;
     if (field_0x1721 != 0) {
         sVar6 = 6;
         sVar5 = 6;
@@ -438,18 +467,18 @@ void daNpc_Hanjo_c::setParam() {
     attention_info.distances[1] = attention_info.distances[0];
     attention_info.distances[3] = daNpcT_getDistTableIdx(sVar6, sVar5);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
-    scale.set(daNpc_Hanjo_Param_c::m.field_0x08, daNpc_Hanjo_Param_c::m.field_0x08,
-              daNpc_Hanjo_Param_c::m.field_0x08);
-    mCcStts.SetWeight(daNpc_Hanjo_Param_c::m.field_0x10);
-    mCylH = daNpc_Hanjo_Param_c::m.field_0x14;
-    mWallR = daNpc_Hanjo_Param_c::m.field_0x1c;
-    mAttnFovY = daNpc_Hanjo_Param_c::m.field_0x50;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+              mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Hanjo_Param_c::m.field_0x18);
-    mRealShadowSize = daNpc_Hanjo_Param_c::m.field_0x0c;
-    mExpressionMorfFrame = daNpc_Hanjo_Param_c::m.field_0x6c;
-    mMorfFrames = daNpc_Hanjo_Param_c::m.field_0x44;
-    gravity = daNpc_Hanjo_Param_c::m.field_0x04;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Hanjo_c::checkChangeEvt() {
@@ -651,8 +680,6 @@ void daNpc_Hanjo_c::afterMoved() {
     }
 }
 
-static daNpc_Hanjo_Param_c l_HIO;
-
 void daNpc_Hanjo_c::setAttnPos() {
     cXyz cStack_38(-10.0f, 10.0f, 0.0f);
     cXyz cStack_44;
@@ -660,11 +687,12 @@ void daNpc_Hanjo_c::setAttnPos() {
     f32 dVar8 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     J3DModel* model = mpMorf[0]->getModel();
     mJntAnm.setParam(this, model, &cStack_38, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_Hanjo_Param_c::m.field_0x24, daNpc_Hanjo_Param_c::m.field_0x20,
-        daNpc_Hanjo_Param_c::m.field_0x2c, daNpc_Hanjo_Param_c::m.field_0x28,
-        daNpc_Hanjo_Param_c::m.field_0x34, daNpc_Hanjo_Param_c::m.field_0x30,
-        daNpc_Hanjo_Param_c::m.field_0x3c, daNpc_Hanjo_Param_c::m.field_0x38,
-        daNpc_Hanjo_Param_c::m.field_0x40, dVar8, NULL);
+        getHeadJointNo(),
+        mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, dVar8, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, dVar8);
     setMtx();
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(getHeadJointNo()));
@@ -672,7 +700,7 @@ void daNpc_Hanjo_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 1, 1.0f, 0);
     cStack_38.set(0.0f, 0.0f, 20.0f);
-    cStack_38.y = daNpc_Hanjo_Param_c::m.field_0x00;
+    cStack_38.y = mpHIO->m.common.attention_offset;
     if (field_0x1721 != 0) {
         cStack_38.set(0.0f, 170.0f, -10.0f);
     } else if (mMotionSeqMngr.getNo() == 2) {
@@ -859,8 +887,8 @@ void daNpc_Hanjo_c::initShoot(int param_1) {
 
 int daNpc_Hanjo_c::shoot(int param_1) {
     csXyz cStack_60;
-    f32 dVar13 = daNpc_Hanjo_Param_c::m.field_0x98;
-    s16 sVar9 = cM_deg2s(daNpc_Hanjo_Param_c::m.field_0x9c);
+    f32 dVar13 = mpHIO->m.field_0x98;
+    s16 sVar9 = cM_deg2s(mpHIO->m.field_0x9c);
     if (mMotionSeqMngr.getNo() == 16 || mMotionSeqMngr.getNo() == 15) {
         switch(mMotionSeqMngr.getStepNo()) {
         case 0:
@@ -875,7 +903,7 @@ int daNpc_Hanjo_c::shoot(int param_1) {
                     mStones[i].initialize();
                     mStones[i].setTmr(0x708);
                     cStack_60 = current.angle;
-                    cStack_60.y += daNpc_Hanjo_Param_c::m.field_0xac;
+                    cStack_60.y += mpHIO->m.field_0xac;
                     mStones[i].setAngle(cStack_60);
                     field_0x170c = i;
                 }
@@ -907,7 +935,7 @@ int daNpc_Hanjo_c::shoot(int param_1) {
 void daNpc_Hanjo_c::initDive() {
     mFaceMotionSeqMngr.setNo(6, -1.0f, 0, 0);
     mMotionSeqMngr.setNo(18, -1.0f, 0, 0);
-    speed.y = daNpc_Hanjo_Param_c::m.field_0x8c;
+    speed.y = mpHIO->m.field_0x8c;
     field_0x1721 = 1;
 }
 
@@ -929,7 +957,7 @@ void daNpc_Hanjo_c::dive() {
                         cLib_addCalc(&speed.y, 2.0f, 0.5f, 5.5f, 0.5f);
                     }
                 }
-                if (0.0f < speed.y && local_34 < current.pos.y + daNpc_Hanjo_Param_c::m.field_0xa8)
+                if (0.0f < speed.y && local_34 < current.pos.y + mpHIO->m.field_0xa8)
                 {
                     field_0x171f = 1;
                     if (mMotionSeqMngr.getNo() == 18) {
@@ -953,7 +981,7 @@ void daNpc_Hanjo_c::dive() {
                     dComIfGp_particle_set(0xffffffff, 0x8364, &cStack_30, 0, 0);
                     dComIfGp_particle_set(0xffffffff, 0x8365, &cStack_30, 0, 0);
                 }
-                current.pos.y = local_34 - daNpc_Hanjo_Param_c::m.field_0xa8;
+                current.pos.y = local_34 - mpHIO->m.field_0xa8;
                 current.pos.y += dVar7 * -20.0f;
             }
             cLib_chaseF(&speedF, 0.0f, 0.3f);
@@ -1220,7 +1248,7 @@ int daNpc_Hanjo_c::cutPursuitBee(int param_1) {
                     fopAc_ac_c* hitActor = mStones[i].getSphP()->GetCoHitObj()->GetAc();
                     fopAc_ac_c* hitActor2 = dCc_GetAc(hitActor);
                     if (hitActor2 != NULL && fopAcM_GetName(hitActor2) == PROC_E_NEST) {
-                        mEventTimer = daNpc_Hanjo_Param_c::m.field_0xb0;
+                        mEventTimer = mpHIO->m.field_0xb0;
                     }
                     mStones[i].initialize();
                 }
@@ -1243,7 +1271,7 @@ int daNpc_Hanjo_c::cutPursuitBee(int param_1) {
         shape_angle.y = current.angle.y;
         mCurAngle.y = current.angle.y;
         field_0xd7e.y = mCurAngle.y;
-        cLib_chaseF(&speedF, daNpc_Hanjo_Param_c::m.field_0x90, 0.5f);
+        cLib_chaseF(&speedF, mpHIO->m.field_0x90, 0.5f);
         if (mEventTimer != 0 &&
             mCyl1.ChkCoHit())
         {
@@ -1491,7 +1519,7 @@ int daNpc_Hanjo_c::cutDive(int param_1) {
         cStack_2c.y = attention_info.position.y;
         mGndChk.SetPos(&cStack_2c);
         f32 dVar7 = dComIfG_Bgsp().GroundCross(&mGndChk);
-        if ((dVar7 - mGroundH) < -daNpc_Hanjo_Param_c::m.field_0x18) {
+        if ((dVar7 - mGroundH) < -mpHIO->m.common.knee_length) {
             rv = 1;
         }
         if (mType == TYPE_1) {
@@ -1507,7 +1535,7 @@ int daNpc_Hanjo_c::cutDive(int param_1) {
         cLib_addCalcAngleS2(&current.angle.y, cStack_34.y, 4, 0x800);
         shape_angle.y = current.angle.y;
         mCurAngle.y = current.angle.y;
-        cLib_chaseF(&speedF, daNpc_Hanjo_Param_c::m.field_0x90, 1.0f);
+        cLib_chaseF(&speedF, mpHIO->m.field_0x90, 1.0f);
         break;
     }
     case 3:
@@ -1554,8 +1582,7 @@ int daNpc_Hanjo_c::wait(void* param_0) {
         switch(mType) {
         case TYPE_0:
             if (chkPointInArea(daPy_getPlayerActorClass()->current.pos, current.pos,
-                                                daNpc_Hanjo_Param_c::m.field_0x54, 150.0f,
-                                                -150.0f, 0)) {
+                               mpHIO->m.common.search_distance, 150.0f, -150.0f, 0)) {
                 if (daPy_getPlayerActorClass()->checkBeeChildDrink()) {
                     mSpeakEvent = 1;
                     field_0x1723 = 1;
@@ -1646,7 +1673,7 @@ int daNpc_Hanjo_c::wait(void* param_0) {
 }
 
 int daNpc_Hanjo_c::throwStone(void* param_0) {
-    int sVar4 = daNpc_Hanjo_Param_c::m.field_0xae;
+    int sVar4 = mpHIO->m.field_0xae;
     switch(mMode) {
     case 0:
     case 1:
@@ -1664,7 +1691,7 @@ int daNpc_Hanjo_c::throwStone(void* param_0) {
     case 2:
         if (daNpcT_chkEvtBit(0x8b) && !daNpcT_chkEvtBit(0xad) && !daNpcT_chkEvtBit(0xb7)) {
             if (chkPointInArea(daPy_getPlayerActorClass()->current.pos, current.pos,
-                               daNpc_Hanjo_Param_c::m.field_0xa4, 1000.0f, -1000.0f, 0) == false)
+                               mpHIO->m.field_0xa4, 1000.0f, -1000.0f, 0) == false)
             {
                 mEvtNo = 8;
             }
@@ -1717,7 +1744,7 @@ int daNpc_Hanjo_c::throwStone(void* param_0) {
 }
 
 int daNpc_Hanjo_c::takayose(void* param_0) {
-    f32 dVar8 = daNpc_Hanjo_Param_c::m.field_0xae;
+    f32 dVar8 = mpHIO->m.field_0xae;
     cXyz cStack_50;
     cXyz cStack_5c;
     switch (mMode) {

--- a/src/d/actor/d_a_npc_hoz.cpp
+++ b/src/d/actor/d_a_npc_hoz.cpp
@@ -254,6 +254,22 @@ const daNpc_Hoz_HIOParam daNpc_Hoz_Param_c::m = {
     600.0f,
 };
 
+static NPC_HOZ_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Hoz_HIO_c::daNpc_Hoz_HIO_c() {
+    m = daNpc_Hoz_Param_c::m;
+}
+
+void daNpc_Hoz_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Hoz_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daNpc_Hoz_c::~daNpc_Hoz_c() {
     if (mType == 1) {
         daNpcT_offTmpBit(0x46);
@@ -262,6 +278,12 @@ daNpc_Hoz_c::~daNpc_Hoz_c() {
     if (heap != NULL) {
         mpMorf[0]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 
     deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
 }
@@ -307,6 +329,11 @@ int daNpc_Hoz_c::create() {
 
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ホズ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
         mGndChk = mAcch.m_gnd;
@@ -315,7 +342,7 @@ int daNpc_Hoz_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(daNpc_Hoz_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -402,7 +429,7 @@ int daNpc_Hoz_c::Draw() {
 #else
         FALSE,
 #endif
-        FALSE, daNpc_Hoz_Param_c::m.common.real_shadow_size, NULL, 100.0f, FALSE, FALSE, FALSE
+        FALSE, mpHIO->m.common.real_shadow_size, NULL, 100.0f, FALSE, FALSE, FALSE
     );
 }
 
@@ -515,10 +542,10 @@ void daNpc_Hoz_c::setParam() {
     selectAction();
     srchActors();
 
-    s16 talk_dist = daNpc_Hoz_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_Hoz_Param_c::m.common.talk_angle;
-    s16 attn_dist = daNpc_Hoz_Param_c::m.common.attention_distance;
-    s16 attn_angle = daNpc_Hoz_Param_c::m.common.attention_angle;
+    s16 talk_dist = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
+    s16 attn_dist = mpHIO->m.common.attention_distance;
+    s16 attn_angle = mpHIO->m.common.attention_angle;
 
     attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(attn_dist, attn_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
@@ -540,23 +567,23 @@ void daNpc_Hoz_c::setParam() {
         attention_info.flags = attn_flags;
     }
 
-    scale.set(daNpc_Hoz_Param_c::m.common.scale, daNpc_Hoz_Param_c::m.common.scale, daNpc_Hoz_Param_c::m.common.scale);
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
 
-    mAcchCir.SetWallR(daNpc_Hoz_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpc_Hoz_Param_c::m.common.knee_length);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
 
-    mCcStts.SetWeight(daNpc_Hoz_Param_c::m.common.weight);
-    mCylH = daNpc_Hoz_Param_c::m.common.height;
-    mWallR = daNpc_Hoz_Param_c::m.common.width;
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
 
     if (mType == 4 || mType == 6) {
         gravity = 0.0f;
     } else {
-        gravity = daNpc_Hoz_Param_c::m.common.gravity;
+        gravity = mpHIO->m.common.gravity;
     }
 
-    mExpressionMorfFrame = daNpc_Hoz_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Hoz_Param_c::m.common.morf_frame;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_Hoz_c::setAfterTalkMotion() {}
@@ -728,11 +755,11 @@ void daNpc_Hoz_c::setAttnPos() {
     cXyz sp34(0.0f, -30.0f, 0.0f);
 
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp34, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-            daNpc_Hoz_Param_c::m.common.body_angleX_min, daNpc_Hoz_Param_c::m.common.body_angleX_max,
-            daNpc_Hoz_Param_c::m.common.body_angleY_min, daNpc_Hoz_Param_c::m.common.body_angleY_max,
-            daNpc_Hoz_Param_c::m.common.head_angleX_min, daNpc_Hoz_Param_c::m.common.head_angleX_max,
-            daNpc_Hoz_Param_c::m.common.head_angleY_min, daNpc_Hoz_Param_c::m.common.head_angleY_max,
-            daNpc_Hoz_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+            mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+            mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+            mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+            mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+            mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
 
     f32 var_f31 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.calcJntRad(0.2f, 1.0f, var_f31);
@@ -748,7 +775,7 @@ void daNpc_Hoz_c::setAttnPos() {
     cXyz sp28;
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(4));
     mDoMtx_stack_c::multVecZero(&sp28);
-    attention_info.position.set(sp28.x, sp28.y + daNpc_Hoz_Param_c::m.common.attention_offset, sp28.z);
+    attention_info.position.set(sp28.x, sp28.y + mpHIO->m.common.attention_offset, sp28.z);
 }
 
 void daNpc_Hoz_c::setCollision() {
@@ -770,12 +797,12 @@ void daNpc_Hoz_c::setCollision() {
             }
 
             pos.y -= 30.0f;
-            cyl_h = daNpc_Hoz_Param_c::m.common.height;
-            cyl_r = daNpc_Hoz_Param_c::m.common.width;
+            cyl_h = mpHIO->m.common.height;
+            cyl_r = mpHIO->m.common.width;
         } else {
             pos = current.pos;
-            cyl_h = daNpc_Hoz_Param_c::m.common.height;
-            cyl_r = daNpc_Hoz_Param_c::m.common.width;
+            cyl_h = mpHIO->m.common.height;
+            cyl_r = mpHIO->m.common.width;
         }
 
         mCyl.SetH(cyl_h);
@@ -827,9 +854,8 @@ int daNpc_Hoz_c::test(void* i_this) {
         mMode = 2;
         // fall-through
     case 2:
-        // TODO: determine pointer type of field_0xE40
-        mFaceMotionSeqMngr.setNo(field_0xE40, -1.0f, 0, 0);
-        mMotionSeqMngr.setNo(field_0xE40, -1.0f, 0, 0);
+        mFaceMotionSeqMngr.setNo((int)mpHIO, -1.0f, 0, 0);
+        mMotionSeqMngr.setNo((int)mpHIO, -1.0f, 0, 0);
         mJntAnm.lookNone(0);
         attention_info.flags = 0;
     case 3:
@@ -1183,7 +1209,7 @@ int daNpc_Hoz_c::waitBoat1_5(void* param_0) {
             }
         }
 
-        if (field_0xf8a == 0 && (current.pos - daPy_getPlayerActorClass()->current.pos).absXZ() <= daNpc_Hoz_Param_c::m.field_0x8c) {
+        if (field_0xf8a == 0 && (current.pos - daPy_getPlayerActorClass()->current.pos).absXZ() <= mpHIO->m.field_0x8c) {
             mSpeakEvent = 1;
         }
 
@@ -1664,8 +1690,6 @@ static int daNpc_Hoz_Draw(void* i_this) {
 static int daNpc_Hoz_IsDelete(void* i_this) {
     return true;
 }
-
-static daNpc_Hoz_Param_c l_HIO;
 
 static actor_method_class daNpc_Hoz_MethodTable = {
     (process_method_func)daNpc_Hoz_Create,

--- a/src/d/actor/d_a_npc_kasi_hana.cpp
+++ b/src/d/actor/d_a_npc_kasi_hana.cpp
@@ -632,8 +632,8 @@ daNpcKasiHana_c::~daNpcKasiHana_c() {
     }
 
 #if DEBUG
-    if (mHIO) {
-        mHIO->removeHIO();
+    if (mpHIO) {
+        mpHIO->removeHIO();
     }
 #endif
 }
@@ -663,12 +663,12 @@ cPhs__Step daNpcKasiHana_c::Create() {
         fopAcM_setCullSizeBox(this, -60.0f, -10.0f, -60.0f, 60.0f, 160.0f, 60.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 #if DEBUG
-        mHIO = &l_HIO;
+        mpHIO = &l_HIO;
         // three daughters: Hana:
-        mHIO->entryHIO("三人娘：ハナ");
+        mpHIO->entryHIO("三人娘：ハナ");
 #endif
 
-        mAcchCir.SetWall(mHIO->m.common.width, mHIO->m.common.knee_length);
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -677,8 +677,8 @@ cPhs__Step daNpcKasiHana_c::Create() {
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgType(0);
         mCyl.SetTgSPrm(0);
-        mCyl.SetH(mHIO->m.common.height);
-        mCyl.SetR(mHIO->m.common.width);
+        mCyl.SetH(mpHIO->m.common.height);
+        mCyl.SetR(mpHIO->m.common.width);
         mGndChk = mAcch.m_gnd;
         mGroundH = mAcch.GetGroundH();
 
@@ -734,7 +734,7 @@ int daNpcKasiHana_c::Execute() {
 
 int daNpcKasiHana_c::Draw() {
     if (!mEscape) {
-        draw(FALSE, FALSE, mHIO->m.common.real_shadow_size, NULL, FALSE);
+        draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, FALSE);
     }
 
     return 1;
@@ -759,7 +759,7 @@ int daNpcKasiHana_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
         case JNT_BACKBONE:
         case JNT_NECK:
         case JNT_HEAD:
-            setLookatMtx(jntNo, i_jointList, mHIO->m.common.neck_rotation_ratio);
+            setLookatMtx(jntNo, i_jointList, mpHIO->m.common.neck_rotation_ratio);
             break;
     }
 
@@ -792,16 +792,16 @@ void daNpcKasiHana_c::setParam() {
         mKasiMng.initPath(getRailNo(), 6);
     }
 
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mHIO->m.common.attention_distance, mHIO->m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mHIO->m.common.talk_distance, mHIO->m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 
 #if DEBUG
-    scale.set(mHIO->m.common.scale, mHIO->m.common.scale, mHIO->m.common.scale);
-    mAcchCir.SetWallR(mHIO->m.common.width);
-    mAcchCir.SetWallH(mHIO->m.common.knee_length);
-    gravity = mHIO->m.common.gravity;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    gravity = mpHIO->m.common.gravity;
 #endif
 }
 
@@ -882,7 +882,7 @@ void daNpcKasiHana_c::setAttnPos() {
 
     mHeadAngle.x = cLib_targetAngleX(&mHeadPos, &sp1c);
     mHeadAngle.y = cLib_targetAngleY(&mHeadPos, &sp1c);
-    attention_info.position.set(mHeadPos.x, mHeadPos.y + mHIO->m.common.attention_offset, mHeadPos.z);
+    attention_info.position.set(mHeadPos.x, mHeadPos.y + mpHIO->m.common.attention_offset, mHeadPos.z);
 
     cXyz sp28;
 
@@ -891,8 +891,8 @@ void daNpcKasiHana_c::setAttnPos() {
     sp28.y = current.pos.y;
     mCyl.SetC(sp28);
     #if DEBUG
-    mCyl.SetH(mHIO->m.common.height);
-    mCyl.SetR(mHIO->m.common.width);
+    mCyl.SetH(mpHIO->m.common.height);
+    mCyl.SetR(mpHIO->m.common.width);
     #endif
     dComIfG_Ccsp()->Set(&mCyl);
 }
@@ -974,34 +974,34 @@ void daNpcKasiHana_c::reset() {
 }
 
 void daNpcKasiHana_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {ANM_MICH_KYA_TALK, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_MICH_KYA_TALK, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1 = {ANM_MICH_IYAN_WAIT, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1 = {ANM_MICH_IYAN_WAIT, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[1] = {&dat1};
-    daNpcF_anmPlayData dat2 = {ANM_MICH_OUEN_WAIT_A, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_MICH_OUEN_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3 = {ANM_MICH_OUEN_WAIT_B, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3 = {ANM_MICH_OUEN_WAIT_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[1] = {&dat3};
-    daNpcF_anmPlayData dat4 = {ANM_W_WAIT_A, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat4 = {ANM_W_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat4[1] = {&dat4};
-    daNpcF_anmPlayData dat5 = {ANM_W_TALK_B, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat5 = {ANM_W_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[1] = {&dat5};
-    daNpcF_anmPlayData dat6 = {ANM_W_TO_WOLF, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat6 = {ANM_W_TO_WOLF, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat6[1] = {&dat6};
-    daNpcF_anmPlayData dat7 = {ANM_W_WALK_A, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat7 = {ANM_W_WALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[1] = {&dat7};
-    daNpcF_anmPlayData dat8 = {ANM_W_LOOK_B, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat8 = {ANM_W_LOOK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat8[1] = {&dat8};
-    daNpcF_anmPlayData dat9 = {ANM_W_RUN_A, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat9 = {ANM_W_RUN_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[1] = {&dat9};
-    daNpcF_anmPlayData dat10 = {ANM_W_SURPRISE, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat10 = {ANM_W_SURPRISE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat10[1] = {&dat10};
-    daNpcF_anmPlayData dat11a = {ANM_W_WAIT_A_2, mHIO->m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11b = {ANM_W_2LADYTALK_B, mHIO->m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11c = {ANM_W_TALK_A, mHIO->m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11d = {ANM_W_WAIT_A_2, mHIO->m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11e = {ANM_W_TALK_B, mHIO->m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11f = {ANM_W_2NORMALTALK_B, mHIO->m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat11a = {ANM_W_WAIT_A_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11b = {ANM_W_2LADYTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11c = {ANM_W_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11d = {ANM_W_WAIT_A_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11e = {ANM_W_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11f = {ANM_W_2NORMALTALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat11[6] = {&dat11a, &dat11b, &dat11c, &dat11d, &dat11e, &dat11f};
 
     daNpcF_anmPlayData** ppDat[12] = {
@@ -1054,7 +1054,7 @@ void daNpcKasiHana_c::playMotionAnmLoop(daNpcF_c::daNpcF_anmPlayData*** i_data) 
 
             if (mMotionPhase == 0) {
                 if (mMotion == MOT_W_WAIT_A_LOOP) {
-                    i_morf = mHIO->m.common.morf_frame;
+                    i_morf = mpHIO->m.common.morf_frame;
                 } else if (0.0f <= mMotionMorfOverride) {
                     i_morf = mMotionMorfOverride;
                 }
@@ -1095,14 +1095,14 @@ void daNpcKasiHana_c::lookat() {
     daPy_py_c* player = NULL;
     J3DModel* model = mAnm_p->getModel();
     BOOL i_snap = FALSE;
-    f32 body_angleX_min = mHIO->m.common.body_angleX_min;
-    f32 body_angleX_max = mHIO->m.common.body_angleX_max;
-    f32 body_angleY_min = mHIO->m.common.body_angleY_min;
-    f32 body_angleY_max = mHIO->m.common.body_angleY_max;
-    f32 head_angleX_min = mHIO->m.common.head_angleX_min;
-    f32 head_angleX_max = mHIO->m.common.head_angleX_max;
-    f32 head_angleY_min = mHIO->m.common.head_angleY_min;
-    f32 head_angleY_max = mHIO->m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
     s16 angle_delta = mCurAngle.y - mOldAngle.y;
     cXyz lookatPos[3] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
     csXyz* lookatAngle[3] = {&mLookatAngle[0], &mLookatAngle[1], &mLookatAngle[2]};
@@ -1174,7 +1174,7 @@ BOOL daNpcKasiHana_c::step(s16 i_targetAngle, int param_2) {
 }
 
 BOOL daNpcKasiHana_c::chkFindPlayer() {
-    if (!chkActorInSight(daPy_getPlayerActorClass(), mHIO->m.common.fov)) {
+    if (!chkActorInSight(daPy_getPlayerActorClass(), mpHIO->m.common.fov)) {
         mActorMngr[0].remove();
         return FALSE;
     }
@@ -1250,14 +1250,14 @@ int daNpcKasiHana_c::wait(int param_1) {
                             }
 
                             f32 distFromCenter = mKasiMng.getDistFromCenter();
-                            if (distFromCenter >= 0.0f && distFromCenter < mHIO->m.track_start_dist) {
+                            if (distFromCenter >= 0.0f && distFromCenter < mpHIO->m.track_start_dist) {
                                 field_0x1441 = 1;
                                 mKasiMng.onSygnal(0x200);
                                 setAction(&daNpcKasiHana_c::chace_st);
                                 return 1;
                             }
                         } else if (pl_front_check()) {
-                            if (actorDistance >= mHIO->m.track_stop_dist + 50.0f) {
+                            if (actorDistance >= mpHIO->m.track_stop_dist + 50.0f) {
                                 setAction(&daNpcKasiHana_c::chace);
                                 return 1;
                             }
@@ -1337,7 +1337,7 @@ int daNpcKasiHana_c::chace(int param_1) {
             setMotion(MOT_W_RUN_A, -1.0f, 0);
             setLookMode(LOOK_NONE);
             fopAcM_SetSpeed(this, 0.0f, 0.0f, 0.0f);
-            fopAcM_SetSpeedF(this, mHIO->m.track_spd);
+            fopAcM_SetSpeedF(this, mpHIO->m.track_spd);
             mKasiMng.chgWeightLight();
             mMode = 1;
             break;
@@ -1347,7 +1347,7 @@ int daNpcKasiHana_c::chace(int param_1) {
             _turn_pos(chacePos, 0x800);
 
             if (pl_front_check()) {
-                if (fopAcM_searchActorDistanceXZ(this, daPy_getPlayerActorClass()) < mHIO->m.track_stop_dist) {
+                if (fopAcM_searchActorDistanceXZ(this, daPy_getPlayerActorClass()) < mpHIO->m.track_stop_dist) {
                     setAction(&daNpcKasiHana_c::wait);
                 }
             } else {
@@ -1666,7 +1666,7 @@ int daNpcKasiHana_c::escape(int param_1) {
         case 0:
             setMotion(MOT_W_RUN_A, -1.0f, 0);
             fopAcM_SetSpeed(this, 0.0f, 0.0f, 0.0f);
-            fopAcM_SetSpeedF(this, mHIO->m.escape_spd);
+            fopAcM_SetSpeedF(this, mpHIO->m.escape_spd);
             setEscapePathDir();
             mKasiMng.onSygnal(0x20);
             mSound.startCreatureVoice(Z2SE_HANA_V_FEAR, -1);

--- a/src/d/actor/d_a_npc_kasi_kyu.cpp
+++ b/src/d/actor/d_a_npc_kasi_kyu.cpp
@@ -103,7 +103,7 @@ enum Motion {
     /* 0xC */ MOT_W_2NORMALTALK_A,
 };
 
-static daNpcKasiKyu_Param_c l_HIO;
+static NPC_KASI_KYU_HIO_CLASS l_HIO;
 
 static daNpc_GetParam2 l_bckGetParamList[16] = {
     {BCK_MICH_IYAN_WAIT, J3DFrameCtrl::EMode_LOOP, GIRLS},
@@ -144,18 +144,6 @@ daNpcKasiKyu_c::EventFn daNpcKasiKyu_c::mEvtSeqList[1] = {
     NULL
 };
 
-daNpcKasiKyu_c::daNpcKasiKyu_c() {}
-
-daNpcKasiKyu_c::~daNpcKasiKyu_c() {
-    for (int i = 0; i < 3; i ++) {
-        dComIfG_resDelete(&mPhases[i], l_arcNames[i]);
-    }
-
-    if (heap != NULL) {
-        mAnm_p->stopZelAnime();
-    }
-}
-
 daNpcKasiKyu_HIOParam const daNpcKasiKyu_Param_c::m = {
     55.0f,
     -3.0f,
@@ -194,6 +182,34 @@ daNpcKasiKyu_HIOParam const daNpcKasiKyu_Param_c::m = {
     16.0f,
 };
 
+#if DEBUG
+daNpcKasiKyu_HIO_c::daNpcKasiKyu_HIO_c() {
+    m = daNpcKasiKyu_Param_c::m;
+}
+
+void daNpcKasiKyu_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpcKasiKyu_c::daNpcKasiKyu_c() {}
+
+daNpcKasiKyu_c::~daNpcKasiKyu_c() {
+    for (int i = 0; i < 3; i ++) {
+        dComIfG_resDelete(&mPhases[i], l_arcNames[i]);
+    }
+
+    if (heap != NULL) {
+        mAnm_p->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
+
 cPhs__Step daNpcKasiKyu_c::Create() {
     fopAcM_ct(this, daNpcKasiKyu_c);
 
@@ -219,7 +235,12 @@ cPhs__Step daNpcKasiKyu_c::Create() {
         fopAcM_setCullSizeBox(this, -60.0f, -10.0f, -60.0f, 60.0f, 220.0f, 60.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-        mAcchCir.SetWall(daNpcKasiKyu_Param_c::m.common.width, daNpcKasiKyu_Param_c::m.common.knee_length);
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("三人娘：キウ");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -228,8 +249,8 @@ cPhs__Step daNpcKasiKyu_c::Create() {
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgType(0);
         mCyl.SetTgSPrm(0);
-        mCyl.SetH(daNpcKasiKyu_Param_c::m.common.height);
-        mCyl.SetR(daNpcKasiKyu_Param_c::m.common.width);
+        mCyl.SetH(mpHIO->m.common.height);
+        mCyl.SetR(mpHIO->m.common.width);
         mGndChk = mAcch.m_gnd;
         mGroundH = mAcch.GetGroundH();
 
@@ -285,7 +306,7 @@ int daNpcKasiKyu_c::Execute() {
 
 int daNpcKasiKyu_c::Draw() {
     if (!mEscape) {
-        draw(FALSE, FALSE, daNpcKasiKyu_Param_c::m.common.real_shadow_size, NULL, FALSE);
+        draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, FALSE);
     }
 
     return 1;
@@ -310,7 +331,7 @@ int daNpcKasiKyu_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
         case 1:
         case 2:
         case 3:
-            setLookatMtx(jntNo, i_jointList, daNpcKasiKyu_Param_c::m.common.neck_rotation_ratio);
+            setLookatMtx(jntNo, i_jointList, mpHIO->m.common.neck_rotation_ratio);
             break;
     }
 
@@ -339,9 +360,9 @@ int daNpcKasiKyu_c::ctrlJointCallBack(J3DJoint* i_joint, int param_2) {
 }
 
 void daNpcKasiKyu_c::setParam() {
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(daNpcKasiKyu_Param_c::m.common.attention_distance, daNpcKasiKyu_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcKasiKyu_Param_c::m.common.talk_distance, daNpcKasiKyu_Param_c::m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 }
 
@@ -407,7 +428,7 @@ void daNpcKasiKyu_c::setAttnPos() {
 
     mHeadAngle.x = cLib_targetAngleX(&mHeadPos, &sp1c);
     mHeadAngle.y = cLib_targetAngleY(&mHeadPos, &sp1c);
-    attention_info.position.set(mHeadPos.x, mHeadPos.y + daNpcKasiKyu_Param_c::m.common.attention_offset, mHeadPos.z);
+    attention_info.position.set(mHeadPos.x, mHeadPos.y + mpHIO->m.common.attention_offset, mHeadPos.z);
 
     cXyz sp28;
 
@@ -416,8 +437,8 @@ void daNpcKasiKyu_c::setAttnPos() {
     sp28.y = current.pos.y;
     mCyl.SetC(sp28);
     #if DEBUG
-    mCyl.SetH(daNpcKasiKyu_Param_c::m.common.height);
-    mCyl.SetR(daNpcKasiKyu_Param_c::m.common.width);
+    mCyl.SetH(mpHIO->m.common.height);
+    mCyl.SetR(mpHIO->m.common.width);
     #endif
     dComIfG_Ccsp()->Set(&mCyl);
 }
@@ -498,37 +519,37 @@ void daNpcKasiKyu_c::reset() {
 }
 
 void daNpcKasiKyu_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {ANM_MICH_KYA_TALK, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_MICH_KYA_TALK, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1 = {ANM_MICH_IYAN_WAIT, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1 = {ANM_MICH_IYAN_WAIT, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[1] = {&dat1};
-    daNpcF_anmPlayData dat2 = {ANM_MICH_OUEN_WAIT_A, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_MICH_OUEN_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3 = {ANM_MICH_OUEN_WAIT_B, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3 = {ANM_MICH_OUEN_WAIT_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[1] = {&dat3};
-    daNpcF_anmPlayData dat4 = {ANM_W_WAIT_A, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat4 = {ANM_W_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat4[1] = {&dat4};
-    daNpcF_anmPlayData dat5 = {ANM_W_TALK_B, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat5 = {ANM_W_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[1] = {&dat5};
-    daNpcF_anmPlayData dat6 = {ANM_W_WALK_A, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat6 = {ANM_W_WALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat6[1] = {&dat6};
-    daNpcF_anmPlayData dat7 = {ANM_W_CELLME, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat7 = {ANM_W_CELLME, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[1] = {&dat7};
-    daNpcF_anmPlayData dat8 = {ANM_W_RUN_A, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat8 = {ANM_W_RUN_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat8[1] = {&dat8};
-    daNpcF_anmPlayData dat9 = {ANM_W_TO_WOLF, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat9 = {ANM_W_TO_WOLF, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[1] = {&dat9};
-    daNpcF_anmPlayData dat10 = {ANM_W_SURPRISE, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat10 = {ANM_W_SURPRISE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat10[1] = {&dat10};
-    daNpcF_anmPlayData dat11a = {ANM_W_WAIT_A_2, daNpcKasiKyu_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11b = {ANM_W_2LADYTALK_B, daNpcKasiKyu_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11c = {ANM_W_TALK_B_2, daNpcKasiKyu_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11d = {ANM_W_WAIT_A_2, daNpcKasiKyu_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11e = {ANM_W_TALK_B, daNpcKasiKyu_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11f = {ANM_W_2NORMALTALK_B, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat11a = {ANM_W_WAIT_A_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11b = {ANM_W_2LADYTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11c = {ANM_W_TALK_B_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11d = {ANM_W_WAIT_A_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11e = {ANM_W_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11f = {ANM_W_2NORMALTALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat11[6] = {&dat11a, &dat11b, &dat11c, &dat11d, &dat11e, &dat11f};
-    daNpcF_anmPlayData dat12a = {ANM_W_2NORMALTALK_A, daNpcKasiKyu_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat12b = {ANM_W_WAIT_A, daNpcKasiKyu_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat12a = {ANM_W_2NORMALTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat12b = {ANM_W_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat12[2] = {&dat12a, &dat12b};
 
     daNpcF_anmPlayData** ppDat[13] = {
@@ -582,7 +603,7 @@ void daNpcKasiKyu_c::playMotionAnmLoop(daNpcF_c::daNpcF_anmPlayData*** i_data) {
 
             if (mMotionPhase == 0) {
                 if (mMotion == MOT_W_WAIT_A_LOOP) {
-                    i_morf = daNpcKasiKyu_Param_c::m.common.morf_frame;
+                    i_morf = mpHIO->m.common.morf_frame;
                 } else if (0.0f <= mMotionMorfOverride) {
                     i_morf = mMotionMorfOverride;
                 }
@@ -623,14 +644,14 @@ void daNpcKasiKyu_c::lookat() {
     daPy_py_c* player = NULL;
     J3DModel* model = mAnm_p->getModel();
     BOOL i_snap = FALSE;
-    f32 body_angleX_min = daNpcKasiKyu_Param_c::m.common.body_angleX_min;
-    f32 body_angleX_max = daNpcKasiKyu_Param_c::m.common.body_angleX_max;
-    f32 body_angleY_min = daNpcKasiKyu_Param_c::m.common.body_angleY_min;
-    f32 body_angleY_max = daNpcKasiKyu_Param_c::m.common.body_angleY_max;
-    f32 head_angleX_min = daNpcKasiKyu_Param_c::m.common.head_angleX_min;
-    f32 head_angleX_max = daNpcKasiKyu_Param_c::m.common.head_angleX_max;
-    f32 head_angleY_min = daNpcKasiKyu_Param_c::m.common.head_angleY_min;
-    f32 head_angleY_max = daNpcKasiKyu_Param_c::m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
     s16 angle_delta = mCurAngle.y - mOldAngle.y;
     cXyz lookatPos[3] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
     csXyz* lookatAngle[3] = {&mLookatAngle[0], &mLookatAngle[1], &mLookatAngle[2]};
@@ -702,7 +723,7 @@ BOOL daNpcKasiKyu_c::step(s16 i_targetAngle, int param_2) {
 }
 
 BOOL daNpcKasiKyu_c::chkFindPlayer() {
-    if (!chkActorInSight(daPy_getPlayerActorClass(), daNpcKasiKyu_Param_c::m.common.fov)) {
+    if (!chkActorInSight(daPy_getPlayerActorClass(), mpHIO->m.common.fov)) {
         mActorMngr[0].remove();
         return FALSE;
     }
@@ -1247,13 +1268,13 @@ int daNpcKasiKyu_c::escape(int param_1) {
             setMotion(MOT_W_RUN_A, -1.0f, 0);
             fopAcM_SetSpeed(this, 0.0f, 0.0f, 0.0f);
             fopAcM_SetSpeedF(this, 0.0f);
-            field_0x1430 = daNpcKasiKyu_Param_c::m.escape_time;
+            field_0x1430 = mpHIO->m.escape_time;
             mMode = 1;
             break;
 
         case 1:
             if (--field_0x1430 <= 0) {
-                fopAcM_SetSpeedF(this, daNpcKasiKyu_Param_c::m.escape_spd);
+                fopAcM_SetSpeedF(this, mpHIO->m.escape_spd);
                 mSound.startCreatureVoice(Z2SE_KIU_V_FEAR, -1);
                 mMode = 2;
             }

--- a/src/d/actor/d_a_npc_kasi_mich.cpp
+++ b/src/d/actor/d_a_npc_kasi_mich.cpp
@@ -103,7 +103,7 @@ enum Motion {
     /* 0xC */ MOT_W_2NORMALTALK_B
 };
 
-static daNpcKasiMich_Param_c l_HIO;
+static NPC_KASI_MICH_HIO_CLASS l_HIO;
 
 static daNpc_GetParam2 l_bckGetParamList[16] = {
     {BCK_MICH_IYAN_WAIT, J3DFrameCtrl::EMode_LOOP, GIRLS},
@@ -144,18 +144,6 @@ daNpcKasiMich_c::EventFn daNpcKasiMich_c::mEvtSeqList[1] = {
     NULL
 };
 
-daNpcKasiMich_c::daNpcKasiMich_c() {}
-
-daNpcKasiMich_c::~daNpcKasiMich_c() {
-    for (int i = 0; i < 3; i ++) {
-        dComIfG_resDelete(&mPhases[i], l_arcNames[i]);
-    }
-
-    if (heap != NULL) {
-        mAnm_p->stopZelAnime();
-    }
-}
-
 daNpcKasiMich_HIOParam const daNpcKasiMich_Param_c::m = {
     55.0f,
     -3.0f,
@@ -194,6 +182,34 @@ daNpcKasiMich_HIOParam const daNpcKasiMich_Param_c::m = {
     16.0f,
 };
 
+#if DEBUG
+daNpcKasiMich_HIO_c::daNpcKasiMich_HIO_c() {
+    m = daNpcKasiMich_Param_c::m;
+}
+
+void daNpcKasiMich_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpcKasiMich_c::daNpcKasiMich_c() {}
+
+daNpcKasiMich_c::~daNpcKasiMich_c() {
+    for (int i = 0; i < 3; i ++) {
+        dComIfG_resDelete(&mPhases[i], l_arcNames[i]);
+    }
+
+    if (heap != NULL) {
+        mAnm_p->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
+
 cPhs__Step daNpcKasiMich_c::Create() {
     fopAcM_ct(this, daNpcKasiMich_c);
 
@@ -219,7 +235,12 @@ cPhs__Step daNpcKasiMich_c::Create() {
         fopAcM_setCullSizeBox(this, -60.0f, -10.0f, -60.0f, 60.0f, 220.0f, 60.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-        mAcchCir.SetWall(daNpcKasiMich_Param_c::m.common.width, daNpcKasiMich_Param_c::m.common.knee_length);
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("三人娘：ミチ");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -228,8 +249,8 @@ cPhs__Step daNpcKasiMich_c::Create() {
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgType(0);
         mCyl.SetTgSPrm(0);
-        mCyl.SetH(daNpcKasiMich_Param_c::m.common.height);
-        mCyl.SetR(daNpcKasiMich_Param_c::m.common.width);
+        mCyl.SetH(mpHIO->m.common.height);
+        mCyl.SetR(mpHIO->m.common.width);
         mGndChk = mAcch.m_gnd;
         mGroundH = mAcch.GetGroundH();
 
@@ -285,7 +306,7 @@ int daNpcKasiMich_c::Execute() {
 
 int daNpcKasiMich_c::Draw() {
     if (!mEscape) {
-        draw(FALSE, FALSE, daNpcKasiMich_Param_c::m.common.real_shadow_size, NULL, FALSE);
+        draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, FALSE);
     }
 
     return 1;
@@ -310,7 +331,7 @@ int daNpcKasiMich_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
         case 1:
         case 2:
         case 3:
-            setLookatMtx(jntNo, i_jointList, daNpcKasiMich_Param_c::m.common.neck_rotation_ratio);
+            setLookatMtx(jntNo, i_jointList, mpHIO->m.common.neck_rotation_ratio);
             break;
     }
 
@@ -339,9 +360,9 @@ int daNpcKasiMich_c::ctrlJointCallBack(J3DJoint* i_joint, int param_2) {
 }
 
 void daNpcKasiMich_c::setParam() {
-    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(daNpcKasiMich_Param_c::m.common.attention_distance, daNpcKasiMich_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
-    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(daNpcKasiMich_Param_c::m.common.talk_distance, daNpcKasiMich_Param_c::m.common.talk_angle);
+    attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 }
 
@@ -407,7 +428,7 @@ void daNpcKasiMich_c::setAttnPos() {
 
     mHeadAngle.x = cLib_targetAngleX(&mHeadPos, &sp1c);
     mHeadAngle.y = cLib_targetAngleY(&mHeadPos, &sp1c);
-    attention_info.position.set(mHeadPos.x, mHeadPos.y + daNpcKasiMich_Param_c::m.common.attention_offset, mHeadPos.z);
+    attention_info.position.set(mHeadPos.x, mHeadPos.y + mpHIO->m.common.attention_offset, mHeadPos.z);
 
     cXyz sp28;
 
@@ -416,8 +437,8 @@ void daNpcKasiMich_c::setAttnPos() {
     sp28.y = current.pos.y;
     mCyl.SetC(sp28);
     #if DEBUG
-    mCyl.SetH(daNpcKasiMich_Param_c::m.common.height);
-    mCyl.SetR(daNpcKasiMich_Param_c::m.common.width);
+    mCyl.SetH(mpHIO->m.common.height);
+    mCyl.SetR(mpHIO->m.common.width);
     #endif
     dComIfG_Ccsp()->Set(&mCyl);
 }
@@ -498,37 +519,37 @@ void daNpcKasiMich_c::reset() {
 }
 
 void daNpcKasiMich_c::playMotion() {
-    daNpcF_anmPlayData dat0 = {ANM_MICH_KYA_TALK, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat0 = {ANM_MICH_KYA_TALK, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat0[1] = {&dat0};
-    daNpcF_anmPlayData dat1 = {ANM_MICH_IYAN_WAIT, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat1 = {ANM_MICH_IYAN_WAIT, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat1[1] = {&dat1};
-    daNpcF_anmPlayData dat2 = {ANM_MICH_OUEN_WAIT_A, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat2 = {ANM_MICH_OUEN_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat2[1] = {&dat2};
-    daNpcF_anmPlayData dat3 = {ANM_MICH_OUEN_WAIT_B, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat3 = {ANM_MICH_OUEN_WAIT_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat3[1] = {&dat3};
-    daNpcF_anmPlayData dat4 = {ANM_W_WAIT_A, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat4 = {ANM_W_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat4[1] = {&dat4};
-    daNpcF_anmPlayData dat5 = {ANM_W_TALK_B, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat5 = {ANM_W_TALK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat5[1] = {&dat5};
-    daNpcF_anmPlayData dat6 = {ANM_W_WALK_A, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat6 = {ANM_W_WALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat6[1] = {&dat6};
-    daNpcF_anmPlayData dat7 = {ANM_W_LOOK_B, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat7 = {ANM_W_LOOK_B, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat7[1] = {&dat7};
-    daNpcF_anmPlayData dat8 = {ANM_W_RUN_A, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat8 = {ANM_W_RUN_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat8[1] = {&dat8};
-    daNpcF_anmPlayData dat9 = {ANM_W_TO_WOLF, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat9 = {ANM_W_TO_WOLF, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat9[1] = {&dat9};
-    daNpcF_anmPlayData dat10 = {ANM_W_SURPRISE, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat10 = {ANM_W_SURPRISE, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat10[1] = {&dat10};
-    daNpcF_anmPlayData dat11a = {ANM_W_TALK_A, daNpcKasiMich_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11b = {ANM_W_2LADYTALK_A, daNpcKasiMich_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11c = {ANM_W_WAIT_A_2, daNpcKasiMich_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11d = {ANM_W_TALK_B, daNpcKasiMich_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11e = {ANM_W_WAIT_A_2, daNpcKasiMich_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat11f = {ANM_W_2NORMALTALK_A, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat11a = {ANM_W_TALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11b = {ANM_W_2LADYTALK_A, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11c = {ANM_W_WAIT_A_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11d = {ANM_W_TALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11e = {ANM_W_WAIT_A_2, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat11f = {ANM_W_2NORMALTALK_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat11[6] = {&dat11a, &dat11b, &dat11c, &dat11d, &dat11e, &dat11f};
-    daNpcF_anmPlayData dat12a = {ANM_W_2NORMALTALK_B, daNpcKasiMich_Param_c::m.common.morf_frame, 1};
-    daNpcF_anmPlayData dat12b = {ANM_W_WAIT_A, daNpcKasiMich_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData dat12a = {ANM_W_2NORMALTALK_B, mpHIO->m.common.morf_frame, 1};
+    daNpcF_anmPlayData dat12b = {ANM_W_WAIT_A, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* pDat12[2] = {&dat12a, &dat12b};
 
     daNpcF_anmPlayData** ppDat[13] = {
@@ -582,7 +603,7 @@ void daNpcKasiMich_c::playMotionAnmLoop(daNpcF_c::daNpcF_anmPlayData*** i_data) 
 
             if (mMotionPhase == 0) {
                 if (mMotion == MOT_W_TALK_A) {
-                    i_morf = daNpcKasiMich_Param_c::m.common.morf_frame;
+                    i_morf = mpHIO->m.common.morf_frame;
                 } else if (0.0f <= mMotionMorfOverride) {
                     i_morf = mMotionMorfOverride;
                 }
@@ -623,14 +644,14 @@ void daNpcKasiMich_c::lookat() {
     daPy_py_c* player = NULL;
     J3DModel* model = mAnm_p->getModel();
     BOOL i_snap = FALSE;
-    f32 body_angleX_min = daNpcKasiMich_Param_c::m.common.body_angleX_min;
-    f32 body_angleX_max = daNpcKasiMich_Param_c::m.common.body_angleX_max;
-    f32 body_angleY_min = daNpcKasiMich_Param_c::m.common.body_angleY_min;
-    f32 body_angleY_max = daNpcKasiMich_Param_c::m.common.body_angleY_max;
-    f32 head_angleX_min = daNpcKasiMich_Param_c::m.common.head_angleX_min;
-    f32 head_angleX_max = daNpcKasiMich_Param_c::m.common.head_angleX_max;
-    f32 head_angleY_min = daNpcKasiMich_Param_c::m.common.head_angleY_min;
-    f32 head_angleY_max = daNpcKasiMich_Param_c::m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
     s16 angle_delta = mCurAngle.y - mOldAngle.y;
     cXyz lookatPos[3] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
     csXyz* lookatAngle[3] = {&mLookatAngle[0], &mLookatAngle[1], &mLookatAngle[2]};
@@ -702,7 +723,7 @@ BOOL daNpcKasiMich_c::step(s16 i_targetAngle, int param_2) {
 }
 
 BOOL daNpcKasiMich_c::chkFindPlayer() {
-    if (!chkActorInSight(daPy_getPlayerActorClass(), daNpcKasiMich_Param_c::m.common.fov)) {
+    if (!chkActorInSight(daPy_getPlayerActorClass(), mpHIO->m.common.fov)) {
         mActorMngr[0].remove();
         return FALSE;
     }
@@ -1190,13 +1211,13 @@ int daNpcKasiMich_c::escape(int param_1) {
             setMotion(MOT_W_RUN_A, -1.0f, 0);
             fopAcM_SetSpeed(this, 0.0f, 0.0f, 0.0f);
             fopAcM_SetSpeedF(this, 0.0f);
-            field_0x1430 = daNpcKasiMich_Param_c::m.escape_time;
+            field_0x1430 = mpHIO->m.escape_time;
             mMode = 1;
             break;
 
         case 1:
             if (--field_0x1430 <= 0) {
-                fopAcM_SetSpeedF(this, daNpcKasiMich_Param_c::m.escape_spd);
+                fopAcM_SetSpeedF(this, mpHIO->m.escape_spd);
                 mSound.startCreatureVoice(Z2SE_MICH_V_FEAR, -1);
                 mMode = 2;
             }

--- a/src/d/actor/d_a_npc_kolin.cpp
+++ b/src/d/actor/d_a_npc_kolin.cpp
@@ -335,14 +335,6 @@ daNpc_Kolin_c::cutFunc daNpc_Kolin_c::mCutList[11] = {
     &daNpc_Kolin_c::cutThankYou
 };
 
-daNpc_Kolin_c::~daNpc_Kolin_c() {
-    if (mpMorf[0] != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 daNpc_Kolin_HIOParam const daNpc_Kolin_Param_c::m = {
     140.0f,
     -3.0f,
@@ -393,6 +385,36 @@ daNpc_Kolin_HIOParam const daNpc_Kolin_Param_c::m = {
     2.0f,
 };
 
+static NPC_KOLIN_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Kolin_HIO_c::daNpc_Kolin_HIO_c() {
+    m = daNpc_Kolin_Param_c::m;
+}
+
+void daNpc_Kolin_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Kolin_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Kolin_c::~daNpc_Kolin_c() {
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
+
 cPhs__Step daNpc_Kolin_c::create() {
     daNpcT_ct(this, daNpc_Kolin_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4, l_motionSequenceData, 4, l_evtList, l_resNameList);
 
@@ -431,11 +453,16 @@ cPhs__Step daNpc_Kolin_c::create() {
         mSound.init(&current.pos, &eyePos, 3, 1);
         field_0x9c0.init(&mAcch, 0.0f, 0.0f);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("コリン");
+#endif
+
         reset();
 
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Kolin_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
 
         field_0xe48.Set(mCcDCyl);
         field_0xe48.SetStts(&mCcStts);
@@ -732,10 +759,10 @@ void daNpc_Kolin_c::setParam() {
     selectAction();
     srchActors();
 
-    s16 talk_distance = daNpc_Kolin_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_Kolin_Param_c::m.common.talk_angle;
-    s16 attention_distance = daNpc_Kolin_Param_c::m.common.attention_distance;
-    s16 attention_angle = daNpc_Kolin_Param_c::m.common.attention_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
+    s16 attention_distance = mpHIO->m.common.attention_distance;
+    s16 attention_angle = mpHIO->m.common.attention_angle;
 
     if (mType == 3) {
         talk_distance = 7;
@@ -770,22 +797,22 @@ void daNpc_Kolin_c::setParam() {
         fopAcM_OffStatus(this, fopAcM_STATUS_UNK_0x100);
     }
 
-    scale.set(daNpc_Kolin_Param_c::m.common.scale, daNpc_Kolin_Param_c::m.common.scale, daNpc_Kolin_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Kolin_Param_c::m.common.weight);
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
 
     if (&daNpc_Kolin_c::follow == mNextAction) {
         mCcStts.SetWeight(109);
     }
 
-    mCylH = daNpc_Kolin_Param_c::m.common.height;
-    mWallR = daNpc_Kolin_Param_c::m.common.width;
-    mAttnFovY = daNpc_Kolin_Param_c::m.common.fov;
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Kolin_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Kolin_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Kolin_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Kolin_Param_c::m.common.morf_frame;
-    gravity = daNpc_Kolin_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Kolin_c::checkChangeEvt() {
@@ -956,8 +983,6 @@ void daNpc_Kolin_c::beforeMove() {
     }
 }
 
-static daNpc_Kolin_Param_c l_HIO;
-
 void daNpc_Kolin_c::setAttnPos() {
     cXyz sp3c(5.0f, 30.0f, 0.0f);
 
@@ -968,11 +993,11 @@ void daNpc_Kolin_c::setAttnPos() {
     mStagger.calc(FALSE);
     f32 rad_val = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp3c, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-                     daNpc_Kolin_Param_c::m.common.body_angleX_min, daNpc_Kolin_Param_c::m.common.body_angleX_max,
-                     daNpc_Kolin_Param_c::m.common.body_angleY_min, daNpc_Kolin_Param_c::m.common.body_angleY_max,
-                     daNpc_Kolin_Param_c::m.common.head_angleX_min, daNpc_Kolin_Param_c::m.common.head_angleX_max,
-                     daNpc_Kolin_Param_c::m.common.head_angleY_min, daNpc_Kolin_Param_c::m.common.head_angleY_max,
-                     daNpc_Kolin_Param_c::m.common.neck_rotation_ratio, rad_val, NULL);
+                     mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+                     mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+                     mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+                     mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+                     mpHIO->m.common.neck_rotation_ratio, rad_val, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, rad_val);
     
     setMtx();
@@ -982,10 +1007,10 @@ void daNpc_Kolin_c::setAttnPos() {
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, FALSE, 1.0f, 0);
 
     sp3c.set(0.0f, 0.0f, 0.0f);
-    sp3c.y = daNpc_Kolin_Param_c::m.common.attention_offset;
+    sp3c.y = mpHIO->m.common.attention_offset;
     if (mType == 10) {
         sp3c.set(26.54f, 0.0f, -97.77f);
-        sp3c.y = daNpc_Kolin_Param_c::m.common.attention_offset;
+        sp3c.y = mpHIO->m.common.attention_offset;
     }
 
     mDoMtx_stack_c::YrotS(mCurAngle.y);
@@ -1091,7 +1116,7 @@ int daNpc_Kolin_c::selectAction() {
     mNextAction = NULL;
 
 #if DEBUG
-    if (daNpc_Kolin_Param_c::m.common.debug_mode_ON) {
+    if (mpHIO->m.common.debug_mode_ON) {
         mNextAction = &daNpc_Kolin_c::test;
         return 1;
     }
@@ -1150,8 +1175,8 @@ void daNpc_Kolin_c::calcFollowSpeedAndAngle(fopAc_ac_c* actor, int param_2, int 
 
         if (param_3 != 0) {
             f32 fVar1;
-            if (daNpc_Kolin_Param_c::m.follow_distance <= actor_distance) {
-                fVar1 = actor_distance - daNpc_Kolin_Param_c::m.follow_distance;
+            if (mpHIO->m.follow_distance <= actor_distance) {
+                fVar1 = actor_distance - mpHIO->m.follow_distance;
             } else {
                 fVar1 = 0.0f;
             }
@@ -1164,7 +1189,7 @@ void daNpc_Kolin_c::calcFollowSpeedAndAngle(fopAc_ac_c* actor, int param_2, int 
         }
 
         if (mMotionSeqMngr.getNo() == MOT_RUN) {
-            cLib_chaseF(&speedF, daNpc_Kolin_Param_c::m.run_speed, 0.5f);
+            cLib_chaseF(&speedF, mpHIO->m.run_speed, 0.5f);
         } else if (mFootLOffset.y < mFootROffset.y) {
             speedF = (mFootLOffset - mOldFootLOffset).absXZ();
         } else {
@@ -1236,7 +1261,7 @@ void daNpc_Kolin_c::followPlayer(int param_1) {
             mMotionSeqMngr.setNo(MOT_WAIT_A, -1.0f, FALSE, 0);
         }
     } else if (mMotionSeqMngr.getNo() != MOT_RUN) {
-        if (fopAcM_searchActorDistanceXZ(this, daPy_getPlayerActorClass()) < daNpc_Kolin_Param_c::m.start_distance) {
+        if (fopAcM_searchActorDistanceXZ(this, daPy_getPlayerActorClass()) < mpHIO->m.start_distance) {
             if (mMotionSeqMngr.getNo() != MOT_WALK_B) {
                 mMotionSeqMngr.setNo(MOT_WALK_B, 4.0f, FALSE, 0);
             }
@@ -1848,10 +1873,10 @@ int daNpc_Kolin_c::wait(void* param_1) {
             if (mType == 4) {
                 actor_p = mActorMngr[4].getActorP();
                 if (actor_p != NULL &&
-                    ((daNpc_Len_c*)actor_p)->checkStartDemo13StbEvt(this, daNpc_Kolin_Param_c::m.common.box_min_x, daNpc_Kolin_Param_c::m.common.box_min_y,
-                                                    daNpc_Kolin_Param_c::m.common.box_min_z, daNpc_Kolin_Param_c::m.common.box_max_x,
-                                                    daNpc_Kolin_Param_c::m.common.box_max_y, daNpc_Kolin_Param_c::m.common.box_max_z,
-                                                    daNpc_Kolin_Param_c::m.common.box_offset)) {
+                    ((daNpc_Len_c*)actor_p)->checkStartDemo13StbEvt(this, mpHIO->m.common.box_min_x, mpHIO->m.common.box_min_y,
+                                                    mpHIO->m.common.box_min_z, mpHIO->m.common.box_max_x,
+                                                    mpHIO->m.common.box_max_y, mpHIO->m.common.box_max_z,
+                                                    mpHIO->m.common.box_offset)) {
                     mEvtNo = 7;
                     field_0x1015 = 1;
                 }
@@ -1980,8 +2005,8 @@ int daNpc_Kolin_c::wait(void* param_1) {
 int daNpc_Kolin_c::timidWalk(void* param_1) {
     fopAc_ac_c* actor_p;
     cXyz work;
-    int shy_walk_time = daNpc_Kolin_Param_c::m.shy_walk_time;
-    int sulk_time = daNpc_Kolin_Param_c::m.sulk_time;
+    int shy_walk_time = mpHIO->m.shy_walk_time;
+    int sulk_time = mpHIO->m.sulk_time;
 
     switch (mMode) {
         case 0:
@@ -2107,7 +2132,7 @@ int daNpc_Kolin_c::follow(void* param_1) {
 }
 
 int daNpc_Kolin_c::clothWait(void* param_1) {
-    int sulk_time = daNpc_Kolin_Param_c::m.sulk_time;
+    int sulk_time = mpHIO->m.sulk_time;
 
     switch (mMode) {
         case 0:

--- a/src/d/actor/d_a_npc_kolinb.cpp
+++ b/src/d/actor/d_a_npc_kolinb.cpp
@@ -196,17 +196,7 @@ daNpc_Kolinb_c::cutFunc daNpc_Kolinb_c::mCutList[7] = {
     &daNpc_Kolinb_c::cutThankYou
 };
 
-daNpc_Kolinb_c::~daNpc_Kolinb_c() {
-    if (mpMorf[0] != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    if (mpBgW != NULL) {
-        dComIfG_Bgsp().Release(mpBgW);
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
+static NPC_KOLINB_HIO_CLASS l_HIO;
 
 daNpc_Kolinb_HIOParam const daNpc_Kolinb_Param_c::m = {
     100.0f,
@@ -252,6 +242,38 @@ daNpc_Kolinb_HIOParam const daNpc_Kolinb_Param_c::m = {
     0.0f,
 };
 
+#if DEBUG
+daNpc_Kolinb_HIO_c::daNpc_Kolinb_HIO_c() {
+    m = daNpc_Kolinb_Param_c::m;
+}
+
+void daNpc_Kolinb_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Kolinb_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Kolinb_c::~daNpc_Kolinb_c() {
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+    if (mpBgW != NULL) {
+        dComIfG_Bgsp().Release(mpBgW);
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
+
 cPhs__Step daNpc_Kolinb_c::create() {
     daNpcT_ct(this, daNpc_Kolinb_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4, l_motionSequenceData, 4, l_evtList, l_resNameList);
 
@@ -289,11 +311,16 @@ cPhs__Step daNpc_Kolinb_c::create() {
 
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("寝床コリン");
+#endif
+
         reset();
 
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Kolinb_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         
         field_0xe44.Set(mCcDCyl);
         field_0xe44.SetStts(&mCcStts);
@@ -461,27 +488,27 @@ void daNpc_Kolinb_c::setParam() {
     selectAction();
     srchActors();
 
-    s16 talk_distance = daNpc_Kolinb_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_Kolinb_Param_c::m.common.talk_angle;
-    s16 attention_distance = daNpc_Kolinb_Param_c::m.common.attention_distance;
-    s16 attention_angle = daNpc_Kolinb_Param_c::m.common.attention_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
+    s16 attention_distance = mpHIO->m.common.attention_distance;
+    s16 attention_angle = mpHIO->m.common.attention_angle;
     attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(attention_distance, attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 
-    scale.set(daNpc_Kolinb_Param_c::m.common.scale, daNpc_Kolinb_Param_c::m.common.scale, daNpc_Kolinb_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Kolinb_Param_c::m.common.weight);
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
 
-    mCylH = daNpc_Kolinb_Param_c::m.common.height;
-    mWallR = daNpc_Kolinb_Param_c::m.common.width;
-    mAttnFovY = daNpc_Kolinb_Param_c::m.common.fov;
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Kolinb_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Kolinb_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Kolinb_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Kolinb_Param_c::m.common.morf_frame;
-    gravity = daNpc_Kolinb_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Kolinb_c::checkChangeEvt() {
@@ -568,7 +595,7 @@ void daNpc_Kolinb_c::setAttnPos() {
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(getHeadJointNo()));
     mDoMtx_stack_c::multVec(&work, &eyePos);
     work.set(100.0f, 0.0f, 0.0f);
-    work.y = daNpc_Kolinb_Param_c::m.common.attention_offset;
+    work.y = mpHIO->m.common.attention_offset;
     mDoMtx_stack_c::YrotS(mCurAngle.y);
     mDoMtx_stack_c::multVec(&work, &work);
     attention_info.position = current.pos + work;
@@ -591,7 +618,7 @@ int daNpc_Kolinb_c::selectAction() {
     mNextAction = NULL;
 
 #if DEBUG
-    if (daNpc_Kolinb_Param_c::m.common.debug_mode_ON) {
+    if (mpHIO->m.common.debug_mode_ON) {
         mNextAction = &daNpc_Kolinb_c::test;
         return 1;
     }
@@ -906,8 +933,6 @@ static int daNpc_Kolinb_Draw(void* a_this) {
 static int daNpc_Kolinb_IsDelete(void* a_this) {
     return 1;
 }
-
-static daNpc_Kolinb_Param_c l_HIO;
 
 static actor_method_class daNpc_Kolinb_MethodTable = {
     (process_method_func)daNpc_Kolinb_Create,

--- a/src/d/actor/d_a_npc_kyury.cpp
+++ b/src/d/actor/d_a_npc_kyury.cpp
@@ -51,20 +51,6 @@ const daNpc_Kyury_HIOParam daNpc_Kyury_Param_c::m = {
     0.0f,    // box_offset
 };
 
-#if DEBUG
-daNpc_Kyury_HIO_c::daNpc_Kyury_HIO_c() {
-    m = daNpc_Kyury_Param_c::m;
-}
-
-void daNpc_Kyury_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
-    // TODO
-}
-
-void daNpc_Kyury_HIO_c::genMessage(JORMContext* ctext) {
-    // TODO
-}
-#endif
-
 static int l_bmdData[3][2] = {
     {41, 1},
     {42, 1},
@@ -150,10 +136,33 @@ daNpc_Kyury_c::cutFunc daNpc_Kyury_c::mCutList[2] = {
     &daNpc_Kyury_c::cutConversation,
 };
 
+NPC_KYURY_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Kyury_HIO_c::daNpc_Kyury_HIO_c() {
+    m = daNpc_Kyury_Param_c::m;
+}
+
+void daNpc_Kyury_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Kyury_HIO_c::genMessage(JORMContext* ctext) {
+    // NONMATCHING
+}
+#endif
+
 daNpc_Kyury_c::~daNpc_Kyury_c() {
     if (mpMorf[0] != 0) {
         mpMorf[0]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
 }
 
@@ -177,10 +186,16 @@ int daNpc_Kyury_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("キュリ－");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Kyury_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -867,8 +882,6 @@ static int daNpc_Kyury_Draw(void* i_this) {
 static int daNpc_Kyury_IsDelete(void* i_this) {
     return 1;
 }
-
-NPC_KYURY_HIO_CLASS l_HIO;
 
 static actor_method_class daNpc_Kyury_MethodTable = {
     (process_method_func)daNpc_Kyury_Create,  (process_method_func)daNpc_Kyury_Delete,

--- a/src/d/actor/d_a_npc_maro.cpp
+++ b/src/d/actor/d_a_npc_maro.cpp
@@ -155,19 +155,6 @@ daNpc_Maro_c::cutFunc daNpc_Maro_c::mCutList[17] = {
     &daNpc_Maro_c::cutTalkToKakashi,
 };
 
-daNpc_Maro_c::~daNpc_Maro_c() {
-    deleteObject();
-    if (field_0x10bc != 0xFFFFFFFF) {
-        dComIfG_TimerDeleteRequest(0);
-    }
-
-    if (mpMorf[0] != 0) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
-}
-
 const daNpc_Maro_HIOParam daNpc_Maro_Param_c::m = {
     100.0f,
     -3.0f,
@@ -210,8 +197,43 @@ const daNpc_Maro_HIOParam daNpc_Maro_Param_c::m = {
     30.0f,
     15.0f,
     30.0f,
-    0x00780000,
+    0x0078,
 };
+
+static NPC_MARO_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Maro_HIO_c::daNpc_Maro_HIO_c() {
+    m = daNpc_Maro_Param_c::m;
+}
+
+void daNpc_Maro_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Maro_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Maro_c::~daNpc_Maro_c() {
+    deleteObject();
+    if (field_0x10bc != 0xFFFFFFFF) {
+        dComIfG_TimerDeleteRequest(0);
+    }
+
+    if (mpMorf[0] != 0) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
+}
 
 int daNpc_Maro_c::create() {
     static int const heapSize[17] = {
@@ -246,11 +268,17 @@ int daNpc_Maro_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("マロ");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                         &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                         fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Maro_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -603,10 +631,10 @@ void daNpc_Maro_c::setParam() {
 
     srchActors();
     u32 uVar7 = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    s16 sVar10 = daNpc_Maro_Param_c::m.common.talk_distance;
-    s16 sVar9 = daNpc_Maro_Param_c::m.common.talk_angle;
-    s16 sVar8 = daNpc_Maro_Param_c::m.common.attention_distance;
-    s16 sVar7 = daNpc_Maro_Param_c::m.common.attention_angle;
+    s16 sVar10 = mpHIO->m.common.talk_distance;
+    s16 sVar9 = mpHIO->m.common.talk_angle;
+    s16 sVar8 = mpHIO->m.common.attention_distance;
+    s16 sVar7 = mpHIO->m.common.attention_angle;
     if (&daNpc_Maro_c::swdTutorial == field_0x110c) {
         sVar10 = 11;
         sVar9 = 6;
@@ -646,18 +674,18 @@ void daNpc_Maro_c::setParam() {
     attention_info.distances[3] = daNpcT_getDistTableIdx(sVar10, sVar9);
 
     attention_info.flags = uVar7;
-    scale.set(daNpc_Maro_Param_c::m.common.scale, daNpc_Maro_Param_c::m.common.scale,
-            daNpc_Maro_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Maro_Param_c::m.common.weight);
-    mCylH = daNpc_Maro_Param_c::m.common.height;
-    mWallR = daNpc_Maro_Param_c::m.common.width;
-    mAttnFovY = daNpc_Maro_Param_c::m.common.fov;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+            mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Maro_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Maro_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Maro_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Maro_Param_c::m.common.morf_frame;
-    gravity = daNpc_Maro_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Maro_c::checkChangeEvt() {
@@ -975,11 +1003,11 @@ void daNpc_Maro_c::setAttnPos() {
     f32 dVar8 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &eyeOffset, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_Maro_Param_c::m.common.body_angleX_min, daNpc_Maro_Param_c::m.common.body_angleX_max,
-        daNpc_Maro_Param_c::m.common.body_angleY_min, daNpc_Maro_Param_c::m.common.body_angleY_max,
-        daNpc_Maro_Param_c::m.common.head_angleX_min, daNpc_Maro_Param_c::m.common.head_angleX_max,
-        daNpc_Maro_Param_c::m.common.head_angleY_min, daNpc_Maro_Param_c::m.common.head_angleY_max,
-        daNpc_Maro_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+        getHeadJointNo(), mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, (float)dVar8);
     setMtx();
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(getHeadJointNo()));
@@ -987,7 +1015,7 @@ void daNpc_Maro_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 0, 1.0f, 0);
     eyeOffset.set(0.0f, 0.0f, 0.0f);
-    eyeOffset.y = daNpc_Maro_Param_c::m.common.attention_offset;
+    eyeOffset.y = mpHIO->m.common.attention_offset;
     mDoMtx_stack_c::YrotS(mCurAngle.y);
     mDoMtx_stack_c::multVec(&eyeOffset, &eyeOffset);
     attention_info.position = current.pos + eyeOffset;
@@ -2861,10 +2889,10 @@ int daNpc_Maro_c::wait(void* param_0) {
                     actor_p = (daNpc_Len_c*)mActorMngr[8].getActorP();
                     if (actor_p != NULL &&
                         ((daNpc_Len_c*) actor_p)->checkStartDemo13StbEvt(
-                            this, daNpc_Maro_Param_c::m.common.box_min_x, daNpc_Maro_Param_c::m.common.box_min_y,
-                            daNpc_Maro_Param_c::m.common.box_min_z, daNpc_Maro_Param_c::m.common.box_max_x,
-                            daNpc_Maro_Param_c::m.common.box_max_y, daNpc_Maro_Param_c::m.common.box_max_z,
-                            daNpc_Maro_Param_c::m.common.box_offset))
+                            this, mpHIO->m.common.box_min_x, mpHIO->m.common.box_min_y,
+                            mpHIO->m.common.box_min_z, mpHIO->m.common.box_max_x,
+                            mpHIO->m.common.box_max_y, mpHIO->m.common.box_max_z,
+                            mpHIO->m.common.box_offset))
                     {
                         mEvtNo = 7;
                         field_0x1133 = 1;
@@ -3380,8 +3408,6 @@ static int daNpc_Maro_Draw(void* i_this) {
 static int daNpc_Maro_IsDelete(void* i_this) {
     return 1;
 }
-
-static daNpc_Maro_Param_c l_HIO;
 
 static actor_method_class daNpc_Maro_MethodTable = {
     (process_method_func)daNpc_Maro_Create,

--- a/src/d/actor/d_a_npc_moi.cpp
+++ b/src/d/actor/d_a_npc_moi.cpp
@@ -244,10 +244,19 @@ enum Motion {
     /* 0x2F */ MOT_UNK_47 = 47,
 };
 
+NPC_MOI_HIO_CLASS l_HIO;
+
 daNpc_Moi_c::~daNpc_Moi_c() {
     if (mpMorf[0] != 0) {
         mpMorf[0]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
 }
 
@@ -277,6 +286,12 @@ int daNpc_Moi_c::create() {
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
         field_0x9c0.init(&mAcch, 0.0f, 0.0f);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("モイ");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
@@ -784,8 +799,6 @@ void daNpc_Moi_c::beforeMove() {
     }
 }
 
-NPC_MOI_HIO_CLASS l_HIO;
-
 void daNpc_Moi_c::setAttnPos() {
     cXyz acStack_3c(-30.0f, 10.0f, 0.0f);
 
@@ -1259,7 +1272,7 @@ int daNpc_Moi_c::injuryWalk() {
 }
 
 int daNpc_Moi_c::poise() {
-    int iVar13 = daNpc_Moi_Param_c::m.field_0x98;
+    int iVar13 = mpHIO->m.field_0x98;
 
     if (field_0x1669 != 0) {
         if (field_0x166c != 0) {

--- a/src/d/actor/d_a_npc_pachi_besu.cpp
+++ b/src/d/actor/d_a_npc_pachi_besu.cpp
@@ -468,14 +468,6 @@ daNpc_Pachi_Besu_c::cutFunc daNpc_Pachi_Besu_c::mCutList[11] = {
     &daNpc_Pachi_Besu_c::cutTutrialCaution,
 };
 
-daNpc_Pachi_Besu_c::~daNpc_Pachi_Besu_c() {
-    if (mpMorf[0] != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 daNpc_Pachi_Besu_HIOParam const daNpc_Pachi_Besu_Param_c::m = {
     160.0f,
     -3.0f,
@@ -520,6 +512,36 @@ daNpc_Pachi_Besu_HIOParam const daNpc_Pachi_Besu_Param_c::m = {
     70.0f,
 };
 
+static NPC_PACHI_BESU_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Pachi_Besu_HIO_c::daNpc_Pachi_Besu_HIO_c() {
+    m = daNpc_Pachi_Besu_Param_c::m;
+}
+
+void daNpc_Pachi_Besu_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Pachi_Besu_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Pachi_Besu_c::~daNpc_Pachi_Besu_c() {
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
+
 cPhs__Step daNpc_Pachi_Besu_c::create() {
     daNpcT_ct(this, daNpc_Pachi_Besu_c, l_faceMotionAnmData, l_motionAnmData,
                        l_faceMotionSequenceData, 4, l_motionSequenceData, 4,
@@ -548,9 +570,14 @@ cPhs__Step daNpc_Pachi_Besu_c::create() {
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("パチチュー：ベス");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Pachi_Besu_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -713,28 +740,26 @@ void daNpc_Pachi_Besu_c::setParam() {
     selectAction();
     srchActors();
 
-    s16 talk_distance = daNpc_Pachi_Besu_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_Pachi_Besu_Param_c::m.common.talk_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
 
-    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(daNpc_Pachi_Besu_Param_c::m.common.attention_distance, daNpc_Pachi_Besu_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 
-    scale.set(daNpc_Pachi_Besu_Param_c::m.common.scale, daNpc_Pachi_Besu_Param_c::m.common.scale, daNpc_Pachi_Besu_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Pachi_Besu_Param_c::m.common.weight);
-    mCylH = daNpc_Pachi_Besu_Param_c::m.common.height;
-    mWallR = daNpc_Pachi_Besu_Param_c::m.common.width;
-    mAttnFovY = daNpc_Pachi_Besu_Param_c::m.common.fov;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Pachi_Besu_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Pachi_Besu_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Pachi_Besu_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Pachi_Besu_Param_c::m.common.morf_frame;
-    gravity = daNpc_Pachi_Besu_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
-
-static daNpc_Pachi_Besu_Param_c l_HIO;
 
 void daNpc_Pachi_Besu_c::afterMoved() {
     fopAc_ac_c* actor_p1 = mActorMngrs[0].getActorP();
@@ -912,11 +937,11 @@ void daNpc_Pachi_Besu_c::setAttnPos() {
     J3DModel* model = mpMorf[0]->getModel();
 
     mJntAnm.setParam(this, model, &sp38, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-                     daNpc_Pachi_Besu_Param_c::m.common.body_angleX_min, daNpc_Pachi_Besu_Param_c::m.common.body_angleX_max,
-                     daNpc_Pachi_Besu_Param_c::m.common.body_angleY_min, daNpc_Pachi_Besu_Param_c::m.common.body_angleY_max,
-                     daNpc_Pachi_Besu_Param_c::m.common.head_angleX_min, daNpc_Pachi_Besu_Param_c::m.common.head_angleX_max,
-                     daNpc_Pachi_Besu_Param_c::m.common.head_angleY_min, daNpc_Pachi_Besu_Param_c::m.common.head_angleY_max,
-                     daNpc_Pachi_Besu_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+                     mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+                     mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+                     mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+                     mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+                     mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, fVar1);
     setMtx();
 
@@ -926,7 +951,7 @@ void daNpc_Pachi_Besu_c::setAttnPos() {
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, TRUE, 1.0f, 0);
 
     attention_info.position = current.pos;
-    attention_info.position.y += daNpc_Pachi_Besu_Param_c::m.common.attention_offset;
+    attention_info.position.y += mpHIO->m.common.attention_offset;
 }
 
 void daNpc_Pachi_Besu_c::setCollision() {
@@ -1097,8 +1122,8 @@ BOOL daNpc_Pachi_Besu_c::test(void* param_1) {
         mMode = 2;
         // fallthrough
     case 2:
-        mFaceMotionSeqMngr.setNo(mHIO->param.common.face_expression, -1.0f, 0, 0);
-        mMotionSeqMngr.setNo(mHIO->param.common.motion, -1.0f, 0, 0);
+        mFaceMotionSeqMngr.setNo(mpHIO->m.common.face_expression, -1.0f, 0, 0);
+        mMotionSeqMngr.setNo(mpHIO->m.common.motion, -1.0f, 0, 0);
         mJntAnm.lookNone(0);
         attention_info.flags = 0;
         break;

--- a/src/d/actor/d_a_npc_saru.cpp
+++ b/src/d/actor/d_a_npc_saru.cpp
@@ -227,14 +227,6 @@ daNpc_Saru_c::cutFunc daNpc_Saru_c::mCutList[4] = {
     &daNpc_Saru_c::cutYmLook,
 };
 
-daNpc_Saru_c::~daNpc_Saru_c() {
-    if (mpMorf[0] != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 daNpc_Saru_HIOParam const daNpc_Saru_Param_c::m = {
     140.0f,
     -3.0f,
@@ -278,8 +270,37 @@ daNpc_Saru_HIOParam const daNpc_Saru_Param_c::m = {
     20.0f,
     100.0f,
     180,
-    0,
 };
+
+static NPC_SARU_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Saru_HIO_c::daNpc_Saru_HIO_c() {
+    m = daNpc_Saru_Param_c::m;
+}
+
+void daNpc_Saru_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Saru_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Saru_c::~daNpc_Saru_c() {
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
 
 int daNpc_Saru_c::create() {
     static int const heapSize[4] = {
@@ -313,13 +334,14 @@ int daNpc_Saru_c::create() {
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
         #if DEBUG
-        field_0xe90->entryHIO("サル"); // Monkey
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("サル"); // Monkey
         #endif
         reset();
 
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, 
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Saru_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         field_0xe4c.Set(mCcDCyl);
         field_0xe4c.SetStts(&mCcStts);
         field_0xe4c.SetTgHitCallback(tgHitCallBack);
@@ -518,10 +540,10 @@ void daNpc_Saru_c::setParam() {
     srchActors();
     u32 uVar1 = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
 
-    s16 sVar1 = daNpc_Saru_Param_c::m.common.talk_distance;
-    s16 sVar2 = daNpc_Saru_Param_c::m.common.talk_angle;
-    s16 sVar3 = daNpc_Saru_Param_c::m.common.attention_distance;
-    s16 sVar4 = daNpc_Saru_Param_c::m.common.attention_angle;
+    s16 sVar1 = mpHIO->m.common.talk_distance;
+    s16 sVar2 = mpHIO->m.common.talk_angle;
+    s16 sVar3 = mpHIO->m.common.attention_distance;
+    s16 sVar4 = mpHIO->m.common.attention_angle;
 
     attention_info.distances[0] = daNpcT_getDistTableIdx(sVar3, sVar4);
     attention_info.distances[1] = attention_info.distances[0];
@@ -533,22 +555,22 @@ void daNpc_Saru_c::setParam() {
 
     attention_info.flags = uVar1;
 
-    scale.set(daNpc_Saru_Param_c::m.common.scale, daNpc_Saru_Param_c::m.common.scale, daNpc_Saru_Param_c::m.common.scale);
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
 
     if (mType != 0) {
         scale.setall(0.8f);
     }
 
-    mCcStts.SetWeight(daNpc_Saru_Param_c::m.common.weight);
-    mCylH = daNpc_Saru_Param_c::m.common.height;
-    mWallR = daNpc_Saru_Param_c::m.common.width;
-    mAttnFovY = daNpc_Saru_Param_c::m.common.fov;
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Saru_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Saru_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Saru_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Saru_Param_c::m.common.morf_frame;
-    gravity = daNpc_Saru_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 void daNpc_Saru_c::setAfterTalkMotion() {
@@ -645,11 +667,11 @@ void daNpc_Saru_c::setAttnPos() {
     mStagger.calc(FALSE);
     f32 fVar1 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp3c, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_Saru_Param_c::m.common.body_angleX_min, daNpc_Saru_Param_c::m.common.body_angleX_max,
-        daNpc_Saru_Param_c::m.common.body_angleY_min, daNpc_Saru_Param_c::m.common.body_angleY_max,
-        daNpc_Saru_Param_c::m.common.head_angleX_min, daNpc_Saru_Param_c::m.common.head_angleX_max,
-        daNpc_Saru_Param_c::m.common.head_angleY_min, daNpc_Saru_Param_c::m.common.head_angleY_max,
-        daNpc_Saru_Param_c::m.common.neck_rotation_ratio, fVar1, NULL);
+        getHeadJointNo(), mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, fVar1, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, fVar1);
 
     setMtx();
@@ -663,7 +685,7 @@ void daNpc_Saru_c::setAttnPos() {
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 0, 1.0f, 0);
 
     sp3c.set(0.0f, 0.0f, 60.0f);
-    sp3c.y = daNpc_Saru_Param_c::m.common.attention_offset;
+    sp3c.y = mpHIO->m.common.attention_offset;
     mDoMtx_stack_c::YrotS(mCurAngle.y);
     mDoMtx_stack_c::multVec(&sp3c, &sp3c);
     attention_info.position = sp3c + current.pos;
@@ -1199,8 +1221,6 @@ static int daNpc_Saru_Draw(void* param_1) {
 static int daNpc_Saru_IsDelete(void* param_1) {
     return 1;
 }
-
-static daNpc_Saru_Param_c l_HIO;
 
 static actor_method_class daNpc_Saru_MethodTable = {
     (process_method_func)daNpc_Saru_Create,

--- a/src/d/actor/d_a_npc_seib.cpp
+++ b/src/d/actor/d_a_npc_seib.cpp
@@ -51,15 +51,7 @@ daNpc_seiB_c::cutFunc daNpc_seiB_c::mCutList[1] = {
     0,
 };
 
-daNpc_seiB_c::~daNpc_seiB_c() {
-    if (heap != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
-daNpc_seiB_Param_c::Data const daNpc_seiB_Param_c::m = {
+daNpc_seiB_HIOParam const daNpc_seiB_Param_c::m = {
     0.0f,
     0.0f,
     1.0f,
@@ -78,16 +70,22 @@ daNpc_seiB_Param_c::Data const daNpc_seiB_Param_c::m = {
     0.0f,
     0.0f,
     0.0f,
+    0,
+    0,
+    0,
+    0,
     0.0f,
     0.0f,
     0.0f,
     0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
     0.0f,
     0.0f,
     0.0f,
@@ -98,6 +96,36 @@ daNpc_seiB_Param_c::Data const daNpc_seiB_Param_c::m = {
     0.0f,
     1200.0f,
 };
+
+static NPC_SEIB_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_seiB_HIO_c::daNpc_seiB_HIO_c() {
+    m = daNpc_seiB_Param_c::m;
+}
+
+void daNpc_seiB_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_seiB_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_seiB_c::~daNpc_seiB_c() {
+    if (heap != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
 
 int daNpc_seiB_c::create() {
     daNpcT_ct(this, daNpc_seiB_c, &l_faceMotionAnmData, l_motionAnmData,
@@ -124,6 +152,12 @@ int daNpc_seiB_c::create() {
 
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("光の精霊ｂ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -132,7 +166,7 @@ int daNpc_seiB_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(mpParam->m.mWeight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         reset();
         mCreating = true;
         Execute();
@@ -227,27 +261,27 @@ void daNpc_seiB_c::setParam() {
     selectAction();
     srchActors();
 
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = mpParam->m.mDist;
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = mpParam->m.mDist;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpParam->m.mDist;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpParam->m.mDist;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = mpHIO->m.mDist;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = mpHIO->m.mDist;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.mDist;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.mDist;
 
     attention_info.distances[0] = 39;
     attention_info.distances[1] = 39;
     attention_info.distances[3] = 39;
     attention_info.flags = 0;
 
-    scale.set(mpParam->m.mScale, mpParam->m.mScale, mpParam->m.mScale);
-    mCcStts.SetWeight(mpParam->m.mWeight);
-    mCylH = mpParam->m.mCylH;
-    mWallR = mpParam->m.mWallR;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(mpParam->m.mWallH);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
 
-    mRealShadowSize = mpParam->m.field_0xc;
-    gravity = mpParam->m.mGravity;
-    mExpressionMorfFrame = mpParam->m.field_0x6c;
-    mMorfFrames = mpParam->m.mMorfFrames;
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_seiB_c::srchActors() {
@@ -522,8 +556,6 @@ static int daNpc_seiB_Draw(void* param_1) {
 static int daNpc_seiB_IsDelete(void* param_1) {
     return 1;
 }
-
-static daNpc_seiB_Param_c l_HIO;
 
 static actor_method_class daNpc_seiB_MethodTable = {
     (process_method_func)daNpc_seiB_Create,  (process_method_func)daNpc_seiB_Delete,

--- a/src/d/actor/d_a_npc_seic.cpp
+++ b/src/d/actor/d_a_npc_seic.cpp
@@ -54,22 +54,6 @@ daNpc_seiC_c::cutFunc daNpc_seiC_c::mCutList[1] = {
     0
 };
 
-daNpc_seiC_c::~daNpc_seiC_c() {
-    OS_REPORT("|%06d:%x|daNpc_seiC_c -> デストラクト\n", g_Counter.mCounter0, this);
-    
-    if (heap != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    #if DEBUG
-    if (field_0xe40 != NULL) {
-        field_0xe40->removeHIO();
-    }
-    #endif
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 daNpc_seiC_HIOParam const daNpc_seiC_Param_c::m = {
     0.0f,
     0.0f,
@@ -89,15 +73,21 @@ daNpc_seiC_HIOParam const daNpc_seiC_Param_c::m = {
     0.0f,
     0.0f,
     0.0f,
+    0,
+    0,
+    0,
+    0,
     0.0f,
     0.0f,
     0.0f,
     0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
     0.0f,
     0.0f,
     0.0f,
@@ -110,7 +100,37 @@ daNpc_seiC_HIOParam const daNpc_seiC_Param_c::m = {
     1200.0f,
 };
 
-static daNpc_seiC_Param_c l_HIO;
+static NPC_SEIC_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_seiC_HIO_c::daNpc_seiC_HIO_c() {
+    m = daNpc_seiC_Param_c::m;
+}
+
+void daNpc_seiC_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_seiC_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_seiC_c::~daNpc_seiC_c() {
+    OS_REPORT("|%06d:%x|daNpc_seiC_c -> デストラクト\n", g_Counter.mCounter0, this);
+
+    if (heap != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+    #if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+    #endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
 
 int daNpc_seiC_c::create() {
     daNpcT_ct(this, daNpc_seiC_c, &l_faceMotionAnmData, &l_motionAnmData, l_faceMotionSequenceData, 
@@ -138,8 +158,8 @@ int daNpc_seiC_c::create() {
         mSound.init(&current.pos, &eyePos, 3, 1);
 
 #if DEBUG
-        //field_0xe40->field_0x8 = &l_HIO;
-        field_0xe40->entryHIO("光の精霊ｃ"); // Spirit of Light c
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("光の精霊ｃ"); // Spirit of Light c
 #endif
 
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, 
@@ -150,7 +170,7 @@ int daNpc_seiC_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(daNpc_seiC_Param_c::m.mSttsWeight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
 
         reset();
         mCreating = true;
@@ -238,7 +258,7 @@ void daNpc_seiC_c::reset() {
     if (mpMatAnm[0] != NULL) {
         mpMatAnm[0]->initialize();
     }
-    
+
     setAngle(home.angle.y);
     mMotionSeqMngr.setNo(0, -1.0f, 0, 0);
 }
@@ -247,27 +267,27 @@ void daNpc_seiC_c::setParam() {
     selectAction();
     srchActors();
 
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = daNpc_seiC_Param_c::m.field_0x90;
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = daNpc_seiC_Param_c::m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = mpHIO->m.field_0x90;
 
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = daNpc_seiC_Param_c::m.field_0x90;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = daNpc_seiC_Param_c::m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.field_0x90;
 
     attention_info.distances[0] = 39;
     attention_info.distances[1] = 39;
     attention_info.distances[3] = 39;
     attention_info.flags = 0;
 
-    scale.set(daNpc_seiC_Param_c::m.mScale, daNpc_seiC_Param_c::m.mScale, daNpc_seiC_Param_c::m.mScale);
-    mCcStts.SetWeight(daNpc_seiC_Param_c::m.mSttsWeight);
-    mCylH = daNpc_seiC_Param_c::m.mCylH;
-    mWallR = daNpc_seiC_Param_c::m.mWallR;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_seiC_Param_c::m.mWallH);
-    mRealShadowSize = daNpc_seiC_Param_c::m.field_0x0c;
-    gravity = daNpc_seiC_Param_c::m.mGravity;
-    mExpressionMorfFrame = daNpc_seiC_Param_c::m.field_0x6c;
-    mMorfFrames = daNpc_seiC_Param_c::m.mMorfFrames;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_seiC_c::srchActors() {

--- a/src/d/actor/d_a_npc_seid.cpp
+++ b/src/d/actor/d_a_npc_seid.cpp
@@ -54,22 +54,6 @@ daNpc_seiD_c::cutFunc daNpc_seiD_c::mCutList[1] = {
     0
 };
 
-daNpc_seiD_c::~daNpc_seiD_c() {
-    OS_REPORT("|%06d:%x|daNpc_seiD_c -> デストラクト\n", g_Counter.mCounter0, this);
-
-    if (heap != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    #if DEBUG
-    if (field_0xe40 != NULL) {
-        field_0xe40->removeHIO();
-    }
-    #endif
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 daNpc_seiD_HIOParam const daNpc_seiD_Param_c::m = {
     0.0f,
     0.0f,
@@ -89,15 +73,21 @@ daNpc_seiD_HIOParam const daNpc_seiD_Param_c::m = {
     0.0f,
     0.0f,
     0.0f,
+    0,
+    0,
+    0,
+    0,
     0.0f,
     0.0f,
     0.0f,
     0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
-    0.0f,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
     0.0f,
     0.0f,
     0.0f,
@@ -110,7 +100,37 @@ daNpc_seiD_HIOParam const daNpc_seiD_Param_c::m = {
     1200.0f,
 };
 
-static daNpc_seiD_Param_c l_HIO;
+static NPC_SEID_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_seiD_HIO_c::daNpc_seiD_HIO_c() {
+    m = daNpc_seiD_Param_c::m;
+}
+
+void daNpc_seiD_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_seiD_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_seiD_c::~daNpc_seiD_c() {
+    OS_REPORT("|%06d:%x|daNpc_seiD_c -> デストラクト\n", g_Counter.mCounter0, this);
+
+    if (heap != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
 
 int daNpc_seiD_c::create() {
     daNpcT_ct(this, daNpc_seiD_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 
@@ -138,8 +158,8 @@ int daNpc_seiD_c::create() {
         mSound.init(&current.pos, &eyePos, 3, 1);
 
 #if DEBUG
-        //field_0xe40->field_0x8 = &l_HIO;
-        field_0xe40->entryHIO("光の精霊ｄ"); // Spirit of Light d
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("光の精霊ｄ"); // Spirit of Light d
 #endif
 
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, 
@@ -150,7 +170,7 @@ int daNpc_seiD_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(daNpc_seiD_Param_c::m.mSttsWeight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
 
         reset();
         mCreating = true;
@@ -247,26 +267,26 @@ void daNpc_seiD_c::setParam() {
     selectAction();
     srchActors();
     
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = daNpc_seiD_Param_c::m.field_0x90;
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = daNpc_seiD_Param_c::m.field_0x90;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = daNpc_seiD_Param_c::m.field_0x90;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = daNpc_seiD_Param_c::m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.field_0x90;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.field_0x90;
 
     attention_info.distances[0] = 39;
     attention_info.distances[1] = 39;
     attention_info.distances[3] = 39;
     attention_info.flags = 0;
 
-    scale.set(daNpc_seiD_Param_c::m.mScale, daNpc_seiD_Param_c::m.mScale, daNpc_seiD_Param_c::m.mScale);
-    mCcStts.SetWeight(daNpc_seiD_Param_c::m.mSttsWeight);
-    mCylH = daNpc_seiD_Param_c::m.mCylH;
-    mWallR = daNpc_seiD_Param_c::m.mWallR;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_seiD_Param_c::m.mWallH);
-    mRealShadowSize = daNpc_seiD_Param_c::m.field_0x0c;
-    gravity = daNpc_seiD_Param_c::m.mGravity;
-    mExpressionMorfFrame = daNpc_seiD_Param_c::m.field_0x6c;
-    mMorfFrames = daNpc_seiD_Param_c::m.mMorfFrames;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_seiD_c::srchActors() {

--- a/src/d/actor/d_a_npc_seira.cpp
+++ b/src/d/actor/d_a_npc_seira.cpp
@@ -120,20 +120,7 @@ daNpc_Seira_c::cutFunc daNpc_Seira_c::mCutList[2] = {
     &daNpc_Seira_c::cutConversationAboutSaru,
 };
 
-static daNpc_Seira_Param_c l_HIO;
-
-daNpc_Seira_c::~daNpc_Seira_c() {
-    deleteObject();
-    if (mpMorf[0] != 0) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    if (mpSeiraMorf != NULL) {
-        mpSeiraMorf->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
-}
+static NPC_SEIRA_HIO_CLASS l_HIO;
 
 const daNpc_Seira_HIOParam daNpc_Seira_Param_c::m = {
     210.0f,
@@ -179,6 +166,39 @@ const daNpc_Seira_HIOParam daNpc_Seira_Param_c::m = {
     0.0f,
 };
 
+#if DEBUG
+daNpc_Seira_HIO_c::daNpc_Seira_HIO_c() {
+    m = daNpc_Seira_Param_c::m;
+}
+
+void daNpc_Seira_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Seira_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Seira_c::~daNpc_Seira_c() {
+    deleteObject();
+    if (mpMorf[0] != 0) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+    if (mpSeiraMorf != NULL) {
+        mpSeiraMorf->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
+}
+
 int daNpc_Seira_c::create() {
     daNpcT_ct(this, daNpc_Seira_c, l_faceMotionAnmData, l_motionAnmData,
                        l_faceMotionSequenceData, 4, l_motionSequenceData, 4,
@@ -206,6 +226,12 @@ int daNpc_Seira_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("セ－ラ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                         &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                         fopAcM_GetShapeAngle_p(this));
@@ -214,7 +240,7 @@ int daNpc_Seira_c::create() {
         mGroundH = mAcch.GetGroundH();
         setEnvTevColor();
         setRoomNo();
-        mCcStts.Init(daNpc_Seira_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -445,10 +471,10 @@ void daNpc_Seira_c::setParam() {
     srchActors();
 
     u32 att_flags = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    s16 talk_dist = daNpc_Seira_Param_c::m.common.talk_distance;
-    s16 talk_ang = daNpc_Seira_Param_c::m.common.talk_angle;
-    s16 att_dist = daNpc_Seira_Param_c::m.common.attention_distance;
-    s16 att_ang = daNpc_Seira_Param_c::m.common.attention_angle;
+    s16 talk_dist = mpHIO->m.common.talk_distance;
+    s16 talk_ang = mpHIO->m.common.talk_angle;
+    s16 att_dist = mpHIO->m.common.attention_distance;
+    s16 att_ang = mpHIO->m.common.attention_angle;
 
     if (checkStageIsSeirasShop()) {
         talk_dist = 4;
@@ -463,19 +489,19 @@ void daNpc_Seira_c::setParam() {
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_dist, talk_ang);
     attention_info.flags = att_flags;
 
-    scale.set(daNpc_Seira_Param_c::m.common.scale, daNpc_Seira_Param_c::m.common.scale,
-            daNpc_Seira_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Seira_Param_c::m.common.weight);
-    mCylH = daNpc_Seira_Param_c::m.common.height;
-    mWallR = daNpc_Seira_Param_c::m.common.width;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+            mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
 
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Seira_Param_c::m.common.knee_length);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
 
-    mRealShadowSize = daNpc_Seira_Param_c::m.common.real_shadow_size;
-    gravity = daNpc_Seira_Param_c::m.common.gravity;
-    mExpressionMorfFrame = daNpc_Seira_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Seira_Param_c::m.common.morf_frame;
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 BOOL daNpc_Seira_c::checkChangeEvt() {
@@ -630,11 +656,11 @@ void daNpc_Seira_c::setAttnPos() {
     mStagger.calc(0);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &eyeOffset, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-        daNpc_Seira_Param_c::m.common.body_angleX_min, daNpc_Seira_Param_c::m.common.body_angleX_max,
-        daNpc_Seira_Param_c::m.common.body_angleY_min, daNpc_Seira_Param_c::m.common.body_angleY_max,
-        daNpc_Seira_Param_c::m.common.head_angleX_min, daNpc_Seira_Param_c::m.common.head_angleX_max,
-        daNpc_Seira_Param_c::m.common.head_angleY_min, daNpc_Seira_Param_c::m.common.head_angleY_max,
-        daNpc_Seira_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+        mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
 
     f32 rad_val = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.calcJntRad(0.2f, 1.0f, rad_val);
@@ -662,7 +688,7 @@ void daNpc_Seira_c::setAttnPos() {
         mDoMtx_stack_c::multVec(&eyeOffset, &attention_info.position);
     } else {
         attention_info.position = current.pos;
-        attention_info.position.y += daNpc_Seira_Param_c::m.common.attention_offset;
+        attention_info.position.y += mpHIO->m.common.attention_offset;
     }
 }
 

--- a/src/d/actor/d_a_npc_seira2.cpp
+++ b/src/d/actor/d_a_npc_seira2.cpp
@@ -106,20 +106,7 @@ char* daNpc_Seira2_c::mCutNameList[1] = {""};
 
 daNpc_Seira2_c::cutFunc daNpc_Seira2_c::mCutList[1] = { NULL };
 
-static daNpc_Seira2_Param_c l_HIO;
-
-daNpc_Seira2_c::~daNpc_Seira2_c() {
-    deleteObject();
-    if (mpMorf[0] != 0) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    if (mpSeiraMorf != NULL) {
-        mpSeiraMorf->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
-}
+static NPC_SEIRA2_HIO_CLASS l_HIO;
 
 const daNpc_Seira2_HIOParam daNpc_Seira2_Param_c::m = {
     210.0f,
@@ -165,6 +152,39 @@ const daNpc_Seira2_HIOParam daNpc_Seira2_Param_c::m = {
     0.0f,
 };
 
+#if DEBUG
+daNpc_Seira2_HIO_c::daNpc_Seira2_HIO_c() {
+    m = daNpc_Seira2_Param_c::m;
+}
+
+void daNpc_Seira2_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Seira2_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Seira2_c::~daNpc_Seira2_c() {
+    deleteObject();
+    if (mpMorf[0] != 0) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+    if (mpSeiraMorf != NULL) {
+        mpSeiraMorf->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
+}
+
 int daNpc_Seira2_c::create() {
     daNpcT_ct(this, daNpc_Seira2_c, l_faceMotionAnmData, l_motionAnmData,
                        l_faceMotionSequenceData, 4, l_motionSequenceData, 4,
@@ -191,6 +211,12 @@ int daNpc_Seira2_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("セ－ラ２");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                         &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                         fopAcM_GetShapeAngle_p(this));
@@ -199,7 +225,7 @@ int daNpc_Seira2_c::create() {
         mGroundH = mAcch.GetGroundH();
         setEnvTevColor();
         setRoomNo();
-        mCcStts.Init(daNpc_Seira2_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -398,10 +424,10 @@ void daNpc_Seira2_c::setParam() {
     srchActors();
 
     u32 att_flags = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    s16 talk_dist = daNpc_Seira2_Param_c::m.common.talk_distance;
-    s16 talk_ang = daNpc_Seira2_Param_c::m.common.talk_angle;
-    s16 att_dist = daNpc_Seira2_Param_c::m.common.attention_distance;
-    s16 att_ang = daNpc_Seira2_Param_c::m.common.attention_angle;
+    s16 talk_dist = mpHIO->m.common.talk_distance;
+    s16 talk_ang = mpHIO->m.common.talk_angle;
+    s16 att_dist = mpHIO->m.common.attention_distance;
+    s16 att_ang = mpHIO->m.common.attention_angle;
 
     if (checkStageIsSeira2sShop()) {
         talk_dist = 4;
@@ -413,19 +439,19 @@ void daNpc_Seira2_c::setParam() {
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_dist, talk_ang);
     attention_info.flags = att_flags;
 
-    scale.set(daNpc_Seira2_Param_c::m.common.scale, daNpc_Seira2_Param_c::m.common.scale,
-            daNpc_Seira2_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_Seira2_Param_c::m.common.weight);
-    mCylH = daNpc_Seira2_Param_c::m.common.height;
-    mWallR = daNpc_Seira2_Param_c::m.common.width;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+            mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
 
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Seira2_Param_c::m.common.knee_length);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
 
-    mRealShadowSize = daNpc_Seira2_Param_c::m.common.real_shadow_size;
-    gravity = daNpc_Seira2_Param_c::m.common.gravity;
-    mExpressionMorfFrame = daNpc_Seira2_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Seira2_Param_c::m.common.morf_frame;
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_Seira2_c::setAfterTalkMotion() {
@@ -539,11 +565,11 @@ void daNpc_Seira2_c::setAttnPos() {
     mStagger.calc(0);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &eyeOffset, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-        daNpc_Seira2_Param_c::m.common.body_angleX_min, daNpc_Seira2_Param_c::m.common.body_angleX_max,
-        daNpc_Seira2_Param_c::m.common.body_angleY_min, daNpc_Seira2_Param_c::m.common.body_angleY_max,
-        daNpc_Seira2_Param_c::m.common.head_angleX_min, daNpc_Seira2_Param_c::m.common.head_angleX_max,
-        daNpc_Seira2_Param_c::m.common.head_angleY_min, daNpc_Seira2_Param_c::m.common.head_angleY_max,
-        daNpc_Seira2_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+        mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
 
     f32 rad_val = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.calcJntRad(0.2f, 1.0f, rad_val);
@@ -571,7 +597,7 @@ void daNpc_Seira2_c::setAttnPos() {
         mDoMtx_stack_c::multVec(&eyeOffset, &attention_info.position);
     } else {
         attention_info.position = current.pos;
-        attention_info.position.y += daNpc_Seira2_Param_c::m.common.attention_offset;
+        attention_info.position.y += mpHIO->m.common.attention_offset;
     }
 }
 

--- a/src/d/actor/d_a_npc_seirei.cpp
+++ b/src/d/actor/d_a_npc_seirei.cpp
@@ -150,14 +150,6 @@ daNpc_Seirei_c::cutFunc daNpc_Seirei_c::mCutList[2] = {
     &daNpc_Seirei_c::cutConversation,
 };
 
-daNpc_Seirei_c::~daNpc_Seirei_c() {
-    if (mpMorf[0] != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 daNpc_Seirei_HIOParam const daNpc_Seirei_Param_c::m = {
     600.0f,
     0.0f,
@@ -204,6 +196,36 @@ daNpc_Seirei_HIOParam const daNpc_Seirei_Param_c::m = {
     1200.0f,
 };
 
+static NPC_SEIREI_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_Seirei_HIO_c::daNpc_Seirei_HIO_c() {
+    m = daNpc_Seirei_Param_c::m;
+}
+
+void daNpc_Seirei_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Seirei_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_Seirei_c::~daNpc_Seirei_c() {
+    if (mpMorf[0] != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
+
 cPhs__Step daNpc_Seirei_c::create() {
     daNpcT_ct(this, daNpc_Seirei_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4,
                        l_motionSequenceData, 4, l_evtList, l_resNameList);
@@ -235,9 +257,14 @@ cPhs__Step daNpc_Seirei_c::create() {
             mSound.init(&current.pos, &eyePos, 3, 1);
         }
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("光の精霊ａ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Seirei_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mAcch.CrrPos(dComIfG_Bgsp());
         mGndChk = mAcch.m_gnd;
         mGroundH = mAcch.GetGroundH();
@@ -362,10 +389,10 @@ void daNpc_Seirei_c::setParam() {
     srchActors();
     dComIfGp_getAttention();
 
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = daNpc_Seirei_Param_c::m.talk_dist;
-    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = daNpc_Seirei_Param_c::m.talk_dist;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = daNpc_Seirei_Param_c::m.talk_dist;
-    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = daNpc_Seirei_Param_c::m.talk_dist;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMax = mpHIO->m.talk_dist;
+    dComIfGp_getAttention()->getDistTable(0x28).mDistMaxRelease = mpHIO->m.talk_dist;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.talk_dist;
+    dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.talk_dist;
 
     attention_info.distances[fopAc_attn_LOCK_e] = 39;
     attention_info.distances[fopAc_attn_TALK_e] = 39;
@@ -377,16 +404,16 @@ void daNpc_Seirei_c::setParam() {
         attention_info.flags = 0;
     }
 
-    mCcStts.SetWeight(daNpc_Seirei_Param_c::m.common.weight);
-    mCylH = daNpc_Seirei_Param_c::m.common.height;
-    mWallR = daNpc_Seirei_Param_c::m.common.width;
-    mAttnFovY = daNpc_Seirei_Param_c::m.common.fov;
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Seirei_Param_c::m.common.knee_length);
-    mRealShadowSize = daNpc_Seirei_Param_c::m.common.real_shadow_size;
-    mExpressionMorfFrame = daNpc_Seirei_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_Seirei_Param_c::m.common.morf_frame;
-    gravity = daNpc_Seirei_Param_c::m.common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Seirei_c::checkChangeEvt() {
@@ -464,13 +491,13 @@ void daNpc_Seirei_c::setAttnPos() {
         sp18.set(300.0f, 40.0f, 0.0f);
         mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(JNT_HEAD));
         mDoMtx_stack_c::multVec(&sp18, &eyePos);
-        sp18.set(0.0f, daNpc_Seirei_Param_c::m.common.attention_offset, 800.0f);
+        sp18.set(0.0f, mpHIO->m.common.attention_offset, 800.0f);
         mDoMtx_stack_c::YrotS(mCurAngle.y);
         mDoMtx_stack_c::multVec(&sp18, &attention_info.position);
         attention_info.position += current.pos;
     } else {
         attention_info.position = current.pos;
-        attention_info.position.y += daNpc_Seirei_Param_c::m.common.attention_offset - 350.0f;
+        attention_info.position.y += mpHIO->m.common.attention_offset - 350.0f;
         eyePos = attention_info.position;
     }
 
@@ -786,8 +813,6 @@ static int daNpc_Seirei_Draw(void* a_this) {
 static int daNpc_Seirei_IsDelete(void* a_this) {
     return 1;
 }
-
-static daNpc_Seirei_Param_c l_HIO;
 
 static actor_method_class daNpc_Seirei_MethodTable = {
     (process_method_func)daNpc_Seirei_Create,

--- a/src/d/actor/d_a_npc_shad.cpp
+++ b/src/d/actor/d_a_npc_shad.cpp
@@ -2234,7 +2234,7 @@ BOOL daNpcShad_c::EvCut_Disappear(int i_cutIndex) {
                 setExpression(EXPR_H_SURPRISE, -1.0f);
                 setMotion(MOT_RUN_A, -1.0f, FALSE);
                 mTurnMode = 0;
-                speedF = daNpcShad_Param_c::m.traveling_speed;
+                speedF = mpHIO->m.traveling_speed;
                 break;
 
             case '0006':

--- a/src/d/actor/d_a_npc_sola.cpp
+++ b/src/d/actor/d_a_npc_sola.cpp
@@ -65,20 +65,42 @@ daNpc_solA_c::cutFunc daNpc_solA_c::mCutList[1] = {
     NULL,
 };
 
-daNpc_solA_c::~daNpc_solA_c() {
-    if (heap != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[field_0xf80], (const char**)l_resNameList);
-}
-
 daNpc_solA_HIOParam const daNpc_solA_Param_c::m = {
     220.0f, -3.0f, 1.0f,   400.0f, 255.0f, 200.0f, 35.0f, 30.0f, 0.0f, 0.0f,  10.0f,
     -10.0f, 30.0f, -10.0f, 45.0f,  -45.0f, 0.6f,   12.0f, 3,     6,    5,     6,
     0.0f,   0.0f,  0.0f,   0.0f,   60,     8,      0,     0,     0,    false, false,
     4.0f,   0.0f,  0.0f,   0.0f,   0.0f,   0.0f,   0.0f,  0.0f,
 };
+
+static NPC_SOLA_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_solA_HIO_c::daNpc_solA_HIO_c() {
+    m = daNpc_solA_Param_c::m;
+}
+
+void daNpc_solA_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_solA_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_solA_c::~daNpc_solA_c() {
+    if (heap != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[field_0xf80], (const char**)l_resNameList);
+}
 
 int daNpc_solA_c::create() {
     daNpcT_ct(this, daNpc_solA_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4,
@@ -101,6 +123,12 @@ int daNpc_solA_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ハイリア兵");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -109,7 +137,7 @@ int daNpc_solA_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(daNpc_solA_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -170,7 +198,7 @@ void daNpc_solA_c::Draw() {
         J3DModelData* mdlData_p = mpMorf[0]->getModel()->getModelData();
         mdlData_p->getMaterialNodePointer(getEyeballMaterialNo())->setMaterialAnm(mpMatAnm[0]);
     }
-    draw(FALSE, FALSE, daNpc_solA_Param_c::m.common.real_shadow_size, NULL, 100.0f, FALSE, FALSE,
+    draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, 100.0f, FALSE, FALSE,
          FALSE);
     return;
 }
@@ -224,27 +252,27 @@ void daNpc_solA_c::setParam() {
     selectAction();
     srchActors();
 
-    s16 talk_distance = daNpc_solA_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_solA_Param_c::m.common.talk_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
 
     attention_info.distances[fopAc_attn_LOCK_e] =
-        daNpcT_getDistTableIdx(daNpc_solA_Param_c::m.common.attention_distance,
-                               daNpc_solA_Param_c::m.common.attention_angle);
+        daNpcT_getDistTableIdx(mpHIO->m.common.attention_distance,
+                               mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] =
         daNpcT_getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 
-    scale.set(daNpc_solA_Param_c::m.common.scale, daNpc_solA_Param_c::m.common.scale,
-              daNpc_solA_Param_c::m.common.scale);
-    mAcchCir.SetWallR(daNpc_solA_Param_c::m.common.width);
-    mAcchCir.SetWallH(daNpc_solA_Param_c::m.common.knee_length);
-    mCcStts.SetWeight(daNpc_solA_Param_c::m.common.weight);
-    mCylH = daNpc_solA_Param_c::m.common.height;
-    mWallR = daNpc_solA_Param_c::m.common.width;
-    gravity = daNpc_solA_Param_c::m.common.gravity;
-    mExpressionMorfFrame = daNpc_solA_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_solA_Param_c::m.common.morf_frame;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+              mpHIO->m.common.scale);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_solA_c::setAfterTalkMotion() {
@@ -309,12 +337,12 @@ void daNpc_solA_c::setAttnPos() {
     cXyz local_38(30.0f, 0.0f, 0.0f);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &local_38, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_solA_Param_c::m.common.body_angleX_min,
-        daNpc_solA_Param_c::m.common.body_angleX_max, daNpc_solA_Param_c::m.common.body_angleY_min,
-        daNpc_solA_Param_c::m.common.body_angleY_max, daNpc_solA_Param_c::m.common.head_angleX_min,
-        daNpc_solA_Param_c::m.common.head_angleX_max, daNpc_solA_Param_c::m.common.head_angleY_min,
-        daNpc_solA_Param_c::m.common.head_angleY_max,
-        daNpc_solA_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+        getHeadJointNo(), mpHIO->m.common.body_angleX_min,
+        mpHIO->m.common.body_angleX_max, mpHIO->m.common.body_angleY_min,
+        mpHIO->m.common.body_angleY_max, mpHIO->m.common.head_angleX_min,
+        mpHIO->m.common.head_angleX_max, mpHIO->m.common.head_angleY_min,
+        mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
 
     f32 fVar1 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.calcJntRad(0.2f, 1.0f, fVar1);
@@ -325,7 +353,7 @@ void daNpc_solA_c::setAttnPos() {
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, FALSE, 1.0f, 0);
 
     attention_info.position = current.pos;
-    attention_info.position.y += daNpc_solA_Param_c::m.common.attention_offset;
+    attention_info.position.y += mpHIO->m.common.attention_offset;
 }
 
 void daNpc_solA_c::setCollision() {
@@ -335,8 +363,8 @@ void daNpc_solA_c::setCollision() {
         mCyl.SetCoSPrm(prm);
 
         pos = current.pos;
-        f32 height = daNpc_solA_Param_c::m.common.height;
-        f32 width = daNpc_solA_Param_c::m.common.width;
+        f32 height = mpHIO->m.common.height;
+        f32 width = mpHIO->m.common.width;
         mCyl.SetH(height);
         mCyl.SetR(width);
         mCyl.SetC(pos);
@@ -459,8 +487,6 @@ static void daNpc_solA_Draw(void* param_0) {
 static bool daNpc_solA_IsDelete(void* param_0) {
     return true;
 }
-
-static daNpc_solA_Param_c l_HIO;
 
 static actor_method_class daNpc_solA_MethodTable = {
     (process_method_func)daNpc_solA_Create,  (process_method_func)daNpc_solA_Delete,

--- a/src/d/actor/d_a_npc_taro.cpp
+++ b/src/d/actor/d_a_npc_taro.cpp
@@ -237,7 +237,27 @@ daNpc_Taro_c::cutFunc daNpc_Taro_c::mCutList[17] = {
     &daNpc_Taro_c::cutTagPush4,
 };
 
-static daNpc_Taro_Param_c l_HIO;
+static NPC_TARO_HIO_CLASS l_HIO;
+
+daNpc_Taro_HIOParam const daNpc_Taro_Param_c::m = {
+    140.0f, -3.0f,  1.0f,   400.0f, 255.0f, 120.0f, 35.0f, 30.0f, 0.0f, 0.0f, 10.0f,
+    -10.0f, 30.0f,  -10.0f, 45.0f,  -45.0f, 0.6f,   12.0f, 3,     6,    5,    6,
+    110.0f, 0.0f,   0.0f,   0.0f,   60,     8,      0,     0,     0,    0,    0,
+    4.0f,   -15.0f, 0.0f,   -10.0f, 15.0f,  30.0f,  10.0f, 55.0f, 120,  90};
+
+#if DEBUG
+daNpc_Taro_HIO_c::daNpc_Taro_HIO_c() {
+    m = daNpc_Taro_Param_c::m;
+}
+
+void daNpc_Taro_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_Taro_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
 
 daNpc_Taro_c::~daNpc_Taro_c() {
     OS_REPORT("|%06d:%x|daNpc_Taro_c -> デストラクト\n", g_Counter.mCounter0, this);
@@ -245,20 +265,14 @@ daNpc_Taro_c::~daNpc_Taro_c() {
         mpMorf[0]->stopZelAnime();
     }
 
-    #if DEBUG
-    if (field_0xe40 != NULL) {
-        field_0xe40->removeHIO();
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
     }
-    #endif
+#endif
 
     deleteRes((l_loadResPtrnList)[mType], (const char**)l_resNameList);
 }
-
-daNpc_Taro_HIOParam const daNpc_Taro_Param_c::m = {
-    140.0f, -3.0f,  1.0f,   400.0f, 255.0f, 120.0f, 35.0f, 30.0f, 0.0f, 0.0f,
-    10.0f,  -10.0f, 30.0f,  -10.0f, 45.0f,  -45.0f, 0.6f, 12.0f, 3,    6,
-    5,      6,      110.0f, 0.0f,   0.0f,   0.0f,   60,    8,     0.0f, 0.0f,
-    4.0f,   -15.0f, 0.0f,   -10.0f, 15.0f,  30.0f,  10.0f, 55.0f, 120,  90};
 
 int daNpc_Taro_c::create() {
     daNpcT_ct(this, daNpc_Taro_c, l_faceMotionAnmData,
@@ -301,15 +315,14 @@ int daNpc_Taro_c::create() {
         field_0x9c0.init(&mAcch, 0.0f, 0.0f);
 
 #if DEBUG
-        // I'm unsure exactly how we're supposed to set + use the param ptr in the debug build...
-        // field_0xe40 = &l_HIO;
-        // field_0xe40->entryHIO("タロ");
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("タロ");
 #endif
 
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                             &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Taro_Param_c::m.mSttsWeight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl1.Set(mCcDCyl);
         mCyl1.SetStts(&mCcStts);
         mCyl1.SetTgHitCallback(tgHitCallBack);
@@ -626,10 +639,10 @@ void daNpc_Taro_c::setParam() {
     selectAction();
     srchActors();
     int attentionFlags = (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    s16 sVar7 = daNpc_Taro_Param_c::m.field_0x48;
-    s16 sVar5 = daNpc_Taro_Param_c::m.field_0x4a;
-    s16 sVar6 = daNpc_Taro_Param_c::m.field_0x4c;
-    s16 sVar4 = daNpc_Taro_Param_c::m.field_0x4e;
+    s16 sVar7 = mpHIO->m.common.talk_distance;
+    s16 sVar5 = mpHIO->m.common.talk_angle;
+    s16 sVar6 = mpHIO->m.common.attention_distance;
+    s16 sVar4 = mpHIO->m.common.attention_angle;
 
     if (mType == TYPE_13) {
         sVar5 = 6;
@@ -663,27 +676,27 @@ void daNpc_Taro_c::setParam() {
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar7, sVar5);
     attention_info.flags = attentionFlags;
-    scale.set(daNpc_Taro_Param_c::m.mScale, daNpc_Taro_Param_c::m.mScale,
-              daNpc_Taro_Param_c::m.mScale);
-    mCcStts.SetWeight(daNpc_Taro_Param_c::m.mSttsWeight);
-    mCylH = daNpc_Taro_Param_c::m.mCylH;
-    mWallR = daNpc_Taro_Param_c::m.mWallR;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
+              mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     if (mTwilight) {
         mCylH = 100.0f;
     }
-    mAttnFovY = daNpc_Taro_Param_c::m.mAttnFovY;
+    mAttnFovY = mpHIO->m.common.fov;
     if (mType == TYPE_13) {
         mAttnFovY = 180.0f;
     }
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_Taro_Param_c::m.mWallH);
-    mRealShadowSize = daNpc_Taro_Param_c::m.field_0x0c;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
     if (&daNpc_Taro_c::practice == mAction) {
         mRealShadowSize = 500.0f;
     }
-    mExpressionMorfFrame = daNpc_Taro_Param_c::m.field_0x6c;
-    mMorfFrames = daNpc_Taro_Param_c::m.mMorfFrames;
-    gravity = daNpc_Taro_Param_c::m.mGravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
 }
 
 BOOL daNpc_Taro_c::checkChangeEvt() {
@@ -967,11 +980,12 @@ void daNpc_Taro_c::setAttnPos() {
     f32 dVar8 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &eyeOffset, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daNpc_Taro_Param_c::m.mBodyUpAngle, daNpc_Taro_Param_c::m.mBodyDownAngle,
-        daNpc_Taro_Param_c::m.mBodyLeftAngle, daNpc_Taro_Param_c::m.mBodyRightAngle,
-        daNpc_Taro_Param_c::m.mHeadUpAngle, daNpc_Taro_Param_c::m.mHeadDownAngle,
-        daNpc_Taro_Param_c::m.mHeadLeftAngle, daNpc_Taro_Param_c::m.mHeadRightAngle,
-        daNpc_Taro_Param_c::m.field_0x40, 0.0f, NULL);
+        getHeadJointNo(),
+        mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, (float)dVar8);
     setMtx();
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(getHeadJointNo()));
@@ -979,7 +993,7 @@ void daNpc_Taro_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 1, 1.0f, 0);
     eyeOffset.set(0.0f, 0.0f, 0.0f);
-    eyeOffset.y = daNpc_Taro_Param_c::m.mAttentionPosYOffset;
+    eyeOffset.y = mpHIO->m.common.attention_offset;
     mDoMtx_stack_c::YrotS(mCurAngle.y);
     mDoMtx_stack_c::multVec(&eyeOffset, &eyeOffset);
     attention_info.position = current.pos + eyeOffset;
@@ -2761,7 +2775,7 @@ int daNpc_Taro_c::cutTagPush4(int param_1) {
 
 int daNpc_Taro_c::wait(void* param_0) {
     fopAc_ac_c* actor_p;
-    int iVar10 = daNpc_Taro_Param_c::m.field_0x8e;
+    int iVar10 = mpHIO->m.field_0x8e;
     s16 local_5e = home.angle.y;
 
     switch (mMode) {
@@ -2834,10 +2848,10 @@ int daNpc_Taro_c::wait(void* param_0) {
             daNpc_Len_c* pLen = (daNpc_Len_c*)mActors[22].getActorP();
             if (pLen != NULL &&
                 pLen->checkStartDemo13StbEvt(
-                    this, daNpc_Taro_Param_c::m.field_0x70, daNpc_Taro_Param_c::m.field_0x74,
-                    daNpc_Taro_Param_c::m.field_0x78, daNpc_Taro_Param_c::m.field_0x7c,
-                    daNpc_Taro_Param_c::m.field_0x80, daNpc_Taro_Param_c::m.field_0x84,
-                    daNpc_Taro_Param_c::m.field_0x88))
+                    this, mpHIO->m.common.box_min_x, mpHIO->m.common.box_min_y,
+                    mpHIO->m.common.box_min_z, mpHIO->m.common.box_max_x,
+                    mpHIO->m.common.box_max_y, mpHIO->m.common.box_max_z,
+                    mpHIO->m.common.box_offset))
             {
                 mEvtNo = 12;
                 field_0x11a1 = 1;
@@ -3118,7 +3132,7 @@ int daNpc_Taro_c::swdTutorial(void* param_0) {
 int daNpc_Taro_c::talk_withMaro(void* param_0) {
     daNpc_Maro_c* pMaro = (daNpc_Maro_c*)mActors[0].getActorP();
     fopAc_ac_c* player = daPy_getPlayerActorClass();
-    int choccaiTimer = daNpc_Taro_Param_c::m.mChoccaiTimer;
+    int choccaiTimer = mpHIO->m.mChoccaiTimer;
 
     switch (mMode) {
     case MODE_ENTER:
@@ -3177,7 +3191,7 @@ int daNpc_Taro_c::talk_withMaro(void* param_0) {
 }
 
 int daNpc_Taro_c::practice(void* param_0) {
-    int iVar4 = daNpc_Taro_Param_c::m.field_0x8e;
+    int iVar4 = mpHIO->m.field_0x8e;
     int iVar3 = 0;
 
     switch (mMode) {

--- a/src/d/actor/d_a_npc_uri.cpp
+++ b/src/d/actor/d_a_npc_uri.cpp
@@ -209,10 +209,19 @@ daNpc_Uri_c::cutFunc daNpc_Uri_c::mCutList[7] = {
     &daNpc_Uri_c::cutMeetingAgain,
 };
 
+NPC_URI_HIO_CLASS l_HIO;
+
 daNpc_Uri_c::~daNpc_Uri_c() {
     if (mpMorf[0] != 0) {
         mpMorf[0]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
 }
 
@@ -242,10 +251,16 @@ int daNpc_Uri_c::create() {
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
         field_0x9c0.init(&mAcch, 0.0f, 0.0f);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ウ－リ");
+#endif
+
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daNpc_Uri_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -705,8 +720,6 @@ void daNpc_Uri_c::beforeMove() {
         attention_info.flags = 0;
     }
 }
-
-NPC_URI_HIO_CLASS l_HIO;
 
 void daNpc_Uri_c::setAttnPos() {
     cXyz acStack_3c(-30.0f, 10.0f, 0.0f);

--- a/src/d/actor/d_a_npc_ykw.cpp
+++ b/src/d/actor/d_a_npc_ykw.cpp
@@ -176,11 +176,7 @@ daNpc_ykW_c::cutFunc daNpc_ykW_c::mCutList[8] = {
     &daNpc_ykW_c::cutHug,
 };
 
-#if DEBUG
-static daNpc_ykW_HIO_c l_HIO;
-#else
-static daNpc_ykW_Param_c l_HIO;
-#endif
+static NPC_YKW_HIO_CLASS l_HIO;
 
 #if DEBUG
 void daNpc_ykW_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {

--- a/src/d/actor/d_a_npc_zelR.cpp
+++ b/src/d/actor/d_a_npc_zelR.cpp
@@ -62,15 +62,7 @@ daNpc_ZelR_c::EventFn daNpc_ZelR_c::mCutList[1] = {
     NULL
 };
 
-daNpc_ZelR_c::~daNpc_ZelR_c() {
-    OS_REPORT("|%06d:%x|daNpc_ZelR_c -> デストラクト\n", g_Counter.mCounter0, this);
-    if (heap) {
-        mpMorf[0]->stopZelAnime();
-    }
-    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
-}
-
-static daNpc_ZelR_Param_c l_HIO;
+static NPC_ZELR_HIO_CLASS l_HIO;
 
 daNpc_ZelR_HIOParam const daNpc_ZelR_Param_c::m = {
     190.0f,
@@ -116,6 +108,35 @@ daNpc_ZelR_HIOParam const daNpc_ZelR_Param_c::m = {
     0.0f,
 };
 
+#if DEBUG
+daNpc_ZelR_HIO_c::daNpc_ZelR_HIO_c() {
+    m = daNpc_ZelR_Param_c::m;
+}
+
+void daNpc_ZelR_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_ZelR_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_ZelR_c::~daNpc_ZelR_c() {
+    OS_REPORT("|%06d:%x|daNpc_ZelR_c -> デストラクト\n", g_Counter.mCounter0, this);
+    if (heap) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (char const**)l_resNameList);
+}
+
 int daNpc_ZelR_c::create() {
     daNpcT_ct(this, daNpc_ZelR_c, l_faceMotionAnmData,
         &l_motionAnmData, l_faceMotionSequenceData, 4,
@@ -145,6 +166,11 @@ int daNpc_ZelR_c::create() {
 
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("フ－ド付きロ－ブゼルダ");
+#endif
+
         mAcch.Set(&current.pos, &old.pos, this, 1, &mAcchCir, &speed, &current.angle, &shape_angle);
         mAcch.CrrPos(dComIfG_Bgsp());
         mGndChk = mAcch.m_gnd;
@@ -153,7 +179,7 @@ int daNpc_ZelR_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(daNpc_ZelR_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -440,10 +466,11 @@ void daNpc_ZelR_c::setAttnPos() {
     mStagger.calc(FALSE);
 
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp38, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-        l_HIO.m.common.body_angleX_min, l_HIO.m.common.body_angleX_max, l_HIO.m.common.body_angleY_min, 
-        l_HIO.m.common.body_angleY_max, l_HIO.m.common.head_angleX_min, l_HIO.m.common.head_angleX_max, 
-        l_HIO.m.common.head_angleY_min, l_HIO.m.common.head_angleY_max, l_HIO.m.common.neck_rotation_ratio,
-        0.0f, NULL);
+        mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
 
     mJntAnm.calcJntRad(0.2f, 1.0f, cM_s2rad(mCurAngle.y - field_0xd7e.y));
 
@@ -455,7 +482,7 @@ void daNpc_ZelR_c::setAttnPos() {
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 0, 1.0f, 0);
 
     attention_info.position = current.pos;
-    attention_info.position.y += l_HIO.m.common.attention_offset;
+    attention_info.position.y += mpHIO->m.common.attention_offset;
 }
 
 void daNpc_ZelR_c::setCollision() {

--- a/src/d/actor/d_a_npc_zelRo.cpp
+++ b/src/d/actor/d_a_npc_zelRo.cpp
@@ -88,14 +88,6 @@ daNpc_ZelRo_c::cutFunc daNpc_ZelRo_c::mCutList[1] = {
     NULL
 };
 
-daNpc_ZelRo_c::~daNpc_ZelRo_c() {
-    if (heap != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-
-    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
-}
-
 const daNpc_ZelRo_HIOParam daNpc_ZelRo_Param_c::m = {
     190.0f,
     -3.0f,
@@ -140,6 +132,36 @@ const daNpc_ZelRo_HIOParam daNpc_ZelRo_Param_c::m = {
     0.0f,
 };
 
+static NPC_ZELRO_HIO_CLASS l_HIO;
+
+#if DEBUG
+daNpc_ZelRo_HIO_c::daNpc_ZelRo_HIO_c() {
+    m = daNpc_ZelRo_Param_c::m;
+}
+
+void daNpc_ZelRo_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daNpc_ZelRo_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daNpc_ZelRo_c::~daNpc_ZelRo_c() {
+    if (heap != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**)l_resNameList);
+}
+
 cPhs__Step daNpc_ZelRo_c::create() {
     daNpcT_ct(this, daNpc_ZelRo_c, l_faceMotionAnmData, l_motionAnmData, l_faceMotionSequenceData, 4, l_motionSequenceData, 4, l_evtList, l_resNameList);
 
@@ -170,6 +192,11 @@ cPhs__Step daNpc_ZelRo_c::create() {
 
         mSound.init(&current.pos, &eyePos, 3, 1);
 
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("フ－ドなしロ－ブゼルダ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this),
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
 
@@ -180,7 +207,7 @@ cPhs__Step daNpc_ZelRo_c::create() {
         setEnvTevColor();
         setRoomNo();
 
-        mCcStts.Init(daNpc_ZelRo_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
         mCyl.SetTgHitCallback(tgHitCallBack);
@@ -374,25 +401,25 @@ void daNpc_ZelRo_c::setParam() {
     selectAction();
     srchActors();
 
-    s16 talk_distance = daNpc_ZelRo_Param_c::m.common.talk_distance;
-    s16 talk_angle = daNpc_ZelRo_Param_c::m.common.talk_angle;
+    s16 talk_distance = mpHIO->m.common.talk_distance;
+    s16 talk_angle = mpHIO->m.common.talk_angle;
 
-    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(daNpc_ZelRo_Param_c::m.common.attention_distance, daNpc_ZelRo_Param_c::m.common.attention_angle);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_distance, talk_angle);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 
-    scale.set(daNpc_ZelRo_Param_c::m.common.scale, daNpc_ZelRo_Param_c::m.common.scale, daNpc_ZelRo_Param_c::m.common.scale);
-    mCcStts.SetWeight(daNpc_ZelRo_Param_c::m.common.weight);
-    mCylH = daNpc_ZelRo_Param_c::m.common.height;
-    mWallR = daNpc_ZelRo_Param_c::m.common.width;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daNpc_ZelRo_Param_c::m.common.knee_length);
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
 
-    mRealShadowSize = daNpc_ZelRo_Param_c::m.common.real_shadow_size;
-    gravity = daNpc_ZelRo_Param_c::m.common.gravity;
-    mExpressionMorfFrame = daNpc_ZelRo_Param_c::m.common.expression_morf_frame;
-    mMorfFrames = daNpc_ZelRo_Param_c::m.common.morf_frame;
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    gravity = mpHIO->m.common.gravity;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
 }
 
 void daNpc_ZelRo_c::setAfterTalkMotion() {
@@ -479,11 +506,11 @@ void daNpc_ZelRo_c::setAttnPos() {
     
     mStagger.calc(FALSE);
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &sp48, getBackboneJointNo(), getNeckJointNo(), getHeadJointNo(),
-                     daNpc_ZelRo_Param_c::m.common.body_angleX_min, daNpc_ZelRo_Param_c::m.common.body_angleX_max,
-                     daNpc_ZelRo_Param_c::m.common.body_angleY_min, daNpc_ZelRo_Param_c::m.common.body_angleY_max,
-                     daNpc_ZelRo_Param_c::m.common.head_angleX_min, daNpc_ZelRo_Param_c::m.common.head_angleX_max,
-                     daNpc_ZelRo_Param_c::m.common.head_angleY_min, daNpc_ZelRo_Param_c::m.common.head_angleY_max,
-                     daNpc_ZelRo_Param_c::m.common.neck_rotation_ratio, 0.0f, NULL);
+                     mpHIO->m.common.body_angleX_min, mpHIO->m.common.body_angleX_max,
+                     mpHIO->m.common.body_angleY_min, mpHIO->m.common.body_angleY_max,
+                     mpHIO->m.common.head_angleX_min, mpHIO->m.common.head_angleX_max,
+                     mpHIO->m.common.head_angleY_min, mpHIO->m.common.head_angleY_max,
+                     mpHIO->m.common.neck_rotation_ratio, 0.0f, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, cM_s2rad((s16)(mCurAngle.y - field_0xd7e.y)));
 
     setMtx();
@@ -492,7 +519,7 @@ void daNpc_ZelRo_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, FALSE, 1.0f, 0);
     attention_info.position = current.pos;
-    attention_info.position.y += daNpc_ZelRo_Param_c::m.common.attention_offset;
+    attention_info.position.y += mpHIO->m.common.attention_offset;
 }
 
 void daNpc_ZelRo_c::setCollision() {
@@ -650,8 +677,6 @@ static int daNpc_ZelRo_Draw(void* a_this) {
 static int daNpc_ZelRo_IsDelete(void* a_this) {
     return 1;
 }
-
-static daNpc_ZelRo_Param_c l_HIO;
 
 static actor_method_class daNpc_ZelRo_MethodTable = {
     (process_method_func)daNpc_ZelRo_Create,

--- a/src/d/actor/d_a_npc_zelda.cpp
+++ b/src/d/actor/d_a_npc_zelda.cpp
@@ -11,12 +11,6 @@
 #include "d/actor/d_a_hozelda.h"
 #include "d/d_debug_viewer.h"
 
-#if DEBUG
-#define HIO_PARAM(i_this) (i_this->mHIO->param)
-#else
-#define HIO_PARAM(_) (daNpc_Zelda_Param_c::m)
-#endif
-
 static u32 l_bmdData[2] = { 11, 1 };
 
 static daNpcT_evtData_c l_evtList[2] = {
@@ -61,19 +55,15 @@ static daNpcT_MotionSeqMngr_c::sequenceStepData_c l_motionSequenceData[8] = {
 const char* daNpc_Zelda_c::mCutNameList = "";
 daNpc_Zelda_c::cutFunc daNpc_Zelda_c::mCutList[1] = { 0 };
 
-#if DEBUG
-static daNpc_Zelda_HIO_c l_HIO;
-#else
-static daNpc_Zelda_Param_c l_HIO;
-#endif
+static NPC_ZELDA_HIO_CLASS l_HIO;
 
 #if DEBUG
 daNpc_Zelda_HIO_c::daNpc_Zelda_HIO_c() {
-    param = daNpc_Zelda_Param_c::m;
+    m = daNpc_Zelda_Param_c::m;
 }
 
 void daNpc_Zelda_HIO_c::genMessage(JORMContext* ctx) {
-    daNpcT_cmnGenMessage(ctx, &param.common);
+    daNpcT_cmnGenMessage(ctx, &m.common);
     ctx->genButton
               ("ファイル書き出し",0x40000002,0,NULL,0xffff,0xffff,0x200,0x18);
 }
@@ -89,7 +79,7 @@ void daNpc_Zelda_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
         if (aJStack_910.open(6, "", NULL, NULL, NULL) != 0) {
             memset(auStack_7e0, 0, 2000);
             int retval = 0;
-            daNpcT_cmnListenPropertyEvent(auStack_7e0, &retval, &param.common);
+            daNpcT_cmnListenPropertyEvent(auStack_7e0, &retval, &m.common);
             aJStack_910.writeData(auStack_7e0, retval);
             aJStack_910.close();
             OS_REPORT("write append success!::%6d\n", retval);
@@ -109,8 +99,8 @@ daNpc_Zelda_c::~daNpc_Zelda_c() {
     }
 
 #if DEBUG
-    if (mHIO != NULL) {
-        mHIO->removeHIO();
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
     }
 #endif
 
@@ -201,9 +191,9 @@ int daNpc_Zelda_c::create() {
         mSound.init(&current.pos, &eyePos, 3, 1);
 
 #if DEBUG
-        mHIO = &l_HIO;
+        mpHIO = &l_HIO;
         // Zelda
-        mHIO->entryHIO("ゼルダ");
+        mpHIO->entryHIO("ゼルダ");
 #endif
 
         reset();
@@ -212,7 +202,7 @@ int daNpc_Zelda_c::create() {
             &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
             fopAcM_GetShapeAngle_p(this));
 
-        mCcStts.Init(HIO_PARAM(this).common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
 
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mCcStts);
@@ -434,26 +424,26 @@ void daNpc_Zelda_c::setParam() {
     srchActors();
 
     s32 attnFlag = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
-    s16 talkDist = HIO_PARAM(this).common.talk_distance;
-    s16 talkAngle = HIO_PARAM(this).common.talk_angle;
-    s16 attnDist = HIO_PARAM(this).common.attention_distance;
-    s16 attnAngle = HIO_PARAM(this).common.attention_angle;
+    s16 talkDist = mpHIO->m.common.talk_distance;
+    s16 talkAngle = mpHIO->m.common.talk_angle;
+    s16 attnDist = mpHIO->m.common.attention_distance;
+    s16 attnAngle = mpHIO->m.common.attention_angle;
     attention_info.distances[fopAc_attn_LOCK_e] =
         daNpcT_getDistTableIdx(attnDist, attnAngle);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talkDist, talkAngle);
     attention_info.flags = attnFlag;
-    scale.set(HIO_PARAM(this).common.scale, HIO_PARAM(this).common.scale, HIO_PARAM(this).common.scale);
-    mCcStts.SetWeight(HIO_PARAM(this).common.weight);
-    mCylH = HIO_PARAM(this).common.height;
-    mWallR = HIO_PARAM(this).common.width;
-    mAttnFovY = HIO_PARAM(this).common.fov;
+    scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);
+    mCcStts.SetWeight(mpHIO->m.common.weight);
+    mCylH = mpHIO->m.common.height;
+    mWallR = mpHIO->m.common.width;
+    mAttnFovY = mpHIO->m.common.fov;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(HIO_PARAM(this).common.knee_length);
-    mRealShadowSize = HIO_PARAM(this).common.real_shadow_size;
-    mExpressionMorfFrame = HIO_PARAM(this).common.expression_morf_frame;
-    mMorfFrames = HIO_PARAM(this).common.morf_frame;
-    gravity = HIO_PARAM(this).common.gravity;
+    mAcchCir.SetWallH(mpHIO->m.common.knee_length);
+    mRealShadowSize = mpHIO->m.common.real_shadow_size;
+    mExpressionMorfFrame = mpHIO->m.common.expression_morf_frame;
+    mMorfFrames = mpHIO->m.common.morf_frame;
+    gravity = mpHIO->m.common.gravity;
     if (field_0xf80 == 0) {
         mAcch.SetGrndNone();
         mAcch.SetWallNone();
@@ -540,15 +530,15 @@ void daNpc_Zelda_c::setAttnPos() {
         getBackboneJointNo(),
         getNeckJointNo(),
         getHeadJointNo(),
-        HIO_PARAM(this).common.body_angleX_min,
-        HIO_PARAM(this).common.body_angleX_max,
-        HIO_PARAM(this).common.body_angleY_min,
-        HIO_PARAM(this).common.body_angleY_max,
-        HIO_PARAM(this).common.head_angleX_min,
-        HIO_PARAM(this).common.head_angleX_max,
-        HIO_PARAM(this).common.head_angleY_min,
-        HIO_PARAM(this).common.head_angleY_max,
-        HIO_PARAM(this).common.neck_rotation_ratio,
+        mpHIO->m.common.body_angleX_min,
+        mpHIO->m.common.body_angleX_max,
+        mpHIO->m.common.body_angleY_min,
+        mpHIO->m.common.body_angleY_max,
+        mpHIO->m.common.head_angleX_min,
+        mpHIO->m.common.head_angleX_max,
+        mpHIO->m.common.head_angleY_min,
+        mpHIO->m.common.head_angleY_max,
+        mpHIO->m.common.neck_rotation_ratio,
         0.0f,
         NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, dVar6);
@@ -560,7 +550,7 @@ void daNpc_Zelda_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 0, 1.0f, 0);
     acStack_3c.set(0.0f, 0.0f, 0.0f);
-    acStack_3c.y = HIO_PARAM(this).common.attention_offset;
+    acStack_3c.y = mpHIO->m.common.attention_offset;
     if (field_0xf80 == 0) {
         acStack_3c.set(0.0f, 170.0f, 10.0f);
     }
@@ -621,7 +611,7 @@ void daNpc_Zelda_c::setCollision() {
 int daNpc_Zelda_c::drawDbgInfo() {
 #if DEBUG
     const daNpc_Zelda_HIOParam* m = &daNpc_Zelda_Param_c::m;
-    if (HIO_PARAM(this).common.debug_info_ON != 0) {
+    if (mpHIO->m.common.debug_info_ON != 0) {
         f32 distMax1 = dComIfGp_getAttention()->getDistTable(
             attention_info.distances[fopAc_attn_JUEL_e]).mDistMax;
         f32 distMax2 = dComIfGp_getAttention()->getDistTable(

--- a/src/d/actor/d_a_npc_zra.inc
+++ b/src/d/actor/d_a_npc_zra.inc
@@ -105,10 +105,10 @@ void daNpc_zrA_c::walkCalc() {
         mPath.getDstPosDstXZ(current.pos, next_pnt);
     }
     s16 target_angle = cLib_targetAngleY(&current.pos, &next_pnt);
-    speedF = HIO_PARAM(this).mWalkSpeed;
-    mAnm_p->setPlaySpeed(HIO_PARAM(this).mWalkSpeed / HIO_PARAM(this).mWalkAnmRate);
+    speedF = mpHIO->m.mWalkSpeed;
+    mAnm_p->setPlaySpeed(mpHIO->m.mWalkSpeed / mpHIO->m.mWalkAnmRate);
     cLib_addCalcAngleS2(&current.angle.y, target_angle,
-                        HIO_PARAM(this).mWalkAngleScale, HIO_PARAM(this).mWalkAngleSpeed);
+                        mpHIO->m.mWalkAngleScale, mpHIO->m.mWalkAngleSpeed);
     mCurAngle = current.angle;
     shape_angle = mCurAngle;
     mOldAngle.y = mCurAngle.y;
@@ -395,7 +395,7 @@ BOOL daNpc_zrA_c::swim(void* param_0) {
                 mSpinTimer = (int)(cM_rnd() * 60.0f) + 90;
                 mSwimMode = SWIM_RAIL;
                 field_0x1521 = true;
-                mScaleFactor = HIO_PARAM(this).mMaxScaleFactor;
+                mScaleFactor = mpHIO->m.mMaxScaleFactor;
                 mCcStts.SetWeight(0);
             }
         } else {
@@ -435,7 +435,7 @@ BOOL daNpc_zrA_c::swim(void* param_0) {
 }
 
 BOOL daNpc_zrA_c::railSwim() {
-    s16 ang_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 ang_step = mpHIO->m.mSwimAngleSpeed;
     s16 ang_scale = 8;
     f32 fvar15 = 0.1f;
     f32 fvar2 = 1.0f;
@@ -477,7 +477,7 @@ BOOL daNpc_zrA_c::railSwim() {
                 mCreatureSound.startCreatureSound(Z2SE_ZRA_DIVE_SPLASH, 0, -1);
             }
 
-            if (current.pos.y <= water_height - HIO_PARAM(this).mMinDepth) {
+            if (current.pos.y <= water_height - mpHIO->m.mMinDepth) {
                 field_0x153e = false;
                 field_0x153c = false;
                 mSwimSpeedScale = 1.0f;
@@ -597,11 +597,11 @@ BOOL daNpc_zrA_c::railSwim() {
         calcSwimAngle(angle, mSwimAngleCalc, ang_scale, ang_step);
     }
 
-    if (mSwimSpeedF > fvar3 * HIO_PARAM(this).mSwimSpeed) {
+    if (mSwimSpeedF > fvar3 * mpHIO->m.mSwimSpeed) {
         fvar15 *= 2.0f;
         fvar2 *= 0.5f;
     }
-    cLib_addCalc2(&mSwimSpeedF, fvar3 * HIO_PARAM(this).mSwimSpeed, fvar15, fvar2);
+    cLib_addCalc2(&mSwimSpeedF, fvar3 * mpHIO->m.mSwimSpeed, fvar15, fvar2);
 
     if (field_0x153c == true && mIsAboveWater == true) {
         if (mAnm_p->getFrame() > 13.0f && mAnm_p->getFrame() < 21.0f) {
@@ -611,7 +611,7 @@ BOOL daNpc_zrA_c::railSwim() {
         }
     } else if (!bvar6) {
         f32 play_speed = mAnm_p->getPlaySpeed();
-        cLib_addCalc2(&play_speed, mSwimSpeedF / HIO_PARAM(this).mSwimAnmRate, 0.2f, 0.1f);
+        cLib_addCalc2(&play_speed, mSwimSpeedF / mpHIO->m.mSwimAnmRate, 0.2f, 0.1f);
         mAnm_p->setPlaySpeed(play_speed);
     }
 
@@ -619,9 +619,9 @@ BOOL daNpc_zrA_c::railSwim() {
     calcSwimPos(swim_speed);
 
     if (!field_0x153c && mAcch.ChkWaterHit()
-        && current.pos.y > water_height - HIO_PARAM(this).mMinDepth)
+        && current.pos.y > water_height - mpHIO->m.mMinDepth)
     {
-        current.pos.y = water_height - HIO_PARAM(this).mMinDepth;
+        current.pos.y = water_height - mpHIO->m.mMinDepth;
     }
 
     if (cLib_calcTimer(&mSpinTimer) == 0) {
@@ -653,8 +653,8 @@ BOOL daNpc_zrA_c::railSwim() {
         } else {
             mSpinTimer = (int)(cM_rnd() * 60.0f) + 90;
             mSpinAngle = 0;
-            mSwimSpeedScale = cM_rnd() * (1.0f - HIO_PARAM(this).mMinSwimSpeedScale)
-                + HIO_PARAM(this).mMinSwimSpeedScale;
+            mSwimSpeedScale = cM_rnd() * (1.0f - mpHIO->m.mMinSwimSpeedScale)
+                + mpHIO->m.mMinSwimSpeedScale;
         }
     }
 
@@ -697,8 +697,8 @@ BOOL daNpc_zrA_c::waitSwim() {
         if (home.angle.y == mCurAngle.y) {
             fopAc_ac_c* actor =
                 getAttnActorP(mActorMngr[0].getActorP() != NULL, srchAttnActor1,
-                              HIO_PARAM(this).mAttnRadius, HIO_PARAM(this).mAttnUpperY,
-                              HIO_PARAM(this).mAttnLowerY, HIO_PARAM(this).mAttnFovY,
+                              mpHIO->m.common.search_distance, mpHIO->m.common.search_height,
+                              mpHIO->m.common.search_depth, mpHIO->m.common.fov,
                               shape_angle.y, 120, true);
             if (actor != NULL) {
                 mActorMngr[1].entry(actor);
@@ -734,7 +734,7 @@ BOOL daNpc_zrA_c::turnSwimInit() {
 }
 
 BOOL daNpc_zrA_c::turnSwim() {
-    s16 ang_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 ang_step = mpHIO->m.mSwimAngleSpeed;
     cXyz pos;
     csXyz angle;
     mPath.getDstPosDst2(current.pos, pos);
@@ -755,14 +755,14 @@ BOOL daNpc_zrA_c::turnSwim() {
             mAnm_p->setPlaySpeed(0.8f);
         } else {
             cXyz swim_speed;
-            mSwimSpeedF = 1.5f * HIO_PARAM(this).mSwimSpeed;
+            mSwimSpeedF = 1.5f * mpHIO->m.mSwimSpeed;
             swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
             mAnm_p->setPlaySpeed(1.0f);
         }
     } else if (mBaseMotionAnm == ANM_STILL) {
         cXyz swim_speed;
-        mSwimSpeedF = 1.5f * HIO_PARAM(this).mSwimSpeed;
+        mSwimSpeedF = 1.5f * mpHIO->m.mSwimSpeed;
         swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
         calcSwimPos(swim_speed);
         mAnm_p->setPlaySpeed(1.0f);
@@ -783,9 +783,9 @@ BOOL daNpc_zrA_c::turnSwim() {
     }
 
     if (mAcch.ChkWaterHit()
-        && current.pos.y > mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth)
+        && current.pos.y > mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth)
     {
-        current.pos.y = mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth;
+        current.pos.y = mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth;
     }
 
     return true;
@@ -868,9 +868,9 @@ void daNpc_zrA_c::calcBank(s16 i_step, s16 i_scale, s16& i_angY, s16& o_angZ) {
 
 void daNpc_zrA_c::calcWaistAngle() {
     if (mResetWaistAngle) {
-        cLib_chaseAngleS(&mWaistAngle.x, 0, HIO_PARAM(this).mSwimAngleSpeed / 2);
-        cLib_chaseAngleS(&mWaistAngle.y, 0, HIO_PARAM(this).mSwimAngleSpeed / 2);
-        cLib_chaseAngleS(&mWaistAngle.z, 0, HIO_PARAM(this).mSwimAngleSpeed / 2);
+        cLib_chaseAngleS(&mWaistAngle.x, 0, mpHIO->m.mSwimAngleSpeed / 2);
+        cLib_chaseAngleS(&mWaistAngle.y, 0, mpHIO->m.mSwimAngleSpeed / 2);
+        cLib_chaseAngleS(&mWaistAngle.z, 0, mpHIO->m.mSwimAngleSpeed / 2);
     } else {
         mDoMtx_stack_c::push();
 
@@ -878,18 +878,18 @@ void daNpc_zrA_c::calcWaistAngle() {
         angle.x = cLib_targetAngleX(&field_0x1578, &current.pos);
         angle.y = cLib_targetAngleY(&current.pos, &field_0x1578);
         angle.z = 0;
-        cXyz vec(0.0f, 0.0f, HIO_PARAM(this).field_0x8c);
+        cXyz vec(0.0f, 0.0f, mpHIO->m.field_0x8c);
         mDoMtx_stack_c::ZXYrotS(angle);
         mDoMtx_stack_c::multVec(&vec, &field_0x1578);
 
         if (mIsTurning) {
-            vec.set(0.0f, 0.0f, HIO_PARAM(this).field_0x90);
+            vec.set(0.0f, 0.0f, mpHIO->m.field_0x90);
             cXyz vec2;
             mDoMtx_stack_c::ZXYrotS(current.angle);
             mDoMtx_stack_c::multVec(&vec, &vec2);
             field_0x1578 -= vec2;
             field_0x1578.normalize();
-            field_0x1578 *= HIO_PARAM(this).field_0x8c;
+            field_0x1578 *= mpHIO->m.field_0x8c;
         }
 
         mDoMtx_stack_c::ZXYrotS(current.angle);
@@ -906,7 +906,7 @@ void daNpc_zrA_c::calcWaistAngle() {
 }
 
 void daNpc_zrA_c::calcWaistAngleInit() {
-    cXyz vec(0.0f, 0.0f, -HIO_PARAM(this).field_0x8c);
+    cXyz vec(0.0f, 0.0f, -mpHIO->m.field_0x8c);
     mDoMtx_stack_c::ZXYrotS(mCurAngle);
     mDoMtx_stack_c::transM(vec);
     mDoMtx_stack_c::multVecZero(&field_0x1578);
@@ -971,17 +971,17 @@ void daNpc_zrA_c::calcSwimPos(cXyz& i_speed) {
 }
 
 void daNpc_zrA_c::calcWaitSwim(BOOL param_0) {
-    cLib_chaseAngleS(&current.angle.x, 0, HIO_PARAM(this).mSwimAngleSpeed);
-    cLib_chaseAngleS(&current.angle.z, 0, HIO_PARAM(this).mSwimAngleSpeed);
+    cLib_chaseAngleS(&current.angle.x, 0, mpHIO->m.mSwimAngleSpeed);
+    cLib_chaseAngleS(&current.angle.z, 0, mpHIO->m.mSwimAngleSpeed);
     mCurAngle = current.angle;
     shape_angle = mCurAngle;
     cLib_chaseF(&mSwimSpeedF, 0.0f, 2.0f);
-    cLib_chaseF(&mScaleFactor, 1.0f, (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+    cLib_chaseF(&mScaleFactor, 1.0f, (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
     calcModulation();
     if (param_0 && mAcch.ChkWaterHit()
-        && current.pos.y > mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth)
+        && current.pos.y > mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth)
     {
-        current.pos.y = mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth;
+        current.pos.y = mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth;
     }
 }
 
@@ -1000,7 +1000,7 @@ BOOL daNpc_zrA_c::ECut_talkSwim(int i_staffID) {
             mAcch.ClrGrndNone();
             mAcch.ClrWallNone();
             setExpression(EXPR_NONE, -1.0f);
-            setMotion(MOT_FLOAT, HIO_PARAM(this).mMorfFrames, true);
+            setMotion(MOT_FLOAT, mpHIO->m.common.morf_frame, true);
             mTurnMode = 0;
             mMode = 2;
             mSwimSpeed.set(0.0f, 0.0f, mSwimSpeedF);
@@ -1031,19 +1031,19 @@ BOOL daNpc_zrA_c::ECut_talkSwim(int i_staffID) {
             break;
         }
 
-        cLib_chaseAngleS(&current.angle.x, 0, HIO_PARAM(this).mSwimAngleSpeed);
-        cLib_chaseAngleS(&current.angle.z, 0, HIO_PARAM(this).mSwimAngleSpeed);
+        cLib_chaseAngleS(&current.angle.x, 0, mpHIO->m.mSwimAngleSpeed);
+        cLib_chaseAngleS(&current.angle.z, 0, mpHIO->m.mSwimAngleSpeed);
         cLib_chaseAngleS(&current.angle.y, fopAcM_searchPlayerAngleY(this),
-                         HIO_PARAM(this).mSwimAngleSpeed);
-        cLib_chaseF(&mScaleFactor, 1.0f, (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+                         mpHIO->m.mSwimAngleSpeed);
+        cLib_chaseF(&mScaleFactor, 1.0f, (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         cXyz zero(0.0f, 0.0f, 0.0f);
         cLib_chasePos(&mSwimSpeed, zero, 0.5f);
         current.pos += mSwimSpeed;
         f32 water_y;
         if (fopAcM_getWaterY(&current.pos, &water_y)
-            && current.pos.y > water_y - HIO_PARAM(this).mMinDepth - 50.0f)
+            && current.pos.y > water_y - mpHIO->m.mMinDepth - 50.0f)
         {
-            cLib_chaseF(&current.pos.y, water_y - HIO_PARAM(this).mMinDepth - 50.0f, 20.0f);
+            cLib_chaseF(&current.pos.y, water_y - mpHIO->m.mMinDepth - 50.0f, 20.0f);
         }
         mCurAngle = current.angle;
         shape_angle = mCurAngle;
@@ -1054,13 +1054,13 @@ BOOL daNpc_zrA_c::ECut_talkSwim(int i_staffID) {
         calcModulation();
         if (talkProc(NULL, true, NULL)) {
             if (mActionType == ACT_TYPE_0) {
-                setMotion(MOT_DIVE_SWIM_B, HIO_PARAM(this).mMorfFrames / 2.0f, true);
+                setMotion(MOT_DIVE_SWIM_B, mpHIO->m.common.morf_frame / 2.0f, true);
             } else {
-                setMotion(MOT_DIVE_SWIM_A, HIO_PARAM(this).mMorfFrames / 2.0f, true);
+                setMotion(MOT_DIVE_SWIM_A, mpHIO->m.common.morf_frame / 2.0f, true);
             }
             mSwimAngleCalc = current.angle;
             mSwimSpeedScale = 1.0f;
-            mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+            mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
             setLookMode(LOOK_NONE);
             ret = true;
         }
@@ -1068,9 +1068,9 @@ BOOL daNpc_zrA_c::ECut_talkSwim(int i_staffID) {
 
     case 2: {
         resetModulation();
-        s16 swim_angle_speed = HIO_PARAM(this).mSwimAngleSpeed;
-        cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                    (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+        s16 swim_angle_speed = mpHIO->m.mSwimAngleSpeed;
+        cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                    (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         cXyz vec;
         csXyz angle;
         mPath.getDstPosDst2(current.pos, vec);
@@ -1086,7 +1086,7 @@ BOOL daNpc_zrA_c::ECut_talkSwim(int i_staffID) {
             if (!calcWaistAngleCheck()) {
                 calcWaistAngleInit();
                 mSwimSpeedScale = 1.0f;
-                mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+                mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
             }
             cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
@@ -1095,9 +1095,9 @@ BOOL daNpc_zrA_c::ECut_talkSwim(int i_staffID) {
         }
 
         if (mAcch.ChkWaterHit()
-            && current.pos.y > mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth)
+            && current.pos.y > mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth)
         {
-            current.pos.y = mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth;
+            current.pos.y = mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth;
         }
         break;
     }
@@ -1172,7 +1172,7 @@ BOOL daNpc_zrA_c::waitWaterfall(void* param_0) {
 }
 
 BOOL daNpc_zrA_c::swimWaterfall(void* param_0) {
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed * 2;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed * 2;
     s16 angle_scale = 2;
     cXyz point, swim_speed;
 
@@ -1191,7 +1191,7 @@ BOOL daNpc_zrA_c::swimWaterfall(void* param_0) {
             setMotion(MOT_SWIM_A, -1.0f, false);
         }
         mSwimMode = SWIM_RAIL;
-        mScaleFactor = HIO_PARAM(this).mMaxScaleFactor;
+        mScaleFactor = mpHIO->m.mMaxScaleFactor;
         mCcStts.SetWeight(0);
         setLookMode(LOOK_NONE);
         mAttnChangeTimer = 0;
@@ -1266,14 +1266,14 @@ BOOL daNpc_zrA_c::swimWaterfall(void* param_0) {
         } else {
             mSwimSpeedScale = 1.0f;
         }
-        cLib_addCalc2(&mSwimSpeedF, mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed, 0.1f, 1.0f);
+        cLib_addCalc2(&mSwimSpeedF, mSwimSpeedScale * mpHIO->m.mSwimSpeed, 0.1f, 1.0f);
         swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
         calcSwimPos(swim_speed);
 
         if (!bvar5) {
             f32 play_speed = mAnm_p->getPlaySpeed();
             f32 target_speed =
-                cLib_minMaxLimit(mSwimSpeedF / HIO_PARAM(this).mSwimAnmRate, 0.0f, 1.5f);
+                cLib_minMaxLimit(mSwimSpeedF / mpHIO->m.mSwimAnmRate, 0.0f, 1.5f);
             cLib_addCalc2(&play_speed, target_speed, 0.2f, 0.1f);
             mAnm_p->setPlaySpeed(play_speed);
         }
@@ -1302,7 +1302,7 @@ BOOL daNpc_zrA_c::diveWaterfall(void* param_0) {
         setMotion(MOT_DIVE_B_SWIM_A, -1.0f, false);
         mSwimAngleCalc = current.angle;
         mSwimSpeedScale = 1.0f;
-        mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+        mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
         setLookMode(LOOK_NONE);
         mSwimMode = SWIM_RAIL;
         mActionSelect = 3;
@@ -1310,7 +1310,7 @@ BOOL daNpc_zrA_c::diveWaterfall(void* param_0) {
         // fallthrough
 
     case 2:
-        if (diveCalc(HIO_PARAM(this).mSwimAngleSpeed, 4, false)) {
+        if (diveCalc(mpHIO->m.mSwimAngleSpeed, 4, false)) {
             mActionSelect = 1;
             setAction(&daNpc_zrA_c::swimWaterfall);
         }
@@ -1362,7 +1362,7 @@ BOOL daNpc_zrA_c::talkSwim(void* param_0) {
                     field_0x1558 = 1;
                     mSwimAngleCalc = current.angle;
                     mSwimSpeedScale = 1.0f;
-                    mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+                    mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
                     setLookMode(LOOK_NONE);
                 } else {
                     mMode = 3;
@@ -1420,7 +1420,7 @@ BOOL daNpc_zrA_c::ECut_carryWaterfall(int i_staffID) {
             mAcch.SetWallNone();
             field_0x153d = false;
             mSwimMode = SWIM_RAIL;
-            mScaleFactor = HIO_PARAM(this).mMaxScaleFactor;
+            mScaleFactor = mpHIO->m.mMaxScaleFactor;
             mCcStts.SetWeight(0);
             setLookMode(LOOK_NONE);
             mAttnChangeTimer = 0;
@@ -1469,7 +1469,7 @@ BOOL daNpc_zrA_c::ECut_carryWaterfall(int i_staffID) {
             }
             ret = true;
         } else {
-            s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed * 2;
+            s16 angle_step = mpHIO->m.mSwimAngleSpeed * 2;
             cXyz pos, swim_speed;
             f32 speed_scale = mSwimSpeedScale;
             if (mPath.getDstPosDst2(current.pos, pos) && mPath.getIdx() == mPath.getNextIdx()) {
@@ -1485,7 +1485,7 @@ BOOL daNpc_zrA_c::ECut_carryWaterfall(int i_staffID) {
                 angle.y = cLib_targetAngleY(&current.pos, &pos);
                 angle.z = current.angle.z;
                 calcSwimAngle(angle, mSwimAngleCalc, 4, angle_step);
-                cLib_addCalc2(&mSwimSpeedF, speed_scale * HIO_PARAM(this).mSwimSpeed,
+                cLib_addCalc2(&mSwimSpeedF, speed_scale * mpHIO->m.mSwimSpeed,
                             0.1f, 1.0f);
                 swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
                 calcSwimPos(swim_speed);
@@ -1511,7 +1511,7 @@ BOOL daNpc_zrA_c::ECut_carryWaterfall(int i_staffID) {
             mSwimMode = SWIM_WAIT;
         }
         cLib_chaseAngleS(&mCurAngle.y, fopAcM_searchPlayerAngleY(this),
-                         HIO_PARAM(this).mSwimAngleSpeed);
+                         mpHIO->m.mSwimAngleSpeed);
         setAngle(mCurAngle.y);
         break;
 
@@ -1582,7 +1582,7 @@ BOOL daNpc_zrA_c::ECut_carryWaterfallSkip(int i_staffID) {
             mSwimMode = SWIM_WAIT;
         }
         cLib_chaseAngleS(&mCurAngle.y, fopAcM_searchPlayerAngleY(this),
-                         HIO_PARAM(this).mSwimAngleSpeed);
+                         mpHIO->m.mSwimAngleSpeed);
         setAngle(mCurAngle.y);
         break;
 
@@ -1599,8 +1599,8 @@ BOOL daNpc_zrA_c::ECut_carryWaterfallSkip(int i_staffID) {
 }
 
 BOOL daNpc_zrA_c::diveCalc(s16 i_angleStep, s16 i_angleScale, BOOL param_2) {
-    cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+    cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
     cXyz pos;
     mPath.getDstPosDst2(current.pos, pos);
     csXyz angle;
@@ -1630,9 +1630,9 @@ BOOL daNpc_zrA_c::diveCalc(s16 i_angleStep, s16 i_angleScale, BOOL param_2) {
     current.pos += dive_speed;
 
     if (param_2 && mAcch.ChkWaterIn()
-        && current.pos.y > mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth)
+        && current.pos.y > mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth)
     {
-        current.pos.y = mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth;
+        current.pos.y = mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth;
     }
 
     if (mBaseMotionAnm == ANM_SWIM_A || mBaseMotionAnm == ANM_SWIM_B) {
@@ -1732,7 +1732,7 @@ BOOL daNpc_zrA_c::waitRiverDescend(void* param_0) {
             } else if (mGameMode == GAME_MODE_1) {
                 if (field_0x15c0 == 0) {
                     if ((player->current.pos - current.pos).absXZ()
-                                                < HIO_PARAM(this).field_0xa8) {
+                                                < mpHIO->m.field_0xa8) {
                         field_0x15c0 = 1;
                         mOrderEvtNo = EVT_BEFORE_BLAST_ZRR;
                     }
@@ -1778,7 +1778,7 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
     cXyz pos_sp94;
     cXyz swim_speed_sp88;
 
-    s16 angle_step_r28 = (s16)HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step_r28 = (s16)mpHIO->m.mSwimAngleSpeed;
     s16 angle_scale_r27 = 6;
     f32 sp28 = 0.25f;
     f32 sp24 = 4.0f;
@@ -1811,8 +1811,8 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
     case 2: {
         csXyz angle_sp44;
         daPy_py_c* player_r26 = daPy_getPlayerActorClass();
-        cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                    (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+        cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                    (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         int ivar8_sp20 = mRiverPathIdx;
         moveRiverPosCalc(pos_sp94);
 
@@ -1858,7 +1858,7 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
                         mAnm_p->setPlaySpeed(1.0f);
                     }
 
-                    if (current.pos.y <= water_height - HIO_PARAM(this).mMinDepth) {
+                    if (current.pos.y <= water_height - mpHIO->m.mMinDepth) {
                         field_0x153e = false;
                         field_0x153c = false;
                         mSwimSpeedF = mSwimSpeed.abs();
@@ -1874,7 +1874,7 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
                 angle_sp44.x = -0x3000;
                 if (mAcch.ChkWaterHit()) {
                     if (head_pos_sp7c.y < water_height) {
-                        angle_step_r28 = HIO_PARAM(this).mSwimAngleSpeed * 2;
+                        angle_step_r28 = mpHIO->m.mSwimAngleSpeed * 2;
                         angle_scale_r27 = 2;
                     } else if (!mIsAboveWater) {
                         cXyz wpillar_pos_sp64 = head_pos_sp7c;
@@ -1929,8 +1929,8 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
 
         cXyz vec_sp58 = field_0x1500 - player_r26->current.pos;
         f32 target_speed_f31 = vec_sp58.abs();
-        if (target_speed_f31 < HIO_PARAM(this).mSwimSpeed) {
-            target_speed_f31 = HIO_PARAM(this).mSwimSpeed;
+        if (target_speed_f31 < mpHIO->m.mSwimSpeed) {
+            target_speed_f31 = mpHIO->m.mSwimSpeed;
         } else {
             target_speed_f31 *= 1.4f;
         }
@@ -1940,8 +1940,8 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
         }
 
         if (field_0x153c) {
-            if (target_speed_f31 < 3.0f * HIO_PARAM(this).mSwimSpeed) {
-                target_speed_f31 = 3.0f * HIO_PARAM(this).mSwimSpeed;
+            if (target_speed_f31 < 3.0f * mpHIO->m.mSwimSpeed) {
+                target_speed_f31 = 3.0f * mpHIO->m.mSwimSpeed;
             }
             target_speed_f31 *= 1.2f;
         } else if (mRiverPathIdx >= mPath.getIdx()) {
@@ -1978,9 +1978,9 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
         mAnm_p->setPlaySpeed(play_speed_sp14);
 
         if (!field_0x153c && mAcch.ChkWaterHit()
-            && current.pos.y > water_height - HIO_PARAM(this).mMinDepth)
+            && current.pos.y > water_height - mpHIO->m.mMinDepth)
         {
-            current.pos.y = water_height - HIO_PARAM(this).mMinDepth;
+            current.pos.y = water_height - mpHIO->m.mMinDepth;
         }
 
         calcBank(angle_step_r28, angle_scale_r27, angle_sp44.y, angle_sp44.z);
@@ -1997,7 +1997,7 @@ BOOL daNpc_zrA_c::swimRiverDescend(void* param_0) {
 
 BOOL daNpc_zrA_c::swimRiverDescend2(void* param_0) {
     cXyz pos, swim_speed;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed;
     f32 water_height = mAcch.m_wtr.GetHeight();
 
     switch (mMode) {
@@ -2042,13 +2042,13 @@ BOOL daNpc_zrA_c::swimRiverDescend2(void* param_0) {
             setAction(&daNpc_zrA_c::waitRiverDescend);
         } else {
             csXyz angle;
-            cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                        (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+            cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                        (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
             
             angle.x = cLib_targetAngleX(&vec, &current.pos);
             angle.y = cLib_targetAngleY(&current.pos, &vec);
             angle.z = current.angle.z;
-            cLib_addCalc2(&mSwimSpeedF, 2.0f * HIO_PARAM(this).mSwimSpeed, 0.25f, 4.0f);
+            cLib_addCalc2(&mSwimSpeedF, 2.0f * mpHIO->m.mSwimSpeed, 0.25f, 4.0f);
             calcSwimAngle(angle, mSwimAngleCalc, 6, angle_step);
             
             swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
@@ -2059,9 +2059,9 @@ BOOL daNpc_zrA_c::swimRiverDescend2(void* param_0) {
             mAnm_p->setPlaySpeed(play_speed);
 
             if (mAcch.ChkWaterHit()
-                && current.pos.y > water_height - HIO_PARAM(this).mMinDepth)
+                && current.pos.y > water_height - mpHIO->m.mMinDepth)
             {
-                current.pos.y = water_height - HIO_PARAM(this).mMinDepth;
+                current.pos.y = water_height - mpHIO->m.mMinDepth;
             }
 
             calcBank(angle_step, 6, angle.y, angle.z);
@@ -2080,7 +2080,7 @@ BOOL daNpc_zrA_c::swimRiverDescend2(void* param_0) {
 }
 
 BOOL daNpc_zrA_c::diveRiverDescend(void* param_0) {
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed * 2;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed * 2;
 
     switch (mMode) {
     case 0:
@@ -2098,8 +2098,8 @@ BOOL daNpc_zrA_c::diveRiverDescend(void* param_0) {
         // fallthrough
 
     case 2: {
-        cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                    (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+        cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                    (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         cXyz pos;
         csXyz angle;
         mPath.getDstPos(current.pos, pos);
@@ -2162,7 +2162,7 @@ BOOL daNpc_zrA_c::diveRiverDescend(void* param_0) {
 BOOL daNpc_zrA_c::swimGoalRiverDescend(void* param_0) {
     daPy_py_c* player;
     cXyz pos, swim_speed;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed;
 
     switch (mMode) {
     case 0:
@@ -2178,14 +2178,14 @@ BOOL daNpc_zrA_c::swimGoalRiverDescend(void* param_0) {
         mSwimAngleCalc = current.angle;
         calcWaistAngleInit();
         field_0x1500 = daPy_getPlayerActorClass()->current.pos;
-        mSwimSpeedF = HIO_PARAM(this).mSwimSpeed;
+        mSwimSpeedF = mpHIO->m.mSwimSpeed;
         mMode = 2;
         // fallthrough
 
     case 2:
         player = daPy_getPlayerActorClass();
-        cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                    (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+        cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                    (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         if (player->current.pos.y < -14100.0f) {
             if (!daNpcF_chkEvtBit(0x60)) {
                 mOrderEvtNo = EVT_THANKS_BLAST;
@@ -2209,8 +2209,8 @@ BOOL daNpc_zrA_c::swimGoalRiverDescend(void* param_0) {
             if (mPath.getIdx() != mPath.getNextIdx()) {
                 vec = field_0x1500 - player->current.pos;
                 target_speed = vec.abs() * 1.2f;
-                if (target_speed < HIO_PARAM(this).mSwimSpeed) {
-                    target_speed = HIO_PARAM(this).mSwimSpeed;
+                if (target_speed < mpHIO->m.mSwimSpeed) {
+                    target_speed = mpHIO->m.mSwimSpeed;
                 }
             } else {
                 target_speed = 0.0f;
@@ -2253,7 +2253,7 @@ BOOL daNpc_zrA_c::swimGoalRiverDescend(void* param_0) {
 
 BOOL daNpc_zrA_c::returnRiverDescend(void* param_0) {
     cXyz pos, swim_speed;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed;
     f32 swim_speed_scale = mSwimSpeedScale;
 
     switch (mMode) {
@@ -2307,18 +2307,18 @@ BOOL daNpc_zrA_c::returnRiverDescend(void* param_0) {
                 calcSwimAngle(angle, mSwimAngleCalc, 8, angle_step);
             }
 
-            cLib_addCalc2(&mSwimSpeedF, swim_speed_scale * HIO_PARAM(this).mSwimSpeed,
+            cLib_addCalc2(&mSwimSpeedF, swim_speed_scale * mpHIO->m.mSwimSpeed,
                           0.2f, 3.0f);
             swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
 
             if (mAcch.ChkWaterHit()) {
-                current.pos.y = mAcch.m_wtr.GetHeight() - HIO_PARAM(this).mMinDepth;
+                current.pos.y = mAcch.m_wtr.GetHeight() - mpHIO->m.mMinDepth;
             }
 
             if (!bvar4) {
                 f32 play_speed = mAnm_p->getPlaySpeed();
-                cLib_addCalc2(&play_speed, mSwimSpeedF / HIO_PARAM(this).mSwimAnmRate,
+                cLib_addCalc2(&play_speed, mSwimSpeedF / mpHIO->m.mSwimAnmRate,
                               0.2f, 0.1f);
                 mAnm_p->setPlaySpeed(play_speed);
             }
@@ -2526,7 +2526,7 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
     dEvent_manager_c& event_manager = dComIfGp_getEventManager();
     BOOL ret = false;
     int prm = -1;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed;
     f32 water_height = mAcch.m_wtr.GetHeight();
     daPy_py_c* player = daPy_getPlayerActorClass();
     cXyz player_pos = player->current.pos;
@@ -2570,8 +2570,8 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
         case 20: {
             mPath.onReverse();
             mPath.setIdx(mPath.getEndIdx() - 1);
-            cXyz pos1(-77941.7f, -18800.0f - HIO_PARAM(this).mMinDepth - 30.0f, 39645.3f);
-            cXyz pos2(-78941.7f, -18800.0f - HIO_PARAM(this).mMinDepth - 30.0f, 39645.3f);
+            cXyz pos1(-77941.7f, -18800.0f - mpHIO->m.mMinDepth - 30.0f, 39645.3f);
+            cXyz pos2(-78941.7f, -18800.0f - mpHIO->m.mMinDepth - 30.0f, 39645.3f);
             current.pos = pos1;
             current.angle.y = cLib_targetAngleY(&pos1, &player_pos);
             setAngle(current.angle.y);
@@ -2582,14 +2582,14 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
                 water_pos.y = water_y;
             }
 
-            cXyz offset(0.0f, 0.0f, HIO_PARAM(this).field_0xa0);
+            cXyz offset(0.0f, 0.0f, mpHIO->m.field_0xa0);
             csXyz angle(0, cLib_targetAngleY(&pos1, &pos2), 0);
             mDoMtx_stack_c::ZXYrotS(angle);
             mDoMtx_stack_c::transM(offset);
             mDoMtx_stack_c::multVecZero(&field_0x159c[0]);
             field_0x159c[0] += water_pos;
             
-            offset.set(0.0f, 0.0f, HIO_PARAM(this).field_0xa4);
+            offset.set(0.0f, 0.0f, mpHIO->m.field_0xa4);
             mDoMtx_stack_c::ZXYrotS(angle);
             mDoMtx_stack_c::transM(offset);
             mDoMtx_stack_c::multVecZero(&field_0x159c[1]);
@@ -2656,8 +2656,8 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
                 mPath.getDstPos(current.pos, pos);
                 cXyz vec = field_0x1500 - player->current.pos;
                 target_speed = vec.abs() * 1.2f;
-                if (target_speed < HIO_PARAM(this).mSwimSpeed) {
-                    target_speed = HIO_PARAM(this).mSwimSpeed;
+                if (target_speed < mpHIO->m.mSwimSpeed) {
+                    target_speed = mpHIO->m.mSwimSpeed;
                 }
             } else {
                 if ((field_0x1500 - player->current.pos).absXZ() < 5.0f) {
@@ -2673,7 +2673,7 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
                         pos = vec3;
                     }
                     if ((player_pos - current.pos).absXZ() > 450.0f) {
-                        target_speed = HIO_PARAM(this).mSwimSpeed * 1.5f * 1.5f;
+                        target_speed = mpHIO->m.mSwimSpeed * 1.5f * 1.5f;
                     } else {
                         target_speed = 15.0f;
                         pos = player_pos;
@@ -2705,9 +2705,9 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
             cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
             if (mAcch.ChkWaterHit()
-                && current.pos.y > water_height - HIO_PARAM(this).mMinDepth)
+                && current.pos.y > water_height - mpHIO->m.mMinDepth)
             {
-                current.pos.y = water_height - HIO_PARAM(this).mMinDepth;
+                current.pos.y = water_height - mpHIO->m.mMinDepth;
             }
 
             if ((field_0x1500 - player->current.pos).absXZ() < 10.0f
@@ -2728,7 +2728,7 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
                 }
             } else {
                 cLib_chaseAngleS(&mCurAngle.y, fopAcM_searchPlayerAngleY(this),
-                                 HIO_PARAM(this).mSwimAngleSpeed);
+                                 mpHIO->m.mSwimAngleSpeed);
                 setAngle(mCurAngle.y);
             }
         }
@@ -2758,7 +2758,7 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
             ret = true;
             mSwimAngleCalc = current.angle;
             mSwimSpeedScale = 1.0f;
-            mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+            mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
             setLookMode(LOOK_NONE);
         }
         break;
@@ -2771,9 +2771,9 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
         break;
 
     case 50: {
-        s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
-        cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                    (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+        s16 angle_step = mpHIO->m.mSwimAngleSpeed;
+        cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                    (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         cXyz pos;
         csXyz angle;
         mPath.getDstPosDst2(current.pos, pos);
@@ -2809,7 +2809,7 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
             if (!calcWaistAngleCheck()) {
                 calcWaistAngleInit();
                 mSwimSpeedScale = 1.0f;
-                mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+                mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
             }
             cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
@@ -2837,8 +2837,8 @@ BOOL daNpc_zrA_c::ECut_thanksBlast(int i_staffID) {
         shape_angle = mCurAngle = current.angle;
         cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
         calcSwimPos(swim_speed);
-        if (mAcch.ChkWaterHit() && current.pos.y > water_y - HIO_PARAM(this).mMinDepth) {
-            current.pos.y = water_y - HIO_PARAM(this).mMinDepth;
+        if (mAcch.ChkWaterHit() && current.pos.y > water_y - mpHIO->m.mMinDepth) {
+            current.pos.y = water_y - mpHIO->m.mMinDepth;
         }
         calcCanoeMove(true);
         if (cLib_calcTimer(&mEventTimer) == 0) {
@@ -2859,7 +2859,7 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
     dEvent_manager_c& event_manager = dComIfGp_getEventManager();
     BOOL ret = false;
     int prm = -1;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed;
     f32 water_height = mAcch.m_wtr.GetHeight();
     daPy_py_c* player = daPy_getPlayerActorClass();
     cXyz player_pos = player->current.pos;
@@ -2899,8 +2899,8 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
         case 20: {
             mPath.onReverse();
             mPath.setIdx(mPath.getEndIdx() - 1);
-            cXyz pos1(-77941.7f, -18800.0f - HIO_PARAM(this).mMinDepth - 30.0f, 39645.3f);
-            cXyz pos2(-78941.7f, -18800.0f - HIO_PARAM(this).mMinDepth - 30.0f, 39645.3f);
+            cXyz pos1(-77941.7f, -18800.0f - mpHIO->m.mMinDepth - 30.0f, 39645.3f);
+            cXyz pos2(-78941.7f, -18800.0f - mpHIO->m.mMinDepth - 30.0f, 39645.3f);
             current.pos = pos1;
             current.angle.y = cLib_targetAngleY(&pos1, &player_pos);
             setAngle(current.angle.y);
@@ -2911,14 +2911,14 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
                 water_pos.y = water_y;
             }
 
-            cXyz offset(0.0f, 0.0f, HIO_PARAM(this).field_0xa0);
+            cXyz offset(0.0f, 0.0f, mpHIO->m.field_0xa0);
             csXyz angle(0, cLib_targetAngleY(&pos1, &pos2), 0);
             mDoMtx_stack_c::ZXYrotS(angle);
             mDoMtx_stack_c::transM(offset);
             mDoMtx_stack_c::multVecZero(&field_0x159c[0]);
             field_0x159c[0] += water_pos;
             
-            offset.set(0.0f, 0.0f, HIO_PARAM(this).field_0xa4);
+            offset.set(0.0f, 0.0f, mpHIO->m.field_0xa4);
             mDoMtx_stack_c::ZXYrotS(angle);
             mDoMtx_stack_c::transM(offset);
             mDoMtx_stack_c::multVecZero(&field_0x159c[1]);
@@ -2971,8 +2971,8 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
                 mPath.getDstPos(current.pos, pos);
                 cXyz vec = field_0x1500 - player->current.pos;
                 target_speed = vec.abs() * 1.2f;
-                if (target_speed < HIO_PARAM(this).mSwimSpeed) {
-                    target_speed = HIO_PARAM(this).mSwimSpeed;
+                if (target_speed < mpHIO->m.mSwimSpeed) {
+                    target_speed = mpHIO->m.mSwimSpeed;
                 }
             } else {
                 if ((field_0x1500 - player->current.pos).absXZ() < 5.0f) {
@@ -2988,7 +2988,7 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
                         pos = vec3;
                     }
                     if ((player_pos - current.pos).absXZ() > 450.0f) {
-                        target_speed = HIO_PARAM(this).mSwimSpeed * 1.5f * 1.5f;
+                        target_speed = mpHIO->m.mSwimSpeed * 1.5f * 1.5f;
                     } else {
                         target_speed = 15.0f;
                         pos = player_pos;
@@ -3020,9 +3020,9 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
             cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
             if (mAcch.ChkWaterHit()
-                && current.pos.y > water_height - HIO_PARAM(this).mMinDepth)
+                && current.pos.y > water_height - mpHIO->m.mMinDepth)
             {
-                current.pos.y = water_height - HIO_PARAM(this).mMinDepth;
+                current.pos.y = water_height - mpHIO->m.mMinDepth;
             }
 
             if ((field_0x1500 - player->current.pos).absXZ() < 10.0f
@@ -3043,7 +3043,7 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
                 }
             } else {
                 cLib_chaseAngleS(&mCurAngle.y, fopAcM_searchPlayerAngleY(this),
-                                 HIO_PARAM(this).mSwimAngleSpeed);
+                                 mpHIO->m.mSwimAngleSpeed);
                 setAngle(mCurAngle.y);
             }
         }
@@ -3075,16 +3075,16 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
                 ret = true;
                 mSwimAngleCalc = current.angle;
                 mSwimSpeedScale = 1.0f;
-                mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+                mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
                 setLookMode(LOOK_NONE);
             }
         }
         break;
 
     case 40: {
-        s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
-        cLib_chaseF(&mScaleFactor, HIO_PARAM(this).mMaxScaleFactor,
-                    (HIO_PARAM(this).mMaxScaleFactor - 1.0f) / 30.0f);
+        s16 angle_step = mpHIO->m.mSwimAngleSpeed;
+        cLib_chaseF(&mScaleFactor, mpHIO->m.mMaxScaleFactor,
+                    (mpHIO->m.mMaxScaleFactor - 1.0f) / 30.0f);
         cXyz pos;
         csXyz angle;
         mPath.getDstPosDst2(current.pos, pos);
@@ -3120,7 +3120,7 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
             if (!calcWaistAngleCheck()) {
                 calcWaistAngleInit();
                 mSwimSpeedScale = 1.0f;
-                mSwimSpeedF = mSwimSpeedScale * HIO_PARAM(this).mSwimSpeed;
+                mSwimSpeedF = mSwimSpeedScale * mpHIO->m.mSwimSpeed;
             }
             cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
@@ -3148,8 +3148,8 @@ BOOL daNpc_zrA_c::ECut_resultAnnounce(int i_staffID) {
         shape_angle = mCurAngle = current.angle;
         cXyz swim_speed(0.0f, 0.0f, mSwimSpeedF);
         calcSwimPos(swim_speed);
-        if (mAcch.ChkWaterHit() && current.pos.y > water_y - HIO_PARAM(this).mMinDepth) {
-            current.pos.y = water_y - HIO_PARAM(this).mMinDepth;
+        if (mAcch.ChkWaterHit() && current.pos.y > water_y - mpHIO->m.mMinDepth) {
+            current.pos.y = water_y - mpHIO->m.mMinDepth;
         }
         calcCanoeMove(true);
         if (cLib_calcTimer(&mEventTimer) == 0) {
@@ -3179,7 +3179,7 @@ void daNpc_zrA_c::calcCanoeMove(BOOL param_0) {
     angle.y = cLib_targetAngleY(&water_pos, &field_0x159c[0]);
     angle.z = 0;
 
-    vec.set(0.0f, 0.0f, HIO_PARAM(this).field_0xa0);
+    vec.set(0.0f, 0.0f, mpHIO->m.field_0xa0);
     mDoMtx_stack_c::ZXYrotS(angle);
     mDoMtx_stack_c::multVec(&vec, &field_0x159c[0]);
     field_0x159c[0] += water_pos;
@@ -3190,7 +3190,7 @@ void daNpc_zrA_c::calcCanoeMove(BOOL param_0) {
     angle.x = cLib_targetAngleX(&field_0x159c[1], &field_0x159c[0]);
     angle.y = cLib_targetAngleY(&field_0x159c[0], &field_0x159c[1]);
 
-    vec.set(0.0f, 0.0f, HIO_PARAM(this).field_0xa4);
+    vec.set(0.0f, 0.0f, mpHIO->m.field_0xa4);
     mDoMtx_stack_c::ZXYrotS(angle);
     mDoMtx_stack_c::multVec(&vec, &field_0x159c[1]);
     field_0x159c[1] += field_0x159c[0];
@@ -3201,7 +3201,7 @@ void daNpc_zrA_c::calcCanoeMove(BOOL param_0) {
     if (param_0) {
         f32 fvar2 = (water_pos - field_0x159c[2]).abs();
         (water_pos - field_0x159c[1]).abs();
-        if (fvar2 > HIO_PARAM(this).field_0xa0 + HIO_PARAM(this).field_0xa4)
+        if (fvar2 > mpHIO->m.field_0xa0 + mpHIO->m.field_0xa4)
         {
             cLib_addCalcPos2(&field_0x159c[2], field_0x159c[1], 0.2f, mSwimSpeedF * 1.2f);
             if (fopAcM_getWaterY(&field_0x159c[2], &water_y)) {
@@ -3371,7 +3371,7 @@ BOOL daNpc_zrA_c::tobikomi3(void* param_0) {
         // fallthrough
 
     case 2: {
-        cXyz vec(0.0f, 0.0f, HIO_PARAM(this).mSwimSpeed * 1.5f);
+        cXyz vec(0.0f, 0.0f, mpHIO->m.mSwimSpeed * 1.5f);
         mDoMtx_stack_c::YrotS(mCurAngle.y);
         mDoMtx_stack_c::multVec(&vec, &vec);
         cLib_chasePos(&mSwimSpeed, vec, 25.0f);
@@ -3397,7 +3397,7 @@ BOOL daNpc_zrA_c::tobiJump(void* param_0) {
     cXyz swim_speed;
     csXyz angle;
     f32 water_y;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed * 2;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed * 2;
     s16 angle_scale = 4;
 
     switch (mMode) {
@@ -3437,7 +3437,7 @@ BOOL daNpc_zrA_c::tobiJump(void* param_0) {
                     mIsAboveWater = false;
                 }
 
-                if (current.pos.y <= water_y - HIO_PARAM(this).mMinDepth) {
+                if (current.pos.y <= water_y - mpHIO->m.mMinDepth) {
                     setAction(&daNpc_zrA_c::tobiEnd);
                     mSwimSpeedF = mSwimSpeed.absXZ();
                 }
@@ -3450,7 +3450,7 @@ BOOL daNpc_zrA_c::tobiJump(void* param_0) {
             angle.z = current.angle.z;
 
             if (fopAcM_getWaterY(&current.pos, &water_y)) {
-                angle_step = HIO_PARAM(this).mSwimAngleSpeed * 2;
+                angle_step = mpHIO->m.mSwimAngleSpeed * 2;
                 angle_scale = 2;
                 if (!(head_pos.y < water_y)) {
                     if (!mIsAboveWater) {
@@ -3472,11 +3472,11 @@ BOOL daNpc_zrA_c::tobiJump(void* param_0) {
             }
 
             calcSwimAngle(angle, mSwimAngleCalc, angle_scale, angle_step);
-            cLib_addCalc2(&mSwimSpeedF, 2.0f * HIO_PARAM(this).mSwimSpeed, 0.7f, 10.0f);
+            cLib_addCalc2(&mSwimSpeedF, 2.0f * mpHIO->m.mSwimSpeed, 0.7f, 10.0f);
             swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
             calcSwimPos(swim_speed);
             f32 play_speed = mAnm_p->getPlaySpeed();
-            cLib_addCalc2(&play_speed, mSwimSpeedF / HIO_PARAM(this).mSwimAnmRate, 0.2f, 0.1f);
+            cLib_addCalc2(&play_speed, mSwimSpeedF / mpHIO->m.mSwimAnmRate, 0.2f, 0.1f);
             mAnm_p->setPlaySpeed(play_speed);
             shape_angle = mCurAngle = current.angle;
         }
@@ -3493,7 +3493,7 @@ BOOL daNpc_zrA_c::tobiJump(void* param_0) {
 
 BOOL daNpc_zrA_c::tobiEnd(void* param_0) {
     cXyz swim_speed;
-    s16 angle_step = HIO_PARAM(this).mSwimAngleSpeed;
+    s16 angle_step = mpHIO->m.mSwimAngleSpeed;
 
     switch (mMode) {
     case 0:
@@ -3514,12 +3514,12 @@ BOOL daNpc_zrA_c::tobiEnd(void* param_0) {
         angle.y = current.angle.y;
         angle.z = current.angle.z;
         calcSwimAngle(angle, mSwimAngleCalc, 8, angle_step);
-        cLib_chaseF(&mSwimSpeedF, HIO_PARAM(this).mSwimSpeed,
-                    HIO_PARAM(this).mSwimSpeed / 3.0f);
+        cLib_chaseF(&mSwimSpeedF, mpHIO->m.mSwimSpeed,
+                    mpHIO->m.mSwimSpeed / 3.0f);
         swim_speed.set(0.0f, 0.0f, mSwimSpeedF);
         calcSwimPos(swim_speed);
         f32 play_speed = mAnm_p->getPlaySpeed();
-        cLib_addCalc2(&play_speed, mSwimSpeedF / HIO_PARAM(this).mSwimAnmRate, 0.2f, 0.1f);
+        cLib_addCalc2(&play_speed, mSwimSpeedF / mpHIO->m.mSwimAnmRate, 0.2f, 0.1f);
         mAnm_p->setPlaySpeed(play_speed);
         calcBank(angle_step, 8, angle.y, angle.z);
         current.angle.z = angle.z;
@@ -3685,7 +3685,7 @@ BOOL daNpc_zrA_c::ECut_searchPrince1(int i_staffID) {
         if (mBaseMotionAnm == ANM_SWIM_A) {
             ret = true;
         }
-        cXyz swim_speed(0.0f, 0.0f, HIO_PARAM(this).mSwimSpeed);
+        cXyz swim_speed(0.0f, 0.0f, mpHIO->m.mSwimSpeed);
         mDoMtx_stack_c::YrotS(mCurAngle.y);
         mDoMtx_stack_c::multVec(&swim_speed, &swim_speed);
         cLib_chasePos(&mSwimSpeed, swim_speed, 25.0f);
@@ -3695,15 +3695,15 @@ BOOL daNpc_zrA_c::ECut_searchPrince1(int i_staffID) {
 
     case 50: {
         cXyz pos(-4807.7f, -207.444f, 5109.854f);
-        cXyz swim_speed(0.0f, 0.0f, HIO_PARAM(this).mSwimSpeed);
+        cXyz swim_speed(0.0f, 0.0f, mpHIO->m.mSwimSpeed);
         csXyz angle;
         angle.x = cLib_targetAngleX(&pos, &current.pos);
         angle.y = cLib_targetAngleY(&current.pos, &pos);
         angle.z = current.angle.z;
-        mAnm_p->setPlaySpeed(HIO_PARAM(this).mSwimSpeed / HIO_PARAM(this).mSwimAnmRate);
-        calcSwimAngle(angle, mSwimAngleCalc, 23, HIO_PARAM(this).mSwimAngleSpeed / 2);
+        mAnm_p->setPlaySpeed(mpHIO->m.mSwimSpeed / mpHIO->m.mSwimAnmRate);
+        calcSwimAngle(angle, mSwimAngleCalc, 23, mpHIO->m.mSwimAngleSpeed / 2);
         calcSwimPos(swim_speed);
-        calcBank(HIO_PARAM(this).mSwimAngleSpeed / 2, 16, angle.y, angle.z);
+        calcBank(mpHIO->m.mSwimAngleSpeed / 2, 16, angle.y, angle.z);
         current.angle.z = angle.z;
         shape_angle = mCurAngle = current.angle;
         if ((pos - current.pos).absXZ() < 100.0f) {
@@ -3817,7 +3817,7 @@ BOOL daNpc_zrA_c::ECut_searchPrince2(int i_staffID) {
         if (mBaseMotionAnm == ANM_SWIM_A) {
             ret = true;
         }
-        cXyz swim_speed(0.0f, 0.0f, HIO_PARAM(this).mSwimSpeed);
+        cXyz swim_speed(0.0f, 0.0f, mpHIO->m.mSwimSpeed);
         mDoMtx_stack_c::YrotS(mCurAngle.y);
         mDoMtx_stack_c::multVec(&swim_speed, &swim_speed);
         cLib_chasePos(&mSwimSpeed, swim_speed, 25.0f);
@@ -3827,15 +3827,15 @@ BOOL daNpc_zrA_c::ECut_searchPrince2(int i_staffID) {
 
     case 50: {
         cXyz pos(-4807.7f, -207.444f, 5109.854f);
-        cXyz swim_speed(0.0f, 0.0f, HIO_PARAM(this).mSwimSpeed);
+        cXyz swim_speed(0.0f, 0.0f, mpHIO->m.mSwimSpeed);
         csXyz angle;
         angle.x = cLib_targetAngleX(&pos, &current.pos);
         angle.y = cLib_targetAngleY(&current.pos, &pos);
         angle.z = current.angle.z;
-        mAnm_p->setPlaySpeed(HIO_PARAM(this).mSwimSpeed / HIO_PARAM(this).mSwimAnmRate);
-        calcSwimAngle(angle, mSwimAngleCalc, 23, HIO_PARAM(this).mSwimAngleSpeed / 2);
+        mAnm_p->setPlaySpeed(mpHIO->m.mSwimSpeed / mpHIO->m.mSwimAnmRate);
+        calcSwimAngle(angle, mSwimAngleCalc, 23, mpHIO->m.mSwimAngleSpeed / 2);
         calcSwimPos(swim_speed);
-        calcBank(HIO_PARAM(this).mSwimAngleSpeed / 2, 16, angle.y, angle.z);
+        calcBank(mpHIO->m.mSwimAngleSpeed / 2, 16, angle.y, angle.z);
         current.angle.z = angle.z;
         shape_angle = mCurAngle = current.angle;
         if ((pos - current.pos).absXZ() < 100.0f) {

--- a/src/d/actor/d_a_obj_automata.cpp
+++ b/src/d/actor/d_a_obj_automata.cpp
@@ -19,7 +19,7 @@ static char* l_resNameList[2] = {
     "AutoMata",
 };
 
-f32 const daObj_AutoMata_Param_c::m[3] = {
+daObj_AutoMata_HIOParam const daObj_AutoMata_Param_c::m = {
     220.0f, 80.0f, 40.0f,
 };
 
@@ -49,11 +49,34 @@ static dCcD_SrcSph l_ccDSph = {
     } // mSphAttr
 };
 
+static OBJ_AUTOMATA_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_AutoMata_HIO_c::daObj_AutoMata_HIO_c() {
+    m = daObj_AutoMata_Param_c::m;
+}
+
+void daObj_AutoMata_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_AutoMata_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daObj_AutoMata_c::~daObj_AutoMata_c() {
     OS_REPORT("|%06d:%x|daObj_AutoMata_c -> デストラクト\n", g_Counter.mCounter0, this);
     if (mpMorf != NULL) {
         mpMorf->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     dComIfG_resDelete(&mPhase, l_resNameList[l_bmdData[field_0xb30][1]]);
 }
 
@@ -70,6 +93,12 @@ int daObj_AutoMata_c::create() {
         fopAcM_SetMtx(this, mpMorf->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -200.0f, -100.0f, -200.0f, 200.0f, 300.0f, 200.0f);
         mCreature.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("オ－トマタ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &field_0x834,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mStts.Init(0xff, 0, this);
@@ -143,10 +172,10 @@ int daObj_AutoMata_c::Execute() {
             mDoMtx_stack_c::copy(mpMorf->getModel()->getAnmMtx(3));
             mDoMtx_stack_c::multVec(&cStack_28, &sphCenter);
             mSph.SetC(sphCenter);
-            mSph.SetR(daObj_AutoMata_Param_c::m[2]);
+            mSph.SetR(mpHIO->m.field_0x8);
             dComIfG_Ccsp()->Set(&mSph);
-            mCyl.SetH(daObj_AutoMata_Param_c::m[0]);
-            mCyl.SetR(daObj_AutoMata_Param_c::m[1]);
+            mCyl.SetH(mpHIO->m.field_0x0);
+            mCyl.SetR(mpHIO->m.field_0x4);
             mCyl.SetC(current.pos);
             dComIfG_Ccsp()->Set(&mCyl);
         }
@@ -300,8 +329,6 @@ static int daObj_AutoMata_Draw(void* i_this) {
 static int daObj_AutoMata_IsDelete(void* i_this) {
     return 1;
 }
-
-static daObj_AutoMata_Param_c l_HIO;
 
 static actor_method_class daObj_AutoMata_MethodTable = {
     (process_method_func)daObj_AutoMata_Create,

--- a/src/d/actor/d_a_obj_boumato.cpp
+++ b/src/d/actor/d_a_obj_boumato.cpp
@@ -14,7 +14,7 @@
 
 static const char* dummyString() { return ""; }
 
-f32 const daObj_BouMato_Param_c::m[7] = {
+daObj_BouMato_HIOParam const daObj_BouMato_Param_c::m = {
     0.0f, -3.0f, 1.0f, 400.0f, 300.0f, 4.0f, 20.0f,
 };
 
@@ -39,8 +39,35 @@ static dCcD_SrcCyl l_ccDCyl = {
 
 static char* l_resName = "H_BouMato";
 
+static daArrow_c* l_findActorPtrs[100];
+
+static u32 l_findCount;
+
+static OBJ_BOUMATO_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_BouMato_HIO_c::daObj_BouMato_HIO_c() {
+    m = daObj_BouMato_Param_c::m;
+}
+
+void daObj_BouMato_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_BouMato_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daObj_BouMato_c::~daObj_BouMato_c() {
     OS_REPORT("|%06d:%x|daObj_BouMato_c -> デストラクト\n", g_Counter.mCounter0, this);
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     dComIfG_resDelete(&mPhase, getResName());
 }
 
@@ -58,6 +85,12 @@ int daObj_BouMato_c::create() {
         mModel->getModelData();
         fopAcM_SetMtx(this, mModel->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 450.0f, 300.0f);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("棒的");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                             &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -178,12 +211,12 @@ int daObj_BouMato_c::Execute() {
     cLib_addCalc2(field_0xa18 + 2, 0, 0.125f, 125.0f);
     setMtx();
     attention_info.position = current.pos;
-    attention_info.position.y += daObj_BouMato_Param_c::m[0];
+    attention_info.position.y += mpHIO->m.field_0x00;
     eyePos = attention_info.position;
     if (field_0xa38 == 0) {
         mCyl.SetC(current.pos);
-        mCyl.SetH(daObj_BouMato_Param_c::m[4]);
-        mCyl.SetR(daObj_BouMato_Param_c::m[5]);
+        mCyl.SetH(mpHIO->m.field_0x10);
+        mCyl.SetR(mpHIO->m.field_0x14);
         dComIfG_Ccsp()->Set(&mCyl);
     }
     mCyl.ClrTgHit();
@@ -197,7 +230,7 @@ int daObj_BouMato_c::Draw() {
         mDoExt_modelUpdateDL(mModel);
         if (mGroundH != -G_CM3D_F_INF) {
             mShadowId =
-                dComIfGd_setShadow(mShadowId, 1, mModel, &current.pos, daObj_BouMato_Param_c::m[3],
+                dComIfGd_setShadow(mShadowId, 1, mModel, &current.pos, mpHIO->m.field_0x0c,
                                    20.0f, current.pos.y, mGroundH, mGndChk, &tevStr, 0, 1.0f,
                                    dDlst_shadowControl_c::getSimpleTex());
         }
@@ -221,10 +254,6 @@ void daObj_BouMato_c::tgHitCallBack(fopAc_ac_c* param_1, dCcD_GObjInf* param_2,
     }
     static_cast<daObj_BouMato_c*>(param_1)->setCutType(cutType);
 }
-
-static daArrow_c* l_findActorPtrs[100];
-
-static u32 l_findCount;
 
 void* daObj_BouMato_c::srchArrow(void* param_1, void* param_2) {
     if (l_findCount < 100 && param_1 != NULL && param_1 != param_2) {
@@ -255,7 +284,7 @@ char* daObj_BouMato_c::getResName() {
 
 void daObj_BouMato_c::setSwayParam(fopAc_ac_c* param_1) {
     f32 dVar7 = 1.0f;
-    f32 local_48[3] = {0.0f, 0.0f, daObj_BouMato_Param_c::m[6]};;
+    f32 local_48[3] = {0.0f, 0.0f, mpHIO->m.field_0x18};
     field_0xa2a = (fopAcM_searchActorAngleY(this, param_1) - shape_angle.y) + 0x8000;
     field_0xa10 = 8;
     mIsCurTurnRight = false;
@@ -329,8 +358,6 @@ static int daObj_BouMato_Draw(void* i_this) {
 static int daObj_BouMato_IsDelete(void* i_this) {
     return 1;
 }
-
-static daObj_BouMato_Param_c l_HIO;
 
 static actor_method_class daObj_BouMato_MethodTable = {
     (process_method_func)daObj_BouMato_Create,

--- a/src/d/actor/d_a_obj_kago.cpp
+++ b/src/d/actor/d_a_obj_kago.cpp
@@ -14,7 +14,7 @@
 #include "d/d_com_inf_game.h"
 #include "f_op/f_op_actor_mng.h"
 
-daObj_Kago_Param_c::Data const daObj_Kago_Param_c::m = {
+daObj_Kago_HIOParam const daObj_Kago_Param_c::m = {
     0.0f,
     -5.0f,
     1.0f,
@@ -61,11 +61,33 @@ static dCcD_SrcCyl l_ccDCyl = {
     }
 };
 
+static OBJ_KAGO_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_Kago_HIO_c::daObj_Kago_HIO_c() {
+    m = daObj_Kago_Param_c::m;
+}
+
+void daObj_Kago_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_Kago_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daObj_Kago_c::~daObj_Kago_c() {
     OS_REPORT("|%06d:%x|daObj_Kago_c -> デストラクト\n", g_Counter.mCounter0, this);
     if (mType == 0 && daNpcT_chkTmpBit(7)) {
         daNpcT_onEvtBit(0x92);
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 
     dComIfG_resDelete(&mPhase, l_resNameList[l_bmdData[0][1]]);
 }
@@ -94,6 +116,12 @@ cPhs__Step daObj_Kago_c::create() {
 
         fopAcM_SetMtx(this, field_0x574->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -100.0f, -50.0f, -100.0f, 100.0f, 100.0f, 100.0f);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ウ－リのかご");
+#endif
+
         reset();
 
         if (mType == 0) {
@@ -101,11 +129,11 @@ cPhs__Step daObj_Kago_c::create() {
             health = 1;
         }
 
-        mAcchCir.SetWall(daObj_Kago_Param_c::m.mWallH, daObj_Kago_Param_c::m.mWallR);
+        mAcchCir.SetWall(mpHIO->m.mWallH, mpHIO->m.mWallR);
         mObjAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), 
                   fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mStts.Init(daObj_Kago_Param_c::m.mWeight, 0, this);
-        
+        mStts.Init(mpHIO->m.mWeight, 0, this);
+
         field_0x808[0].Set(l_ccDCyl);
         field_0x808[0].SetStts(&mStts);
         field_0x808[1].Set(l_ccDCyl);
@@ -154,26 +182,26 @@ int daObj_Kago_c::Delete() {
 int daObj_Kago_c::Execute() {
     int iVar1 = 0;
     f32 fVar1;
-    f32 reg_f30 = daObj_Kago_Param_c::m.field_0x28;
+    f32 reg_f30 = mpHIO->m.field_0x28;
     s16 sp_0xc = 0;
     s16 sVar2 = 0;
     int iVar3;
     s16 sp_0x8;
 
-    scale.set(daObj_Kago_Param_c::m.field_0x08 * field_0xb0c, daObj_Kago_Param_c::m.field_0x08 * field_0xb0c, daObj_Kago_Param_c::m.field_0x08 * field_0xb0c);
+    scale.set(mpHIO->m.field_0x08 * field_0xb0c, mpHIO->m.field_0x08 * field_0xb0c, mpHIO->m.field_0x08 * field_0xb0c);
     attention_info.flags = 0;
     fopAcM_OffCarryType(this, fopAcM_CARRY_CHICKEN);
     attention_info.distances[4] = 13;
 
     if (mType == 0) {
-        mStts.SetWeight(daObj_Kago_Param_c::m.mWeight);
-        mAcchCir.SetWall(daObj_Kago_Param_c::m.mWallH, 50.0f);
+        mStts.SetWeight(mpHIO->m.mWeight);
+        mAcchCir.SetWall(mpHIO->m.mWallH, 50.0f);
     } else {
         mStts.SetWeight(0xFF);
-        mAcchCir.SetWall(daObj_Kago_Param_c::m.mWallH, daObj_Kago_Param_c::m.mWallR);
+        mAcchCir.SetWall(mpHIO->m.mWallH, mpHIO->m.mWallR);
     }
 
-    gravity = daObj_Kago_Param_c::m.mGravity;
+    gravity = mpHIO->m.mGravity;
     iVar1 = 0;
     if ((fopAcM_checkCarryNow(this) != 0 || fopAcM_checkHawkCarryNow(this) != 0) || field_0xba2 != 0) {
         iVar1 = 1;
@@ -218,7 +246,7 @@ int daObj_Kago_c::Execute() {
         mObjAcch.ClrGrndNone();
 
         if (field_0xba0 != 0 && cM3d_IsZero(speedF) == 0) {
-            popup(daObj_Kago_Param_c::m.field_0x20, daObj_Kago_Param_c::m.field_0x24, NULL);
+            popup(mpHIO->m.field_0x20, mpHIO->m.field_0x24, NULL);
             if (fopAcM_carryOffRevise(this) != 0) {
                 speed.setall(0.0f);
             }
@@ -454,8 +482,8 @@ int daObj_Kago_c::Execute() {
             dComIfG_Ccsp()->Set(&field_0x808[1]);
         } else {
             field_0x808[0].ClrCoHit();
-            field_0x808[0].SetR(daObj_Kago_Param_c::m.mWallR);
-            field_0x808[0].SetH(daObj_Kago_Param_c::m.field_0x14);
+            field_0x808[0].SetR(mpHIO->m.mWallR);
+            field_0x808[0].SetH(mpHIO->m.field_0x14);
             field_0x808[0].SetC(current.pos);
             dComIfG_Ccsp()->Set(&field_0x808[0]);
         }
@@ -486,7 +514,7 @@ int daObj_Kago_c::Draw() {
             model = field_0x574;
         } else if (mGroundH != -G_CM3D_F_INF) {
             field_0xb78 = dComIfGd_setShadow(field_0xb78, 1, field_0x574, &current.pos,
-                                             daObj_Kago_Param_c::m.field_0x0c, 20.0f,
+                                             mpHIO->m.field_0x0c, 20.0f,
                                              current.pos.y, mGroundH, field_0x7cc, &tevStr,
                                              0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
         }
@@ -577,8 +605,6 @@ int daObj_Kago_c::getWallAngle(s16 param_1, s16* param_2) {
     *param_2 = cM_atan2s(sp5c.x, sp5c.z) + 0x4000;
     return 1;
 }
-
-static daObj_Kago_Param_c l_HIO;
 
 void daObj_Kago_c::setGoalPosAndAngle() {
     static cXyz pos(1593.0f, 659.0f, -334.0f);

--- a/src/d/actor/d_a_obj_kbacket.cpp
+++ b/src/d/actor/d_a_obj_kbacket.cpp
@@ -38,21 +38,27 @@ static dCcD_SrcCyl l_ccDCyl = {
     }
 };
 
-static daObj_KBacket_Param_c l_HIO;
+static OBJ_KBACKET_HIO_CLASS l_HIO;
 
-static inline const daObj_KBacket_HIOParam* get_params(daObj_KBacket_c* i_this) {
 #if DEBUG
-    return &i_this->mHIO->param;
-#else
-    return &daObj_KBacket_Param_c::m;
-#endif
+daObj_KBacket_HIO_c::daObj_KBacket_HIO_c() {
+    m = daObj_KBacket_Param_c::m;
 }
+
+void daObj_KBacket_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_KBacket_HIO_c::genMessage(JORMContext*) {
+    // NONMATCHING
+}
+#endif
 
 daObj_KBacket_c::~daObj_KBacket_c() {
     OS_REPORT("|%06d:%x|daObj_KBacket_c -> デストラクト\n", g_Counter.mCounter0, this);
 #if DEBUG
-    if (mHIO != NULL) {
-        mHIO->removeHIO();
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
     }
 #endif
     dComIfG_resDelete(&field_0x56c, l_resNameList[l_bmdData[field_0x9d0 * 2 + 1]]);
@@ -79,8 +85,8 @@ int daObj_KBacket_c::create() {
         fopAcM_setCullSizeBox(this, -50.0f, -50.0f, -50.0f, 50.0f, 50.0f, 50.0f);
 
 #if DEBUG
-        //TODO: init mHIO
-        mHIO->entryHIO("カカシのバケツ");
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("カカシのバケツ");
 #endif
 
         reset();
@@ -92,7 +98,7 @@ int daObj_KBacket_c::create() {
         mObjAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                         &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                         fopAcM_GetShapeAngle_p(this));
-        mStts.Init(get_params(this)->field_0x10, 0, this);
+        mStts.Init(mpHIO->m.field_0x10, 0, this);
         mCyl.Set(l_ccDCyl);
         mCyl.SetStts(&mStts);
         mObjAcch.CrrPos(dComIfG_Bgsp());
@@ -143,8 +149,8 @@ int daObj_KBacket_c::Delete() {
 
 int daObj_KBacket_c::Execute() {
 
-    f32 movePMag = get_params(this)->field_0x28;
-    f32 scaleFactor = get_params(this)->field_0x8;
+    f32 movePMag = mpHIO->m.field_0x28;
+    f32 scaleFactor = mpHIO->m.field_0x08;
     s16 wallAngle = 0;
     scale.set(scaleFactor, scaleFactor, scaleFactor);
 
@@ -152,10 +158,10 @@ int daObj_KBacket_c::Execute() {
 
     attention_info.distances[4] = 6;
 
-    mAcchCir.SetWallR(get_params(this)->field_0x1c);
-    mAcchCir.SetWallH(get_params(this)->field_0x18);
+    mAcchCir.SetWallR(mpHIO->m.field_0x1c);
+    mAcchCir.SetWallH(mpHIO->m.field_0x18);
 
-    gravity = get_params(this)->field_0x4;
+    gravity = mpHIO->m.field_0x04;
 
     BOOL isCarry = FALSE;
     if (fopAcM_checkCarryNow(this) != 0) {
@@ -200,14 +206,14 @@ int daObj_KBacket_c::Execute() {
     } else {
         s16 wallAngleDiff; // needs to be declared up here for regalloc
 
-        mStts.SetWeight(get_params(this)->field_0x10);
+        mStts.SetWeight(mpHIO->m.field_0x10);
         mObjAcch.ClrWallNone();
         mObjAcch.ClrGrndNone();
         if (field_0xa49 != 0 && cM3d_IsZero(speedF) == FALSE) {
-            s16 angle = cM_deg2s(get_params(this)->field_0x24);
+            s16 angle = cM_deg2s(mpHIO->m.field_0x24);
             speed.setall(0.0f);
-            speed.y = get_params(this)->field_0x20 * cM_ssin(angle);
-            speedF = get_params(this)->field_0x20 * cM_scos(angle);
+            speed.y = mpHIO->m.field_0x20 * cM_ssin(angle);
+            speedF = mpHIO->m.field_0x20 * cM_scos(angle);
 
             field_0xa18 = 0x4000;
 
@@ -494,8 +500,8 @@ int daObj_KBacket_c::Execute() {
         field_0xa18 = calcRollAngle(field_0xa18, 0x10000);
     }
 
-    mCyl.SetR(get_params(this)->field_0x1c);
-    mCyl.SetH(get_params(this)->field_0x14);
+    mCyl.SetR(mpHIO->m.field_0x1c);
+    mCyl.SetH(mpHIO->m.field_0x14);
     mCyl.SetC(current.pos);
 
     dComIfG_Ccsp()->Set(&mCyl);

--- a/src/d/actor/d_a_obj_pleaf.cpp
+++ b/src/d/actor/d_a_obj_pleaf.cpp
@@ -9,11 +9,33 @@
 
 static char* l_resName = "J_Hatake";
 
-daObj_Pleaf_c::~daObj_Pleaf_c() {
-    dComIfG_resDelete(&mPhaseReq, getResName());
+daObj_Pleaf_HIOParam const daObj_Pleaf_Param_c::m = {0, -3.0f, 1.0f, 900.0f};
+
+static OBJ_PLEAF_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_Pleaf_HIO_c::daObj_Pleaf_HIO_c() {
+    m = daObj_Pleaf_Param_c::m;
 }
 
-daObj_Pleaf_Param_c::params const daObj_Pleaf_Param_c::m = {0, -3.0f, 1.0f, 900.0f};
+void daObj_Pleaf_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_Pleaf_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daObj_Pleaf_c::~daObj_Pleaf_c() {
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    dComIfG_resDelete(&mPhaseReq, getResName());
+}
 
 int daObj_Pleaf_c::create() {
     fopAcM_ct(this, daObj_Pleaf_c);
@@ -28,6 +50,12 @@ int daObj_Pleaf_c::create() {
         }
         fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -300.0f, -50.0f, -300.0f, 300.0f, 50.0f, 300.0f);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("かぼちゃ畑の葉っぱ");
+#endif
+
         mObjAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                      fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                      fopAcM_GetShapeAngle_p(this));
@@ -85,7 +113,7 @@ int daObj_Pleaf_c::Draw() {
     if (mGroundDist != -G_CM3D_F_INF) {
         mShadowKey =
             dComIfGd_setShadow(mShadowKey, 1, mpModel, &current.pos,
-                               daObj_Pleaf_Param_c::m.field_0xc, 20.0f, current.pos.y, mGroundDist,
+                               mpHIO->m.field_0xc, 20.0f, current.pos.y, mGroundDist,
                                mGndChk, &tevStr, 0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
     }
     return 1;
@@ -166,5 +194,3 @@ actor_process_profile_definition g_profile_OBJ_PLEAF = {
     fopAc_ACTOR_e,             // mActorType
     fopAc_CULLBOX_CUSTOM_e,    // cullType
 };
-
-static daObj_Pleaf_Param_c l_HIO;

--- a/src/d/actor/d_a_obj_sekidoor.cpp
+++ b/src/d/actor/d_a_obj_sekidoor.cpp
@@ -6,7 +6,7 @@
 #include "d/dolzel_rel.h" // IWYU pragma: keep
 
 #include "d/actor/d_a_obj_sekidoor.h"
-   
+
 
 static struct {
     u32 bmdIdx;
@@ -20,11 +20,33 @@ static struct {
 
 static char* l_resNameList[2] = {"", "SekiDoor"};
 
+static OBJ_SEKIDOOR_HIO_CLASS l_HIO;
+
+const daObj_SekiDoor_HIOParam daObj_SekiDoor_Param_c::m = {0};
+
+static const f32 reference_posy = 460.0f;
+
+static const f32 rising_speed_y = 4.0f;
+
+#if DEBUG
+daObj_SekiDoor_HIO_c::daObj_SekiDoor_HIO_c() {
+    m = daObj_SekiDoor_Param_c::m;
+}
+
+void daObj_SekiDoor_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_SekiDoor_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 int daObj_SekiDoor_c::create() {
     fopAcM_ct(this, daObj_SekiDoor_c);
 
     mBitSW = 0;
-    
+
     cPhs__Step step = (cPhs__Step)dComIfG_resLoad(&mPhaseReq, l_resNameList[l_bmdData[mBitSW].resIdx]);
     if (step == cPhs_COMPLEATE_e) {
         if (getBitSW() != 0xff){
@@ -72,17 +94,16 @@ int daObj_SekiDoor_c::Create() {
 }
 
 int daObj_SekiDoor_c::Delete() {
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     dComIfG_resDelete(&mPhaseReq, l_resNameList[l_bmdData[mBitSW].resIdx]);
 
     return 1;
 }
-
-
-const u8 daObj_SekiDoor_Param_c::m = 0;
-
-static const f32 reference_posy = 460.0f;
-
-static const f32 rising_speed_y = 4.0f;
 
 
 int daObj_SekiDoor_c::Execute(Mtx** i_mtx) {
@@ -245,9 +266,6 @@ static int daObj_SekiDoor_Draw(void* i_this) {
 static int daObj_SekiDoor_IsDelete(void* param_0) {
     return 1;
 }
-
-
-static daObj_SekiDoor_Param_c l_HIO;
 
 static actor_method_class daObj_SekiDoor_MethodTable = {
     (process_method_func)daObj_SekiDoor_Create,

--- a/src/d/actor/d_a_obj_sekizo.cpp
+++ b/src/d/actor/d_a_obj_sekizo.cpp
@@ -21,6 +21,26 @@ static struct {
 
 static char* l_resNameList[2] = {"", "Sekizo"};
 
+static u8 lit_3800[12];
+
+daObj_Sekizo_HIOParam const daObj_Sekizo_Param_c::m = {};
+
+static OBJ_SEKIZO_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_Sekizo_HIO_c::daObj_Sekizo_HIO_c() {
+    m = daObj_Sekizo_Param_c::m;
+}
+
+void daObj_Sekizo_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_Sekizo_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 cPhs__Step daObj_Sekizo_c::create() {
     fopAcM_ct(this, daObj_Sekizo_c);
 
@@ -59,6 +79,12 @@ int daObj_Sekizo_c::Create() {
 }
 
 int daObj_Sekizo_c::Delete() {
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     dComIfG_resDelete(&mPhaseReq, l_resNameList[l_bmdData[field_0x5b0].resIdx]);
     return 1;
 }
@@ -122,10 +148,6 @@ static int daObj_Sekizo_Draw(void* i_this) {
 static int daObj_Sekizo_IsDelete(void* i_this) {
     return 1;
 }
-
-static u8 lit_3800[12];
-
-static daObj_Sekizo_Param_c l_HIO;
 
 static actor_method_class daObj_Sekizo_MethodTable = {
     (process_method_func)daObj_Sekizo_Create, (process_method_func)daObj_Sekizo_Delete,

--- a/src/d/actor/d_a_obj_sekizoa.cpp
+++ b/src/d/actor/d_a_obj_sekizoa.cpp
@@ -115,11 +115,28 @@ static cXyz l_srcPosR(-600.0f, 1000.0f, 1800.0f);
 
 static cXyz l_srcPosL(600.0f, 1000.0f, 1800.0f);
 
-daObj_Sekizoa_Param_c::Data const daObj_Sekizoa_Param_c::m = {
-    600.0, -10.0, 1.0, 1100.0, 255.0, 550.0, 100.0, 70.0, 0.0, 0.0,   30.0, 0.0,   30.0,     -30.0,
-    45.0,  -45.0, 0.6, 8.0,    0x3,   0x6,   0x5,   0x6,  0.0, 0.0,   0.0,  0.0,   0x3C0008, 0.0,
-    0.0,   4.0,   0.0, 0.0,    0.0,   0.0,   0.0,   0.0,  0.0, 600.0, 30.0, 0.004, 0,
+daObj_Sekizoa_HIOParam const daObj_Sekizoa_Param_c::m = {
+    600.0f, -10.0f, 1.0f,   1100.0f, 255.0f,   550.0f, 100.0f, 70.0f, 0.0f, 0.0f, 30.0f,
+    0.0f,   30.0f,  -30.0f, 45.0f,   -45.0f,   0.6f,   8.0f,   0x3,   0x6,  0x5,  0x6,
+    0.0f,   0.0f,   0.0f,   0.0f,    0x3C0008, 0.0f,   0.0f,   4.0f,  0.0f, 0.0f, 0.0f,
+    0.0f,   0.0f,   0.0f,   0.0f,    600.0f,   30.0f,  0.004f, 0,
 };
+
+static OBJ_SEKIZOA_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_Sekizoa_HIO_c::daObj_Sekizoa_HIO_c() {
+    m = daObj_Sekizoa_Param_c::m;
+}
+
+void daObj_Sekizoa_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_Sekizoa_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
 
 daObj_Sekizoa_c::~daObj_Sekizoa_c() {
     if (mpMorf[0] != NULL) {
@@ -131,6 +148,13 @@ daObj_Sekizoa_c::~daObj_Sekizoa_c() {
     if (mpMorf[1] != NULL) {
         mpMorf[1]->stopZelAnime();
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     if (mType == TYPE_0) {
         if (daNpcT_chkTmpBit(0x31)) {
             mDoAud_subBgmStop();
@@ -164,11 +188,17 @@ int daObj_Sekizoa_c::create() {
         fopAcM_SetMtx(this, mpMorf[0]->getModel()->getBaseTRMtx());
         fopAcM_setCullSizeBox2(this, mpModelData);
         mSound.init(&current.pos, &eyePos, 3, 1);
+        
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("石像");
+#endif
+        
         reset();
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                     &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this),
                     fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daObj_Sekizoa_Param_c::m.field_0x10, 0,
+        mCcStts.Init(mpHIO->m.inner.field_0x10, 0,
                         this);
 
         mCyl.Set(mCcDCyl);
@@ -455,19 +485,19 @@ void daObj_Sekizoa_c::setParam() {
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = 0x13;
     attention_info.flags = 0;
-    scale.set(daObj_Sekizoa_Param_c::m.field_0x08, daObj_Sekizoa_Param_c::m.field_0x08,
-              daObj_Sekizoa_Param_c::m.field_0x08);
-    mCcStts.SetWeight(daObj_Sekizoa_Param_c::m.field_0x10);
-    mCylH = daObj_Sekizoa_Param_c::m.field_0x14;
-    mWallR = daObj_Sekizoa_Param_c::m.field_0x1C;
-    mAttnFovY = daObj_Sekizoa_Param_c::m.field_0x50;
+    scale.set(mpHIO->m.inner.field_0x08, mpHIO->m.inner.field_0x08,
+              mpHIO->m.inner.field_0x08);
+    mCcStts.SetWeight(mpHIO->m.inner.field_0x10);
+    mCylH = mpHIO->m.inner.field_0x14;
+    mWallR = mpHIO->m.inner.field_0x1C;
+    mAttnFovY = mpHIO->m.inner.field_0x50;
 
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daObj_Sekizoa_Param_c::m.field_0x18);
-    mRealShadowSize = daObj_Sekizoa_Param_c::m.field_0x0C;
-    mExpressionMorfFrame = daObj_Sekizoa_Param_c::m.field_0x6C;
-    mMorfFrames = daObj_Sekizoa_Param_c::m.field_0x44;
-    gravity = daObj_Sekizoa_Param_c::m.field_0x04;
+    mAcchCir.SetWallH(mpHIO->m.inner.field_0x18);
+    mRealShadowSize = mpHIO->m.inner.field_0x0C;
+    mExpressionMorfFrame = mpHIO->m.inner.field_0x6C;
+    mMorfFrames = mpHIO->m.inner.field_0x44;
+    gravity = mpHIO->m.inner.field_0x04;
 
     if (mType == TYPE_2 || mType == TYPE_3) {
         gravity = 0.0f;
@@ -685,11 +715,11 @@ void daObj_Sekizoa_c::setAttnPos() {
     mStagger.calc(0);
     f32 rad_angle_y = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.setParam(this, mpMorf[0]->getModel(), &vec_pos, getBackboneJointNo(), getNeckJointNo(),
-                     getHeadJointNo(), daObj_Sekizoa_Param_c::m.field_0x24,
-                     daObj_Sekizoa_Param_c::m.field_0x20, daObj_Sekizoa_Param_c::m.field_0x2C,
-                     daObj_Sekizoa_Param_c::m.field_0x28, daObj_Sekizoa_Param_c::m.field_0x34,
-                     daObj_Sekizoa_Param_c::m.field_0x30, daObj_Sekizoa_Param_c::m.field_0x3C,
-                     daObj_Sekizoa_Param_c::m.field_0x38, daObj_Sekizoa_Param_c::m.field_0x40, 0.0f,
+                     getHeadJointNo(), mpHIO->m.inner.field_0x24,
+                     mpHIO->m.inner.field_0x20, mpHIO->m.inner.field_0x2C,
+                     mpHIO->m.inner.field_0x28, mpHIO->m.inner.field_0x34,
+                     mpHIO->m.inner.field_0x30, mpHIO->m.inner.field_0x3C,
+                     mpHIO->m.inner.field_0x38, mpHIO->m.inner.field_0x40, 0.0f,
                      NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, rad_angle_y);
     setMtx();
@@ -720,7 +750,7 @@ void daObj_Sekizoa_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos, mCurAngle.y, 1, 1.0f, 0);
     attention_info.position = current.pos;
-    attention_info.position.y += daObj_Sekizoa_Param_c::m.field_0x00;
+    attention_info.position.y += mpHIO->m.inner.field_0x00;
 }
 
 
@@ -1070,19 +1100,19 @@ int daObj_Sekizoa_c::checkMoveDirection() {
     cXyz temp_vec;
     cXyz temp_vec2;
 
-    f32 temp_float_y = daObj_Sekizoa_Param_c::m.field_0x00 * 0.33f;
+    f32 temp_float_y = mpHIO->m.inner.field_0x00 * 0.33f;
     fopAc_ac_c* actor_3 = mActorMngrs[3].getActorP();
-    temp_vec.set(0.0f, 0.0f, daObj_Sekizoa_Param_c::m.field_0x8C);
+    temp_vec.set(0.0f, 0.0f, mpHIO->m.field_0x8C);
     mDoMtx_stack_c::transS(current.pos);
     mDoMtx_stack_c::YrotM(current.angle.y);
     mDoMtx_stack_c::multVec(&temp_vec, &temp_vec2);
-    if (chkPointInArea(actor_3->current.pos, temp_vec2, daObj_Sekizoa_Param_c::m.field_0x8C / 2,
+    if (chkPointInArea(actor_3->current.pos, temp_vec2, mpHIO->m.field_0x8C / 2,
                        300.0f, -300.0f, 0) == false)
     {
         temp_vec2.y += 10.0f;
         mGndChk.SetPos(&temp_vec2);
         if (fabsf(dComIfG_Bgsp().GroundCross(&mGndChk) - current.pos.y) < 0.1f) {
-            temp_vec.set(0.0f, temp_float_y, daObj_Sekizoa_Param_c::m.field_0x8C);
+            temp_vec.set(0.0f, temp_float_y, mpHIO->m.field_0x8C);
             mDoMtx_stack_c::YrotS(current.angle.y);
             mDoMtx_stack_c::multVec(&temp_vec, &temp_vec2);
             temp_vec2 = current.pos + temp_vec2;
@@ -1207,7 +1237,7 @@ void daObj_Sekizoa_c::jump() {
                     break;
                 }
                 mCXyzJump = current.pos;
-                mJumpSpeed = daObj_Sekizoa_Param_c::m.field_0x90;
+                mJumpSpeed = mpHIO->m.field_0x90;
                 return;
             }
         } else {
@@ -1222,27 +1252,27 @@ void daObj_Sekizoa_c::jump() {
                     mSound.startCreatureVoice(Z2SE_SEKI_V_COL2, -1);
                     mSound.startCreatureSound(Z2SE_SEKI_JUMP_COL, 0, -1);
                 }
-                mJumpSpeed = daObj_Sekizoa_Param_c::m.field_0x90;
+                mJumpSpeed = mpHIO->m.field_0x90;
                 mJump = 3;
             }
             if (mJump == 2) {
-                cLib_chaseF(&mJumpHeight, daObj_Sekizoa_Param_c::m.field_0x8C, mJumpSpeed);
+                cLib_chaseF(&mJumpHeight, mpHIO->m.field_0x8C, mJumpSpeed);
             } else {
                 cLib_chaseF(&mJumpHeight, 0.0f, mJumpSpeed);
             }
 
-            f32 var_f31 = daObj_Sekizoa_Param_c::m.field_0x94;
-            f32 var_f29 = var_f31 * ((daObj_Sekizoa_Param_c::m.field_0x8C * 0.5f) *
-                                     (daObj_Sekizoa_Param_c::m.field_0x8C * 0.5f));
-            f32 var_f30 = mJumpHeight - (daObj_Sekizoa_Param_c::m.field_0x8C * 0.5f);
+            f32 var_f31 = mpHIO->m.field_0x94;
+            f32 var_f29 = var_f31 * ((mpHIO->m.field_0x8C * 0.5f) *
+                                     (mpHIO->m.field_0x8C * 0.5f));
+            f32 var_f30 = mJumpHeight - (mpHIO->m.field_0x8C * 0.5f);
 
             temp_vec.set(0.0f, var_f29 + (-var_f31 * (var_f30 * var_f30)), mJumpHeight);
 
             mDoMtx_stack_c::YrotS(current.angle.y);
             mDoMtx_stack_c::multVec(&temp_vec, &temp_vec2);
             current.pos = mCXyzJump + temp_vec2;
-            cLib_chaseF(&mJumpSpeed, daObj_Sekizoa_Param_c::m.field_0x90 * 0.5f, 0.25f);
-            if (mJumpHeight <= 0 || daObj_Sekizoa_Param_c::m.field_0x8C <= mJumpHeight) {
+            cLib_chaseF(&mJumpSpeed, mpHIO->m.field_0x90 * 0.5f, 0.25f);
+            if (mJumpHeight <= 0 || mpHIO->m.field_0x8C <= mJumpHeight) {
                 landing();
                 mJump = 4;
                 return;
@@ -2322,7 +2352,7 @@ int daObj_Sekizoa_c::puzzle(void* param_0) {
                 }
                 if (daPy_getPlayerActorClass()->checkPlayerFly() != 0) {
                     if (mType == TYPE_0) {
-                        mLatencyTime = daObj_Sekizoa_Param_c::m.field_0x98;
+                        mLatencyTime = mpHIO->m.field_0x98;
                         mEvtNo = 5;
                     }
                 } else {
@@ -2409,9 +2439,6 @@ static int daObj_Sekizoa_Draw(void* i_this) {
 static int daObj_Sekizoa_IsDelete(void* i_this) {
     return 1;
 }
-
-
-static daObj_Sekizoa_Param_c l_HIO;
 
 static actor_method_class daObj_Sekizoa_MethodTable = {
     daObj_Sekizoa_Create,   daObj_Sekizoa_Delete, daObj_Sekizoa_Execute,

--- a/src/d/actor/d_a_obj_smtile.cpp
+++ b/src/d/actor/d_a_obj_smtile.cpp
@@ -27,8 +27,33 @@ static s8 l_tileMoveData[21][4] = {
     0x02, 0x02, -0x1, 0x03, 0x05, 0x02, -0x1, 0x02, 0x04, 0x02, -0x1, 0x01, 0x03, 0x02,
 };
 
+static OBJ_SMTILE_HIO_CLASS l_HIO;
+
+daObj_SMTile_HIOParam const daObj_SMTile_Param_c::m = {600.0f, 20.0f};
+
+#if DEBUG
+daObj_SMTile_HIO_c::daObj_SMTile_HIO_c() {
+    m = daObj_SMTile_Param_c::m;
+}
+
+void daObj_SMTile_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_SMTile_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daObj_SMTile_c::~daObj_SMTile_c() {
     OS_REPORT("|%06d:%x|daObj_SMTile_c -> デストラクト\n", g_Counter.mCounter0, this);
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     dComIfG_resDelete(
         &mPhase,
         l_resNameList[l_bmdData[mType][1]]);
@@ -53,15 +78,17 @@ int daObj_SMTile_c::create() {
         if (fopAcM_entrySolidHeap(this, createHeapCallBack, 0x800) == 0) {
             return cPhs_ERROR_e;
         }
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("石像の間の光るタイル");
+#endif
+
         field_0xb2b = 1;
         Execute();
     }
     return rv;
 }
-
-f32 const daObj_SMTile_Param_c::m[2] = {
-    600.0f, 20.0f,
-};
 
 int daObj_SMTile_c::CreateHeap() {
     J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes(
@@ -191,8 +218,8 @@ void daObj_SMTile_c::setDstPos() {
         local_2c.x = l_tileMoveData[i][0];
         local_2c.z = l_tileMoveData[i][1];
         local_38 = local_2c;
-        local_38.x *= daObj_SMTile_Param_c::m[0];
-        local_38.z *= daObj_SMTile_Param_c::m[0];
+        local_38.x *= mpHIO->m.field_0x0;
+        local_38.z *= mpHIO->m.field_0x0;
         mDoMtx_stack_c::multVec(&local_38, &field_0x68c[i]);
         switch ((u8)l_tileMoveData[i][3]) {
         case 0:
@@ -209,8 +236,8 @@ void daObj_SMTile_c::setDstPos() {
             break;    
         }
 
-        local_2c.x *= daObj_SMTile_Param_c::m[0];
-        local_2c.z *= daObj_SMTile_Param_c::m[0];
+        local_2c.x *= mpHIO->m.field_0x0;
+        local_2c.z *= mpHIO->m.field_0x0;
         mDoMtx_stack_c::multVec(&local_2c, &field_0x590[i]);
     }
 }
@@ -225,7 +252,7 @@ void daObj_SMTile_c::setPrtcls(int param_1, int param_2) {
                     mDoAud_seStart(Z2SE_OBJ_SEKI_TILE_EMERGE, &field_0x788[i], 0, 0);
                 }
                 field_0x788[i] = current.pos + field_0x68c[i];
-                mParticleTimers[i] = daObj_SMTile_Param_c::m[1];
+                mParticleTimers[i] = mpHIO->m.field_0x4;
                 field_0xa28[i] = param_1;
             }
         }
@@ -254,21 +281,21 @@ void daObj_SMTile_c::touchPrtcls(f32 param_1) {
                 dComIfGp_particle_set(mParticleIds[i], id[field_0xa28[i]], &field_0x788[i], 0, 0);
             JPABaseEmitter* emitter = dComIfGp_particle_getEmitter(mParticleIds[i]);
             if (emitter != NULL) {
-                f32 dVar6 = daObj_SMTile_Param_c::m[1] - mParticleTimers[i];
-                dVar6 /= daObj_SMTile_Param_c::m[1];
+                f32 dVar6 = mpHIO->m.field_0x4 - mParticleTimers[i];
+                dVar6 /= mpHIO->m.field_0x4;
                 local_3c.setall(0.0f);
                 switch ((u8)l_tileMoveData[i][3]) {
                 case 0:
-                    local_3c.z = daObj_SMTile_Param_c::m[0] * dVar6;
+                    local_3c.z = mpHIO->m.field_0x0 * dVar6;
                     break;
                 case 1:
-                    local_3c.x = daObj_SMTile_Param_c::m[0] * dVar6;
+                    local_3c.x = mpHIO->m.field_0x0 * dVar6;
                     break;
                 case 2:
-                    local_3c.x = daObj_SMTile_Param_c::m[0] * dVar6 * -1.0f;
+                    local_3c.x = mpHIO->m.field_0x0 * dVar6 * -1.0f;
                     break;
                 case 3:
-                    local_3c.z = daObj_SMTile_Param_c::m[0] * dVar6 * -1.0f;
+                    local_3c.z = mpHIO->m.field_0x0 * dVar6 * -1.0f;
                     break;
                 }
 
@@ -312,8 +339,6 @@ static int daObj_SMTile_Draw(void* i_this) {
 static int daObj_SMTile_IsDelete(void* i_this) {
     return 1;
 }
-
-static daObj_SMTile_Param_c l_HIO;
 
 static actor_method_class daObj_SMTile_MethodTable = {
     (process_method_func)daObj_SMTile_Create,

--- a/src/d/actor/d_a_obj_stick.cpp
+++ b/src/d/actor/d_a_obj_stick.cpp
@@ -11,7 +11,7 @@
 #include "m_Do/m_Do_ext.h"
 #include "d/actor/d_a_npc.h"
 
-const daObj_Stick_Param_c::daObj_Stick_HIOParam daObj_Stick_Param_c::m = {
+const daObj_Stick_HIOParam daObj_Stick_Param_c::m = {
     0.0f, -3.0f, 1.0f, 100.0f
 };
 
@@ -24,7 +24,29 @@ dCcD_SrcSph daObj_Stick_c::mCcDSph = {
 
 static char* l_resName = "Taro6";
 
+static OBJ_STICK_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_Stick_HIO_c::daObj_Stick_HIO_c() {
+    m = daObj_Stick_Param_c::m;
+}
+
+void daObj_Stick_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_Stick_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daObj_Stick_c::~daObj_Stick_c() {
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
     dComIfG_resDelete(&mPhase, getResName());
 }
 
@@ -47,6 +69,12 @@ int daObj_Stick_c::create() {
         modelData = mpModel->getModelData();
         fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -50.0, -50.0, -75.0, 50.0, 50.0, 75.0);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("タロの棒");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), 
             fopAcM_GetOldPosition_p(this), 
             this, 
@@ -105,7 +133,7 @@ int daObj_Stick_c::Execute() {
     setMtx();
     mSph.ClrCoHit();
     attention_info.position = current.pos;
-    attention_info.position.y += daObj_Stick_Param_c::m.attention_offset;
+    attention_info.position.y += mpHIO->m.attention_offset;
     eyePos = attention_info.position;
     attention_info.flags = 0;
     
@@ -122,7 +150,7 @@ int daObj_Stick_c::Draw() {
             1, 
             mpModel, 
             &current.pos, 
-            daObj_Stick_Param_c::m.real_shadow_size, 
+            mpHIO->m.real_shadow_size,
             20.0f, 
             current.pos.y,
             mGroundHeight, 
@@ -214,5 +242,3 @@ actor_process_profile_definition g_profile_OBJ_STICK = {
   fopAc_ACTOR_e,            // mActorType
   fopAc_CULLBOX_CUSTOM_e,   // cullType
 };
-
-static daObj_Stick_Param_c l_HIO;

--- a/src/d/actor/d_a_obj_tks.cpp
+++ b/src/d/actor/d_a_obj_tks.cpp
@@ -51,6 +51,12 @@ daObjTks_c::~daObjTks_c() {
     if (parentActorID != fpcM_ERROR_PROCESS_ID_e) {
         fopAcM_delete(parentActorID);
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 }
 
 const daObjTks_HIOParam daObjTks_Param_c::m = {
@@ -94,6 +100,18 @@ const daObjTks_HIOParam daObjTks_Param_c::m = {
     0.8f,
 };
 
+static OBJ_TKS_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObjTks_HIO_c::daObjTks_HIO_c() {
+    m = daObjTks_Param_c::m;
+}
+
+void daObjTks_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 int daObjTks_c::Create() {
     fopAcM_ct(this, daObjTks_c);
 
@@ -109,12 +127,18 @@ int daObjTks_c::Create() {
 
         mSound.init(&current.pos, &eyePos, 3, 1);
 
-        mAcchCir.SetWall(daObjTks_Param_c::m.common.width, daObjTks_Param_c::m.common.knee_length);
-        mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("おばちゃんアイテム");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.common.width, mpHIO->m.common.knee_length);
+        mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
+                  fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
         mAcch.OffClrSpeedY();
         mAcch.SetWallNone();
     
-        mCcStts.Init(daObjTks_Param_c::m.common.weight, 0, this);
+        mCcStts.Init(mpHIO->m.common.weight, 0, this);
         mCcCyl.Set(mCcDCyl);
         mCcCyl.SetStts(&mCcStts);
         mCcCyl.SetTgType(0);
@@ -122,8 +146,8 @@ int daObjTks_c::Create() {
         mCcCyl.SetCoIGrp(8);
         mCcCyl.SetCoVsGrp(0x40);
 
-        mCcCyl.SetH(daObjTks_Param_c::m.common.height);
-        mCcCyl.SetR(daObjTks_Param_c::m.common.width);
+        mCcCyl.SetH(mpHIO->m.common.height);
+        mCcCyl.SetR(mpHIO->m.common.width);
 
         mAcch.CrrPos(dComIfG_Bgsp());
 
@@ -209,7 +233,7 @@ int daObjTks_c::Draw() {
     }
 
     mAnm_p->getModel()->getModelData()->getMaterialNodePointer(2)->setMaterialAnm(mpMatAnm);
-    draw(FALSE, FALSE, daObjTks_Param_c::m.common.real_shadow_size, NULL, FALSE);
+    draw(FALSE, FALSE, mpHIO->m.common.real_shadow_size, NULL, FALSE);
     return 1;
 }
 
@@ -234,7 +258,7 @@ int daObjTks_c::ctrlJoint(J3DJoint* i_joint, J3DModel* i_model) {
     case 15:
     case 16:
     case 17:
-        setLookatMtx(jnt_no, spC, daObjTks_Param_c::m.common.neck_rotation_ratio);
+        setLookatMtx(jnt_no, spC, mpHIO->m.common.neck_rotation_ratio);
         break;
     }
 
@@ -369,7 +393,7 @@ void daObjTks_c::reset() {
     daPy_py_c* player = daPy_getPlayerActorClass();
     mDoMtx_stack_c::transS(*fopAcM_GetPosition_p(player));
     mDoMtx_stack_c::YrotM(fopAcM_GetAngle_p(player)->y);
-    mDoMtx_stack_c::transM(daObjTks_Param_c::m.offset_x, daObjTks_Param_c::m.offset_y, daObjTks_Param_c::m.offset_z);
+    mDoMtx_stack_c::transM(mpHIO->m.offset_x, mpHIO->m.offset_y, mpHIO->m.offset_z);
     mDoMtx_stack_c::multVecZero(&home.pos);
     old.pos = home.pos;
     current.pos = home.pos;
@@ -432,10 +456,10 @@ void daObjTks_c::setExpression(int i_expression, f32 i_morf) {
 }
 
 void daObjTks_c::playExpression() {
-    daNpcF_anmPlayData anm0_phase1 = {1, daObjTks_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm0_phase1 = {1, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm0_m[] = {&anm0_phase1};
 
-    daNpcF_anmPlayData anm1_phase1 = {0, daObjTks_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm1_phase1 = {0, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm1_m[] = {&anm1_phase1};
 
     daNpcF_anmPlayData** anmData_p[] = {anm0_m, anm1_m};
@@ -446,16 +470,16 @@ void daObjTks_c::playExpression() {
 }
 
 void daObjTks_c::playMotion() {
-    daNpcF_anmPlayData anm0_phase1 = {2, daObjTks_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm0_phase1 = {2, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm0_m[] = {&anm0_phase1};
 
-    daNpcF_anmPlayData anm1_phase1 = {3, daObjTks_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData anm1_phase1 = {3, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData* anm1_m[] = {&anm1_phase1, NULL};
 
-    daNpcF_anmPlayData anm2_phase1 = {4, daObjTks_Param_c::m.common.morf_frame, 0};
+    daNpcF_anmPlayData anm2_phase1 = {4, mpHIO->m.common.morf_frame, 0};
     daNpcF_anmPlayData* anm2_m[] = {&anm2_phase1};
 
-    daNpcF_anmPlayData anm3_phase1 = {5, daObjTks_Param_c::m.common.morf_frame, 1};
+    daNpcF_anmPlayData anm3_phase1 = {5, mpHIO->m.common.morf_frame, 1};
     daNpcF_anmPlayData* anm3_m[] = {&anm3_phase1, NULL};
 
     daNpcF_anmPlayData** anmData_p[] = {anm0_m, anm1_m, anm2_m, anm3_m};
@@ -470,14 +494,14 @@ void daObjTks_c::lookat() {
     J3DModel* model_p = mAnm_p->getModel();
 
     int var_r28 = 0;
-    f32 body_angleX_min = daObjTks_Param_c::m.common.body_angleX_min;
-    f32 body_angleX_max = daObjTks_Param_c::m.common.body_angleX_max;
-    f32 body_angleY_min = daObjTks_Param_c::m.common.body_angleY_min;
-    f32 body_angleY_max = daObjTks_Param_c::m.common.body_angleY_max;
-    f32 head_angleX_min = daObjTks_Param_c::m.common.head_angleX_min;
-    f32 head_angleX_max = daObjTks_Param_c::m.common.head_angleX_max;
-    f32 head_angleY_min = daObjTks_Param_c::m.common.head_angleY_min;
-    f32 head_angleY_max = daObjTks_Param_c::m.common.head_angleY_max;
+    f32 body_angleX_min = mpHIO->m.common.body_angleX_min;
+    f32 body_angleX_max = mpHIO->m.common.body_angleX_max;
+    f32 body_angleY_min = mpHIO->m.common.body_angleY_min;
+    f32 body_angleY_max = mpHIO->m.common.body_angleY_max;
+    f32 head_angleX_min = mpHIO->m.common.head_angleX_min;
+    f32 head_angleX_max = mpHIO->m.common.head_angleX_max;
+    f32 head_angleY_min = mpHIO->m.common.head_angleY_min;
+    f32 head_angleY_max = mpHIO->m.common.head_angleY_max;
 
     s16 temp_r26 = mCurAngle.y - mOldAngle.y;
     cXyz sp30[] = {mLookatPos[0], mLookatPos[1], mLookatPos[2]};
@@ -723,7 +747,7 @@ void daObjTks_c::warp() {
                 if (eventMgr.getIsAddvance(staff_id)) {
                     switch (*(u32*)cut_name) {
                     case '0002':
-                        gravity = daObjTks_Param_c::m.common.gravity;
+                        gravity = mpHIO->m.common.gravity;
                         break;
                     case '0001':
                         JUT_ASSERT(1419, FALSE);
@@ -790,8 +814,8 @@ void daObjTks_c::setParam() {
     scale.setall(field_0xdcc);
 
     #if DEBUG
-    mAcchCir.SetWallR(daObjTks_Param_c::m.common.width);
-    mAcchCir.SetWallH(daObjTks_Param_c::m.common.height);
+    mAcchCir.SetWallR(mpHIO->m.common.width);
+    mAcchCir.SetWallH(mpHIO->m.common.height);
     #endif
 }
 
@@ -854,13 +878,13 @@ void daObjTks_c::setAttnPos() {
         mEyeAngle.x = 0;
     }
 
-    attention_info.position.set(current.pos.x, current.pos.y + daObjTks_Param_c::m.common.attention_offset, current.pos.z);
+    attention_info.position.set(current.pos.x, current.pos.y + mpHIO->m.common.attention_offset, current.pos.z);
 
     if (!fopAcM_checkCarryNow(this)) {
         mCcCyl.SetC(current.pos);
         #if DEBUG
-        mCcCyl.SetH(daObjTks_Param_c::m.common.height);
-        mCcCyl.SetR(daObjTks_Param_c::m.common.width);
+        mCcCyl.SetH(mpHIO->m.common.height);
+        mCcCyl.SetR(mpHIO->m.common.width);
         #endif
         dComIfG_Ccsp()->Set(&mCcCyl);
     }
@@ -871,8 +895,6 @@ BOOL daObjTks_c::drawDbgInfo() {
 }
 
 void daObjTks_c::drawOtherMdls() {}
-
-static daObjTks_Param_c l_HIO;
 
 static actor_method_class daObjTks_MethodTable = {
     (process_method_func)daObjTks_Create,

--- a/src/d/actor/d_a_obj_yel_bag.cpp
+++ b/src/d/actor/d_a_obj_yel_bag.cpp
@@ -38,6 +38,22 @@ static u16 emttrId[4] = {
     0x01B8, 0x01B9, 0x01BA, 0x01BB,
 };
 
+static OBJ_YBAG_HIO_CLASS l_HIO;
+
+#if DEBUG
+daObj_YBag_HIO_c::daObj_YBag_HIO_c() {
+    m = daObj_YBag_Param_c::m;
+}
+
+void daObj_YBag_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daObj_YBag_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
 daObj_YBag_c::daObj_YBag_c() {
 }
 
@@ -45,6 +61,12 @@ daObj_YBag_c::~daObj_YBag_c() {
     for (int i = 0; l_loadRes_list[mType][i] >= 0; i++) {
         dComIfG_resDelete(&mPhases[i], l_resNames[l_loadRes_list[mType][i]]);
     }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
 }
 
 const dCcD_SrcGObjInf daObj_YBag_c::mCcDObjInfo = {
@@ -54,7 +76,7 @@ const dCcD_SrcGObjInf daObj_YBag_c::mCcDObjInfo = {
     {0},
 };
 
-f32 const daObj_YBag_Param_c::m[11] = {
+daObj_YBag_HIOParam const daObj_YBag_Param_c::m = {
     0.0f, -4.0f, 1.0f, 400.0f, 255.0f, 10.0f, 4.0f, 10.0f, 
     41.0f, 32.0f, 3.0f,
 };
@@ -82,10 +104,16 @@ int daObj_YBag_c::create() {
         }
         fopAcM_SetMtx(this, mModel->getBaseTRMtx());
         fopAcM_setCullSizeBox(this, -300.0, -50.0f, -300.0, 300.0f, 450.0f, 300.0f);
-        mAcchCir.SetWall(daObj_YBag_Param_c::m[7], daObj_YBag_Param_c::m[6]);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("イリアのバッグ");
+#endif
+
+        mAcchCir.SetWall(mpHIO->m.field_0x1c, mpHIO->m.field_0x18);
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1, &mAcchCir,
                   fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mStts.Init(daObj_YBag_Param_c::m[4], 0, this);
+        mStts.Init(mpHIO->m.field_0x10, 0, this);
         mCyl.Set(mCcDCyl);
         mCyl.SetStts(&mStts);
         mAcch.CrrPos(dComIfG_Bgsp());
@@ -122,12 +150,12 @@ int daObj_YBag_c::Delete() {
 
 int daObj_YBag_c::Execute() {
     int local_8c = fopAcM_checkCarryNow(this) != 0;
-    scale.set(daObj_YBag_Param_c::m[2], daObj_YBag_Param_c::m[2], daObj_YBag_Param_c::m[2]);
+    scale.set(mpHIO->m.field_0x08, mpHIO->m.field_0x08, mpHIO->m.field_0x08);
     attention_info.flags = 0;
     attention_info.distances[4] = 6;
-    mAcchCir.SetWallR(daObj_YBag_Param_c::m[7]);
-    mAcchCir.SetWallH(daObj_YBag_Param_c::m[6]);
-    gravity = daObj_YBag_Param_c::m[1];
+    mAcchCir.SetWallR(mpHIO->m.field_0x1c);
+    mAcchCir.SetWallH(mpHIO->m.field_0x18);
+    gravity = mpHIO->m.field_0x04;
     if (local_8c != 0) {
         mAcch.ClrWallHit();
         mAcch.ClrGroundHit();
@@ -145,17 +173,17 @@ int daObj_YBag_c::Execute() {
         mAcch.ClrGrndNone();
         if (field_0xa34 != 0 && cM3d_IsZero(speedF) == false) {
             fopAcM_carryOffRevise(this);
-            s16 sVar11 = cM_deg2s(daObj_YBag_Param_c::m[9]);
+            s16 sVar11 = cM_deg2s(mpHIO->m.field_0x24);
             speed.setall(0.0f);
             speed.y =
-                daObj_YBag_Param_c::m[8] * cM_ssin(sVar11);
+                mpHIO->m.field_0x20 * cM_ssin(sVar11);
             speedF =
-                daObj_YBag_Param_c::m[8] * cM_scos(sVar11);
+                mpHIO->m.field_0x20 * cM_scos(sVar11);
             field_0xa04 = 0x4000;
             field_0xa33 = 1;
         } else {
             fopAcM_getWaterY(&current.pos, &field_0x9f4);
-            if (field_0x9f4 != -G_CM3D_F_INF && daObj_YBag_Param_c::m[10] < field_0x9f4 - field_0x9f0 &&
+            if (field_0x9f4 != -G_CM3D_F_INF && mpHIO->m.field_0x28 < field_0x9f4 - field_0x9f0 &&
                 current.pos.y <= field_0x9f4 && field_0xa32 == 0)
             {
                 if (field_0xa33 != 0) {
@@ -177,7 +205,7 @@ int daObj_YBag_c::Execute() {
                     cLib_addCalc(&speed.y, 2.0f, 0.5f, 0.5f, 0.5f);
                 }
                 if (field_0x9f4 <
-                    current.pos.y + daObj_YBag_Param_c::m[10])
+                    current.pos.y + mpHIO->m.field_0x28)
                 {
                     field_0x9dc.y = 0x100;
                     mAcch.ClrGroundHit();
@@ -205,7 +233,7 @@ int daObj_YBag_c::Execute() {
                     } else {
                         cLib_chaseF(&speedF, 0.0f, 0.1f);
                     }
-                    cLib_addCalc2(&current.pos.y, field_0x9f4 - daObj_YBag_Param_c::m[10], 0.5f,
+                    cLib_addCalc2(&current.pos.y, field_0x9f4 - mpHIO->m.field_0x28, 0.5f,
                                   2.0f);
                     speed.y = 0.0f;
                     setHamonPrtcl();
@@ -313,13 +341,13 @@ int daObj_YBag_c::Execute() {
         setRoomNo();
     }
     attention_info.position = current.pos;
-    attention_info.position.y += daObj_YBag_Param_c::m[0];
+    attention_info.position.y += mpHIO->m.field_0x00;
     eyePos = current.pos;
     setMtx();
     field_0xa04 = calcRollAngle(field_0xa04, 0x10000);
     mCyl.ClrCoHit();
-    mCyl.SetR(daObj_YBag_Param_c::m[7]);
-    mCyl.SetH(daObj_YBag_Param_c::m[5]);
+    mCyl.SetR(mpHIO->m.field_0x1c);
+    mCyl.SetH(mpHIO->m.field_0x14);
     mCyl.SetC(current.pos);
     dComIfG_Ccsp()->Set(&mCyl);
     field_0xa34 = local_8c != 0;
@@ -344,7 +372,7 @@ int daObj_YBag_c::Draw() {
         } else {
             ;
             mShadowId = dComIfGd_setShadow(mShadowId, 1, mModel, &current.pos,
-                daObj_YBag_Param_c::m[3], 20.0f,
+                mpHIO->m.field_0x0c, 20.0f,
                 current.pos.y, field_0x9f0, mGndChk,
                 &tevStr, 0, 1.0f, dDlst_shadowControl_c::getSimpleTex());
         }
@@ -469,8 +497,6 @@ void daObj_YBag_c::setSmokePrtcl() {
     dComIfGp_particle_levelEmitterOnEventMove(field_0xa10);
     dComIfGp_particle_levelEmitterOnEventMove(field_0xa14);
 }
-
-static daObj_YBag_Param_c l_HIO;
 
 void daObj_YBag_c::setWaterPrtcl() {
     static const cXyz scl(0.4f, 0.4f, 0.4f);

--- a/src/d/actor/d_a_peru.cpp
+++ b/src/d/actor/d_a_peru.cpp
@@ -102,15 +102,7 @@ daPeru_c::cutAppearFunc daPeru_c::mCutList[3] = {
     &daPeru_c::cutAppear_skip,
 };
 
-daPeru_c::~daPeru_c() {
-    OS_REPORT("|%06d:%x|daPeru_c -> デストラクト\n", g_Counter.mCounter0, this);
-    if (heap != NULL) {
-        mpMorf[0]->stopZelAnime();
-    }
-    deleteRes(l_loadResPtrnList[mType], (const char**) l_resNameList);
-}
-
-PeruParams const daPeru_Param_c::m = {
+daPeru_HIOParam const daPeru_Param_c::m = {
     60.0f,
     -3.0f,
     1.0f,
@@ -154,6 +146,37 @@ PeruParams const daPeru_Param_c::m = {
     0.0f,
 };
 
+static PERU_HIO_CLASS l_HIO;
+
+#if DEBUG
+daPeru_HIO_c::daPeru_HIO_c() {
+    m = daPeru_Param_c::m;
+}
+
+void daPeru_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daPeru_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daPeru_c::~daPeru_c() {
+    OS_REPORT("|%06d:%x|daPeru_c -> デストラクト\n", g_Counter.mCounter0, this);
+    if (heap != NULL) {
+        mpMorf[0]->stopZelAnime();
+    }
+
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+
+    deleteRes(l_loadResPtrnList[mType], (const char**) l_resNameList);
+}
+
 int daPeru_c::create() {
     daNpcT_ct(this, daPeru_c, (daNpcT_faceMotionAnmData_c*)l_faceMotionAnmData, (daNpcT_motionAnmData_c*)l_motionAnmData, (daNpcT_MotionSeqMngr_c::sequenceStepData_c*)l_faceMotionSequenceData, 4, (daNpcT_MotionSeqMngr_c::sequenceStepData_c*)l_motionSequenceData, 4, l_evtList, l_resNameList);
     OS_REPORT("------------ ルイーズ生成処理開始\n");
@@ -182,9 +205,15 @@ int daPeru_c::create() {
                                               -300.0f, 300.0f,
                                               450.0f, 300.0f);
         mSound.init(&current.pos, &eyePos, 3, 1);
+
+#if DEBUG
+        mpHIO = &l_HIO;
+        mpHIO->entryHIO("ルイーズ");
+#endif
+
         mAcch.Set(fopAcM_GetPosition_p(this), fopAcM_GetOldPosition_p(this), this, 1,
                          &mAcchCir, fopAcM_GetSpeed_p(this), fopAcM_GetAngle_p(this), fopAcM_GetShapeAngle_p(this));
-        mCcStts.Init(daPeru_Param_c::m.field_0x00[4], 0, this);
+        mCcStts.Init(mpHIO->m.inner.field_0x10, 0, this);
         for (int i = 0; i < 2; i++) {
             mCyls[i].Set(mCcDCyl);
             mCyls[i].SetStts(&mCcStts);
@@ -279,7 +308,7 @@ int daPeru_c::Draw() {
         u16 eyeballMat = getEyeballMaterialNo();
         modelData->getMaterialNodePointer(eyeballMat)->setMaterialAnm(matAnm);
     }
-    return draw(0, 0, daPeru_Param_c::m.field_0x00[3], NULL, 100.0f, 0, field_0xe80, 0);
+    return draw(0, 0, mpHIO->m.inner.field_0x0C, NULL, 100.0f, 0, field_0xe80, 0);
 }
 
 int daPeru_c::createHeapCallBack(fopAc_ac_c* i_this) {
@@ -311,20 +340,20 @@ int daPeru_c::isDelete() {
 
 void daPeru_c::reset() {
     initialize();
-    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(daPeru_Param_c::m.field_0x48[2], daPeru_Param_c::m.field_0x48[3]);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x4C, mpHIO->m.inner.field_0x4E);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
-    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(daPeru_Param_c::m.field_0x48[0], daPeru_Param_c::m.field_0x48[1]);
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x48, mpHIO->m.inner.field_0x4A);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
-    scale.setall(daPeru_Param_c::m.field_0x00[2]);
-    mCcStts.SetWeight(daPeru_Param_c::m.field_0x00[4]);
-    mCylH = daPeru_Param_c::m.field_0x00[5];
-    mWallR = daPeru_Param_c::m.field_0x00[7];
+    scale.setall(mpHIO->m.inner.field_0x08);
+    mCcStts.SetWeight(mpHIO->m.inner.field_0x10);
+    mCylH = mpHIO->m.inner.field_0x14;
+    mWallR = mpHIO->m.inner.field_0x1C;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daPeru_Param_c::m.field_0x00[6]);
-    mRealShadowSize = daPeru_Param_c::m.field_0x00[3];
-    gravity = daPeru_Param_c::m.field_0x00[1];
-    mExpressionMorfFrame = daPeru_Param_c::m.field_0x64[2];
-    mMorfFrames = daPeru_Param_c::m.field_0x00[17];
+    mAcchCir.SetWallH(mpHIO->m.inner.field_0x18);
+    mRealShadowSize = mpHIO->m.inner.field_0x0C;
+    gravity = mpHIO->m.inner.field_0x04;
+    mExpressionMorfFrame = mpHIO->m.inner.field_0x6C;
+    mMorfFrames = mpHIO->m.inner.field_0x44;
     mActionFunc = NULL;
     if (mpMatAnm[0] != NULL) {
         mpMatAnm[0]->initialize();
@@ -346,19 +375,19 @@ void daPeru_c::setParam() {
     if (mType == 0 && !daNpcT_chkEvtBit(0x127)) {
         attention_info.flags = 0;
     }
-    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(daPeru_Param_c::m.field_0x48[2], daPeru_Param_c::m.field_0x48[3]);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x4C, mpHIO->m.inner.field_0x4E);
     attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
-    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(daPeru_Param_c::m.field_0x48[0], daPeru_Param_c::m.field_0x48[1]);
-    scale.setall(daPeru_Param_c::m.field_0x00[2]);
-    mCcStts.SetWeight(daPeru_Param_c::m.field_0x00[4]);
-    mCylH = daPeru_Param_c::m.field_0x00[5];
-    mWallR = daPeru_Param_c::m.field_0x00[7];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x48, mpHIO->m.inner.field_0x4A);
+    scale.setall(mpHIO->m.inner.field_0x08);
+    mCcStts.SetWeight(mpHIO->m.inner.field_0x10);
+    mCylH = mpHIO->m.inner.field_0x14;
+    mWallR = mpHIO->m.inner.field_0x1C;
     mAcchCir.SetWallR(mWallR);
-    mAcchCir.SetWallH(daPeru_Param_c::m.field_0x00[6]);
-    mRealShadowSize = daPeru_Param_c::m.field_0x00[3];
-    gravity = daPeru_Param_c::m.field_0x00[1];
-    mExpressionMorfFrame = daPeru_Param_c::m.field_0x64[2];
-    mMorfFrames = daPeru_Param_c::m.field_0x00[17];
+    mAcchCir.SetWallH(mpHIO->m.inner.field_0x18);
+    mRealShadowSize = mpHIO->m.inner.field_0x0C;
+    gravity = mpHIO->m.inner.field_0x04;
+    mExpressionMorfFrame = mpHIO->m.inner.field_0x6C;
+    mMorfFrames = mpHIO->m.inner.field_0x44;
 }
 
 void daPeru_c::setAfterTalkMotion() {
@@ -418,11 +447,11 @@ void daPeru_c::setAttnPos() {
     f32 dVar9 = cM_s2rad(mCurAngle.y - field_0xd7e.y);
     mJntAnm.setParam(
         this, mpMorf[0]->getModel(), &acStack_3c, getBackboneJointNo(), getNeckJointNo(),
-        getHeadJointNo(), daPeru_Param_c::m.field_0x00[9], daPeru_Param_c::m.field_0x00[8],
-        daPeru_Param_c::m.field_0x00[11], daPeru_Param_c::m.field_0x00[10],
-        daPeru_Param_c::m.field_0x00[13], daPeru_Param_c::m.field_0x00[12],
-        daPeru_Param_c::m.field_0x00[15], daPeru_Param_c::m.field_0x00[14],
-        daPeru_Param_c::m.field_0x00[16], dVar9, NULL);
+        getHeadJointNo(), mpHIO->m.inner.field_0x24, mpHIO->m.inner.field_0x20,
+        mpHIO->m.inner.field_0x2C, mpHIO->m.inner.field_0x28,
+        mpHIO->m.inner.field_0x34, mpHIO->m.inner.field_0x30,
+        mpHIO->m.inner.field_0x3C, mpHIO->m.inner.field_0x38,
+        mpHIO->m.inner.field_0x40, dVar9, NULL);
     mJntAnm.calcJntRad(0.2f, 1.0f, dVar9);
     setMtx();
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getAnmMtx(getHeadJointNo()));
@@ -430,7 +459,7 @@ void daPeru_c::setAttnPos() {
     mJntAnm.setEyeAngleX(eyePos, 1.0f, 0);
     mJntAnm.setEyeAngleY(eyePos,
         mCurAngle.y, 0, 1.0f, 0);
-    cXyz cStack_48(0.0f, daPeru_Param_c::m.field_0x00[0], 30.0f);
+    cXyz cStack_48(0.0f, mpHIO->m.inner.field_0x00, 30.0f);
     mDoMtx_stack_c::copy(mpMorf[0]->getModel()->getBaseTRMtx());
     mDoMtx_stack_c::multVec(&cStack_48, &attention_info.position);
 }
@@ -502,7 +531,7 @@ int daPeru_c::wait(int param_0) {
         if (!mStagger.checkStagger()) {
             if (mPlayerActorMngr.getActorP() != NULL && !mTwilight) {
                 mJntAnm.lookNone(0);
-                if (chkActorInSight(mPlayerActorMngr.getActorP(), daPeru_Param_c::m.field_0x50[0],
+                if (chkActorInSight(mPlayerActorMngr.getActorP(), mpHIO->m.inner.field_0x50,
                                     mCurAngle.y))
                 {
                     mJntAnm.lookPlayer(0);
@@ -903,8 +932,6 @@ int daPeru_c::cutAppear(int param_1) {
     }
     return _cutAppear_Main(*pCutId);
 }
-
-static daPeru_Param_c l_HIO;
 
 int daPeru_c::_cutAppear_Init(int const& param_1) {
     switch(param_1) {

--- a/src/d/actor/d_a_tag_lantern.cpp
+++ b/src/d/actor/d_a_tag_lantern.cpp
@@ -8,7 +8,29 @@
 #include "d/actor/d_a_tag_lantern.h"
 #include "d/d_procname.h"
 
-daTag_Lantern_c::~daTag_Lantern_c() {}
+static TAG_LANTERN_HIO_CLASS l_HIO;
+
+#if DEBUG
+daTag_Lantern_HIO_c::daTag_Lantern_HIO_c() {
+    m = daTag_Lantern_Param_c::m;
+}
+
+void daTag_Lantern_HIO_c::listenPropertyEvent(const JORPropertyEvent* event) {
+    // NONMATCHING
+}
+
+void daTag_Lantern_HIO_c::genMessage(JORMContext* ctx) {
+    // NONMATCHING
+}
+#endif
+
+daTag_Lantern_c::~daTag_Lantern_c() {
+#if DEBUG
+    if (mpHIO != NULL) {
+        mpHIO->removeHIO();
+    }
+#endif
+}
 
 int daTag_Lantern_c::create() {
     fopAcM_ct(this, daTag_Lantern_c);
@@ -99,8 +121,6 @@ static int daTag_Lantern_Draw(void* i_this) {
 static int daTag_Lantern_IsDelete(void* i_this) {
     return 1;
 }
-
-static daTag_Lantern_Param_c l_HIO;
 
 static actor_method_class daTag_Lantern_MethodTable = {
     (process_method_func)daTag_Lantern_Create,  (process_method_func)daTag_Lantern_Delete,


### PR DESCRIPTION
This PR cleans up TUs which use the "HIO param" pattern, where retail uses a static field in `*_Param_c` and debug uses an instance field in `*_HIO_c`. I believe all reported regressions in `ShieldD` are noise in assembly generation rather than true regressions.