### PR TITLE
Use attention enums everywhere instead of integer literals

### DIFF
--- a/include/f_op/f_op_actor.h
+++ b/include/f_op/f_op_actor.h
@@ -91,38 +91,47 @@ enum fopAc_attention_type {
     /* 0x2 */ fopAc_attn_BATTLE_e,
 
 #if !PLATFORM_GCN
-    fopAc_attn_UNK_3,
-    fopAc_attn_UNK_4,
-    fopAc_attn_UNK_5,
+    /* 0x3 */ fopAc_attn_UNK_3,
+    /* 0x4 */ fopAc_attn_UNK_4,
+    /* 0x5 */ fopAc_attn_UNK_5,
 #endif
 
-    /* 0x3 */ fopAc_attn_SPEAK_e,
-    /* 0x4 */ fopAc_attn_CARRY_e,
-    /* 0x5 */ fopAc_attn_DOOR_e,
-    /* 0x6 */ fopAc_attn_JUEL_e,
+    /* 0x3 (0x6) */ fopAc_attn_SPEAK_e,
+    /* 0x4 (0x7) */ fopAc_attn_CARRY_e,
+    /* 0x5 (0x8) */ fopAc_attn_DOOR_e,
+    /* 0x6 (0x9) */ fopAc_attn_JUEL_e,
 
 #if !PLATFORM_GCN
-    fopAc_attn_UNK_10,
+    /* 0xA */ fopAc_attn_UNK_10,
 #endif
 
-    /* 0x7 */ fopAc_attn_ETC_e,
-    /* 0x8 */ fopAc_attn_CHECK_e,
+    /* 0x7 (0xB) */ fopAc_attn_ETC_e,
+    /* 0x8 (0xC) */ fopAc_attn_CHECK_e,
 
     fopAc_attn_MAX_e,
 };
 
 enum fopAc_AttentionFlag_e {
-    /* 0x00000001 */ fopAc_AttnFlag_LOCK_e   = (1 << fopAc_attn_LOCK_e),
-    /* 0x00000002 */ fopAc_AttnFlag_TALK_e   = (1 << fopAc_attn_TALK_e),
-    /* 0x00000004 */ fopAc_AttnFlag_BATTLE_e = (1 << fopAc_attn_BATTLE_e),
+    /* 0x00000001 */ fopAc_AttnFlag_LOCK_e      = (1 << fopAc_attn_LOCK_e),
+    /* 0x00000002 */ fopAc_AttnFlag_TALK_e      = (1 << fopAc_attn_TALK_e),
+    /* 0x00000004 */ fopAc_AttnFlag_BATTLE_e    = (1 << fopAc_attn_BATTLE_e),
 
-    /* 0x00000008 */ fopAc_AttnFlag_SPEAK_e  = (1 << fopAc_attn_SPEAK_e),
-    /* 0x00000010 */ fopAc_AttnFlag_CARRY_e  = (1 << fopAc_attn_CARRY_e),
-    /* 0x00000020 */ fopAc_AttnFlag_DOOR_e   = (1 << fopAc_attn_DOOR_e),
-    /* 0x00000040 */ fopAc_AttnFlag_JUEL_e   = (1 << fopAc_attn_JUEL_e),
-    /* 0x00000080 */ fopAc_AttnFlag_ETC_e    = (1 << fopAc_attn_ETC_e),
+#if !PLATFORM_GCN
+    /* 0x00000008 */ fopAc_AttnFlag_UNK_3_e     = (1 << fopAc_attn_UNK_3),
+    /* 0x00000010 */ fopAc_AttnFlag_UNK_4_e     = (1 << fopAc_attn_UNK_4),
+    /* 0x00000020 */ fopAc_AttnFlag_UNK_5_e     = (1 << fopAc_attn_UNK_5),
+#endif
 
-    /* 0x00000100 */ fopAc_AttnFlag_CHECK_e  = (1 << fopAc_attn_CHECK_e),
+    /* 0x00000008 (0x00000040) */ fopAc_AttnFlag_SPEAK_e    = (1 << fopAc_attn_SPEAK_e),
+    /* 0x00000010 (0x00000080) */ fopAc_AttnFlag_CARRY_e    = (1 << fopAc_attn_CARRY_e),
+    /* 0x00000020 (0x00000100) */ fopAc_AttnFlag_DOOR_e     = (1 << fopAc_attn_DOOR_e),
+    /* 0x00000040 (0x00000200) */ fopAc_AttnFlag_JUEL_e     = (1 << fopAc_attn_JUEL_e),
+#if !PLATFORM_GCN
+    /* 0x00000400 */ fopAc_AttnFlag_UNK_10_e                = (1 << fopAc_attn_UNK_10),
+#endif
+    /* 0x00000080 (0x00000800) */ fopAc_AttnFlag_ETC_e      = (1 << fopAc_attn_ETC_e),
+
+    /* 0x00000100 (0x00001000) */ fopAc_AttnFlag_CHECK_e    = (1 << fopAc_attn_CHECK_e),
 
     /* 0x00200000 */ fopAc_AttnFlag_UNK_0x200000   = 0x200000,
     /* 0x00400000 */ fopAc_AttnFlag_UNK_0x400000   = 0x400000,

--- a/src/d/actor/d_a_b_gnd.cpp
+++ b/src/d/actor/d_a_b_gnd.cpp
@@ -4787,7 +4787,7 @@ static int daB_GND_Create(fopAc_ac_c* a_this) {
             l_HIO.no = mDoHIO_CREATE_CHILD("ガノンドロフ", &l_HIO);
         }
 
-        a_this->attention_info.distances[2] = 36;
+        a_this->attention_info.distances[fopAc_attn_BATTLE_e] = 36;
 
         fopAcM_SetMtx(a_this, i_this->mpModelMorf->getModel()->getBaseTRMtx());
         fopAcM_SetMin(a_this, -400.0f, -200.0f, -400.0f);

--- a/src/d/actor/d_a_cstatue.cpp
+++ b/src/d/actor/d_a_cstatue.cpp
@@ -321,7 +321,7 @@ int daCstatue_c::create() {
                 dComIfGs_onTbox(20);
             }
         }
-        attention_info.distances[4] = 8;
+        attention_info.distances[fopAc_attn_CARRY_e] = 8;
         fopAcM_SetMtx(this, mModel->getBaseTRMtx());
         int acchTblSize;
         if (mType == daCstatueType_Normal || mType == daCstatueType_Normal2) {
@@ -376,7 +376,7 @@ int daCstatue_c::create() {
             }
             mSph->SetTgType(0xd97afddf);
             mControlDistanceOffset = JMAFastSqrt(650000.0f);
-            attention_info.distances[0] = 92;
+            attention_info.distances[fopAc_attn_LOCK_e] = 92;
             cLib_onBit<u32>(attention_info.flags, fopAc_AttnFlag_LOCK_e);
             mTargetFrame = 35.0f;
         }

--- a/src/d/actor/d_a_e_ge.cpp
+++ b/src/d/actor/d_a_e_ge.cpp
@@ -1315,7 +1315,7 @@ int daE_GE_c::create() {
             l_HIO.id = mDoHIO_CREATE_CHILD("グェー", &l_HIO);
         }
 
-        attention_info.flags = 4;
+        attention_info.flags = fopAc_AttnFlag_BATTLE_e;
         fopAcM_SetMtx(this, mpMorfSO->getModel()->getBaseTRMtx());
         fopAcM_SetMin(this, -200.0f, -200.0f, -200.0f);
         fopAcM_SetMax(this, 200.0f, 200.0f, 200.0f);

--- a/src/d/actor/d_a_e_hz.cpp
+++ b/src/d/actor/d_a_e_hz.cpp
@@ -1634,7 +1634,7 @@ void daE_HZ_c::action() {
         setActionMode(ACTION_WATER_DEATH);
     }
 
-    attention_info.flags = 4;
+    attention_info.flags = fopAc_AttnFlag_BATTLE_e;
     field_0x566 = 1;
 
     switch (mAction) {

--- a/src/d/actor/d_a_e_kk.cpp
+++ b/src/d/actor/d_a_e_kk.cpp
@@ -876,7 +876,7 @@ void daE_KK_c::executeDead() {
     case 0:
         fopAcM_OffStatus(this, 0);
         attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
-        attention_info.distances[2] = 0;
+        attention_info.distances[fopAc_attn_BATTLE_e] = 0;
         offHeadLockFlg();
         health = 0;
         speedF = 0.0f;
@@ -1266,8 +1266,8 @@ int daE_KK_c::execute() {
             return 1;
         }
 
-        if (attention_info.distances[2] == 0) {
-            attention_info.distances[2] = 0x45;
+        if (attention_info.distances[fopAc_attn_BATTLE_e] == 0) {
+            attention_info.distances[fopAc_attn_BATTLE_e] = 0x45;
             fopAcM_SetGroup(this, 2);
             fopAcM_OnStatus(this, 0);
             attention_info.flags |= fopAc_AttnFlag_BATTLE_e;
@@ -1443,7 +1443,7 @@ int daE_KK_c::create() {
             field_0x760 = current.pos.y;
 
             attention_info.flags = fopAc_AttnFlag_BATTLE_e;
-            attention_info.distances[2] = 0x4C;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 0x4C;
 
             if (field_0x679 != 3) {
                 setActionMode(0, 0);
@@ -1461,7 +1461,7 @@ int daE_KK_c::create() {
         fopAcM_SetMax(this, 600.0f, 600.0f, 600.0f);
 
         if (field_0x679 == 2 && !checkItemGet(fpcNm_ITEM_IRONBALL, 1)) {
-            attention_info.distances[2] = 0;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 0;
             fopAcM_SetGroup(this, 0);
             fopAcM_OffStatus(this, 0);
             attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;

--- a/src/d/actor/d_a_e_mk.cpp
+++ b/src/d/actor/d_a_e_mk.cpp
@@ -2886,7 +2886,7 @@ static int daE_MK_Create(fopAc_ac_c* i_actor) {
         mk->sound.init(&i_actor->current.pos, &i_actor->eyePos, 3, 1);
         mk->atInfo.mpSound = &mk->sound;
 
-        i_actor->attention_info.distances[2] = 4;
+        i_actor->attention_info.distances[fopAc_attn_BATTLE_e] = 4;
 
         mk->stts.Init(0xFF, 0, i_actor);
         mk->tgSph.Set(cc_sph_src);

--- a/src/d/actor/d_a_e_mm_mt.cpp
+++ b/src/d/actor/d_a_e_mm_mt.cpp
@@ -134,7 +134,7 @@ static void e_mm_mt_normal(e_mm_mt_class* i_this) {
             fopAcM_SetGroup(actor, 3);
             fopAcM_OffStatus(actor, 0);
             actor->attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
-            actor->attention_info.distances[2] = 0;
+            actor->attention_info.distances[fopAc_attn_BATTLE_e] = 0;
             fopAcM_OnStatus(actor, 0x400);
             s16 actor_angle = player->shape_angle.y + 0x4000;
             s16 angle = actor->shape_angle.y - actor_angle;
@@ -372,7 +372,7 @@ static void e_mm_mt_drop(e_mm_mt_class* i_this) {
         i_this->enemy.attention_info.position = i_this->enemy.current.pos;
         cLib_addCalcAngleS2(&i_this->m_rotation.z, (TREG_S(6)+0x10000)-0x8000, 1, 0x1000);
         cLib_onBit<u32>(i_this->enemy.attention_info.flags, fopAc_AttnFlag_CARRY_e);
-        i_this->enemy.attention_info.distances[4] = 7;
+        i_this->enemy.attention_info.distances[fopAc_attn_CARRY_e] = 7;
         i_this->m_rotation.y += i_this->m_spin;
         if (i_this->enemy.speedF >= 20.0f) {
             i_this->m_sphere.OnAtSetBit();

--- a/src/d/actor/d_a_e_rd.cpp
+++ b/src/d/actor/d_a_e_rd.cpp
@@ -5237,7 +5237,7 @@ static void action(e_rd_class* i_this) {
 
 
     if (i_this->field_0x9bc == 0) {
-        a_this->attention_info.distances[2] = 3;
+        a_this->attention_info.distances[fopAc_attn_BATTLE_e] = 3;
         if (i_this->field_0x9ec) {
             cMtx_YrotS(*calc_mtx, i_this->field_0xa0c.y);
             if (i_this->field_0xaf0 == 0) {

--- a/src/d/actor/d_a_e_sb.cpp
+++ b/src/d/actor/d_a_e_sb.cpp
@@ -1115,7 +1115,7 @@ cPhs__Step daE_SB_c::Create() {
         }
 
         attention_info.flags = fopAc_AttnFlag_BATTLE_e;
-        attention_info.distances[2] = 0x24;
+        attention_info.distances[fopAc_attn_BATTLE_e] = 0x24;
         fopAcM_SetMtx(this, mpMorf->getModel()->getBaseTRMtx());
         fopAcM_SetMin(this, -200.0f, 0.0f, -200.0f);
         fopAcM_SetMax(this, 200.0f, 200.0f, 200.0f);

--- a/src/d/actor/d_a_e_sw.cpp
+++ b/src/d/actor/d_a_e_sw.cpp
@@ -1755,10 +1755,10 @@ cPhs__Step daE_SW_c::create() {
         if (field_0x694 == 0) {
             mBgc.OnLineCheck();
             field_0x698 = 2;
-            attention_info.distances[2] = 3;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 3;
             d_setAction(&daE_SW_c::d_wait);
         } else {
-            attention_info.distances[2] = 4;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 4;
 
             if (field_0x6dc > 1.0f) {
                 field_0x98c.SetAtSpl((dCcG_At_Spl)1);

--- a/src/d/actor/d_a_e_tk.cpp
+++ b/src/d/actor/d_a_e_tk.cpp
@@ -720,7 +720,7 @@ static int daE_TK_Create(fopAc_ac_c* i_this) {
         fopAcM_SetMin(a_this, -100.0f, -100.0f, -100.0f);
         fopAcM_SetMax(a_this, 100.0f, 100.0f, 100.0f);
 
-        a_this->attention_info.distances[2] = 0x04;
+        a_this->attention_info.distances[fopAc_attn_BATTLE_e] = 0x04;
         a_this->health = 10;
         a_this->field_0x560 = 10;
 

--- a/src/d/actor/d_a_e_tk2.cpp
+++ b/src/d/actor/d_a_e_tk2.cpp
@@ -524,7 +524,7 @@ static int daE_TK2_Create(fopAc_ac_c* i_this) {
         fopAcM_SetMin(a_this, -100.0f, -100.0f, -100.0f);
         fopAcM_SetMax(a_this, 100.0f, 100.0f, 100.0f);
 
-        a_this->attention_info.distances[2] = 0x04;
+        a_this->attention_info.distances[fopAc_attn_BATTLE_e] = 0x04;
         a_this->health = 0;
         a_this->field_0x560 = 0;
 

--- a/src/d/actor/d_a_e_tt.cpp
+++ b/src/d/actor/d_a_e_tt.cpp
@@ -1278,7 +1278,7 @@ int daE_TT_c::create() {
                 l_HIO.id = mDoHIO_CREATE_CHILD("テクタイト", &l_HIO);  // Tektite
             }
 
-            attention_info.flags = 4;
+            attention_info.flags = fopAc_AttnFlag_BATTLE_e;
             fopAcM_SetMtx(this, mpMorfSO->getModel()->getBaseTRMtx());
             fopAcM_SetMin(this, -200.0f, -200.0f, -200.0f);
             fopAcM_SetMax(this, 200.0f, 200.0f, 200.0f);

--- a/src/d/actor/d_a_e_ym.cpp
+++ b/src/d/actor/d_a_e_ym.cpp
@@ -562,7 +562,7 @@ void daE_YM_c::setAppear() {
         mType = 0;
     }
 
-    field_0x714 = 4;
+    field_0x714 = fopAc_AttnFlag_BATTLE_e;
 }
 
 void daE_YM_c::setMoveSound(int param_0) {
@@ -689,7 +689,7 @@ void daE_YM_c::executeWait() {
                 case 1:
                     field_0x718 = 1;
                     if (field_0x6d4) {
-                        field_0x714 = 4;
+                        field_0x714 = fopAc_AttnFlag_BATTLE_e;
                     } else {
                         field_0x714 = 0;
                     }
@@ -727,13 +727,13 @@ void daE_YM_c::executeWait() {
 
         case 4: {
             if (field_0x6d4) {
-                field_0x714 = 4;
+                field_0x714 = fopAc_AttnFlag_BATTLE_e;
             } else {
                 field_0x714 = 0;
             }
 
             if (dComIfGs_isSwitch(field_0x6a3, fopAcM_GetRoomNo(this)) && mType == 1) {
-                field_0x714 = 4;
+                field_0x714 = fopAc_AttnFlag_BATTLE_e;
                 if (mTagPosP != NULL) {
                     setActionMode(ACT_FLY);
                 } else {
@@ -2259,7 +2259,7 @@ void daE_YM_c::executeRail() {
         case 0: {
             mIsHide = 1;
             field_0x6a6 = 4;
-            field_0x714 |= 4;
+            field_0x714 |= fopAc_AttnFlag_BATTLE_e;
             field_0x6dc = -70.0f;
             dPnt* point_p = dPath_GetPnt(mpPath, mCurrentPntNo);
             current.pos = old.pos = point_p->m_position;
@@ -2361,14 +2361,14 @@ void daE_YM_c::executeBackRail() {
                     field_0x6a5 = 0;
                     mSphCc.SetCoSPrm(0x145);
                     mSphCc.SetTgType(0x10000);
-                    field_0x714 &= ~0x4;
+                    field_0x714 &= ~fopAc_AttnFlag_BATTLE_e;
                     bckSet(0x10, 2, 3.0f, 0.0f);
                 } else {
                     if (field_0x6a5 == 2) {
                         field_0x6f0 = 0xf;
                         mSphCc.SetCoSPrm(0x145);
                         mSphCc.SetTgType(0x10000);
-                        field_0x714 &= ~0x4;
+                        field_0x714 &= ~fopAc_AttnFlag_BATTLE_e;
                     } else {
                         field_0x6f0 = 7;
                     }
@@ -2413,7 +2413,7 @@ void daE_YM_c::executeBackRail() {
             // following needed for both (a) dbg stack reg to use r31, and (b) force b instruction in asm:
             int _;
             if (field_0x6f0 == 0) {
-                field_0x714 |= 4;
+                field_0x714 |= fopAc_AttnFlag_BATTLE_e;
                 setActionMode(ACT_RAIL);
             }
 
@@ -2499,7 +2499,7 @@ void daE_YM_c::executeSwitch() {
             mIsHide = 1;
             if (mpPath != NULL) {
                 if (mpPath->field_0x4 == 1) {
-                    field_0x714 = 4;
+                    field_0x714 = fopAc_AttnFlag_BATTLE_e;
                 } else {
                     field_0x714 = 0;
                     field_0x6cf = 0;
@@ -2627,7 +2627,7 @@ void daE_YM_c::executeFire() {
                 }
             }
             if (field_0x6d4) {
-                field_0x714 = 4;
+                field_0x714 = fopAc_AttnFlag_BATTLE_e;
             } else {
                 field_0x714 = 0;
             }
@@ -2655,7 +2655,7 @@ void daE_YM_c::executeFire() {
                 field_0x6cc = 1;
             }
             if (mpMorf->checkFrame(14.0f)) {
-                attention_info.distances[2] = 0x2e;
+                attention_info.distances[fopAc_attn_BATTLE_e] = 0x2e;
                 gravity = 0.0f;
                 fopAcM_SearchByName(0x1f7, &field_0x660);
                 if (field_0x660 != NULL) {
@@ -2751,7 +2751,7 @@ void daE_YM_c::executeFire() {
 
 void daE_YM_c::setRiverAttention() {
     cXyz player_pos = daPy_getPlayerActorClass()->current.pos;
-    attention_info.distances[2] = 60;
+    attention_info.distances[fopAc_attn_BATTLE_e] = 60;
     field_0x714 = 0;
     if (current.pos.abs(mpKago->current.pos) > 2000.0f) {
         return;
@@ -2764,7 +2764,7 @@ void daE_YM_c::setRiverAttention() {
     mDoMtx_stack_c::multVecZero(&my_vec_0);
     my_vec_1.set(my_vec_0.x, my_vec_0.z, my_vec_0.y);
     if (abs(cM_atan2s(my_vec_1.y, my_vec_1.absXZ()) - 0x4000) < 0x2000) {
-        field_0x714 = 4;
+        field_0x714 = fopAc_AttnFlag_BATTLE_e;
     }
 }
 
@@ -2862,7 +2862,7 @@ void daE_YM_c::executeRiver() {
             next_path = mpKago->checkNextPath(current.pos);
             if (mpKago->isFlying()) {
                 if (field_0x6f2) {
-                    field_0x714 = 4;
+                    field_0x714 = fopAc_AttnFlag_BATTLE_e;
                     if (next_path < 200.0f) {
                         cLib_chaseF(&field_0x6ec, 70.0f, 1.0f);
                     } else if (next_path > 1000.0f) {
@@ -3602,7 +3602,7 @@ int daE_YM_c::create() {
             l_HIO.field_0x4 = mDoHIO_CREATE_CHILD("闇の虫", &l_HIO);
         }
 
-        field_0x714 = 4;
+        field_0x714 = fopAc_AttnFlag_BATTLE_e;
         attention_info.distances[fopAc_attn_BATTLE_e] = 58;
         fopAcM_SetMtx(this, mpMorf->getModel()->getBaseTRMtx());
         fopAcM_SetMin(this, -200.0f, -100.0f, -200.0f);

--- a/src/d/actor/d_a_e_ymb.cpp
+++ b/src/d/actor/d_a_e_ymb.cpp
@@ -2752,9 +2752,9 @@ void daE_YMB_c::action() {
     }
 
     if (mAction != 5) {
-        attention_info.distances[2] = 24;
+        attention_info.distances[fopAc_attn_BATTLE_e] = 24;
     } else {
-        attention_info.distances[2] = 25;
+        attention_info.distances[fopAc_attn_BATTLE_e] = 25;
     }
 
     field_0x712 = 0;

--- a/src/d/actor/d_a_e_zh.cpp
+++ b/src/d/actor/d_a_e_zh.cpp
@@ -814,7 +814,7 @@ void daE_ZH_c::executeWait() {
 
     switch (mMoveMode) {
         case 0:
-            attention_info.distances[2] = 3;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 3;
             fopAcM_OnStatus(this, 0);
             attention_info.flags |= fopAc_AttnFlag_BATTLE_e;
             setBck(BCK_ZH_WAIT01, 0, 3.0f, 1.0f);
@@ -871,7 +871,7 @@ void daE_ZH_c::executeBallWait() {
             if (bitSw != 0xFF && fopAcM_isSwitch(this, bitSw) && mStartFlag != 0) {
                 fopAcM_OnStatus(this, 0);
                 attention_info.flags |= fopAc_AttnFlag_BATTLE_e;
-                attention_info.distances[2] = 3;
+                attention_info.distances[fopAc_attn_BATTLE_e] = 3;
                 mMoveMode = 10;
             }
             break;
@@ -1498,7 +1498,7 @@ void daE_ZH_c::executeCatchFlyMove() {
         case 12:
             fopAcM_OffStatus(this, 0);
             attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
-            attention_info.distances[2] = 0;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 0;
 
             for (int i = 0; i < 3; i++) {
                 field_0x764[i] = 0.0f;
@@ -1639,7 +1639,7 @@ void daE_ZH_c::executeFlyDelete() {
         case 0:
             fopAcM_OffStatus(this, 0);
             attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
-            attention_info.distances[2] = 0;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 0;
 
             if (bitSw != 0xFF && fopAcM_isSwitch(this, bitSw)) {
                 fopAcM_offSwitch(this, bitSw);
@@ -1662,7 +1662,7 @@ void daE_ZH_c::executeFlyDelete() {
                 if (fabsf(current.pos.y - (fopAcM_rc_c::getRoofY() + 200.0f)) < 20.0f) {
                     fopAcM_OffStatus(this, 0);
                     attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
-                    attention_info.distances[2] = 0;
+                    attention_info.distances[fopAc_attn_BATTLE_e] = 0;
 
                     if (arg0 == 0) {
                         setActionMode(ACTION_EXECUTE_WAIT, 0);
@@ -2191,7 +2191,7 @@ cPhs__Step daE_ZH_c::create() {
         if (arg0 == 2) {
             fopAcM_OffStatus(this, 0);
             attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
-            attention_info.distances[2] = 0;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 0;
             fopAcM_SetGroup(this, 0);
             fopAcM_SetMin(this, -2000.0f, -2000.0f, -2000.0f);
             fopAcM_SetMax(this, 2000.0f, 2000.0f, 2000.0f);
@@ -2255,7 +2255,7 @@ cPhs__Step daE_ZH_c::create() {
 
             shape_angle.z = 0;
             shape_angle.x = 0;
-            attention_info.distances[2] = 3;
+            attention_info.distances[fopAc_attn_BATTLE_e] = 3;
             fopAcM_OffStatus(this, 0);
             attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
 
@@ -2283,7 +2283,7 @@ cPhs__Step daE_ZH_c::create() {
 
                         setBck(BCK_ZH_WAIT01, 0, 3.0f, 1.0f);
                         field_0x78c = 0;
-                        attention_info.distances[2] = 3;
+                        attention_info.distances[fopAc_attn_BATTLE_e] = 3;
                         fopAcM_OffStatus(this, 0);
                         attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
 
@@ -2300,7 +2300,7 @@ cPhs__Step daE_ZH_c::create() {
                     setActionMode(ACTION_EXECUTE_DEAD_STOP, 0);
                 }
             } else {
-                attention_info.distances[2] = 0;
+                attention_info.distances[fopAc_attn_BATTLE_e] = 0;
                 field_0x764[0] = 255.0f;
                 field_0x764[2] = 50.0f;
                 mStartFlag = 0;

--- a/src/d/actor/d_a_e_zm.cpp
+++ b/src/d/actor/d_a_e_zm.cpp
@@ -416,7 +416,7 @@ void daE_ZM_c::executeWait() {
                 mTimer = l_HIO.wait_time_to_appear_after_attack;
                 attention_info.distances[fopAc_attn_BATTLE_e] = 0;
                 fopAcM_OffStatus(this, 0);
-                attention_info.flags &= 0xFFFFFFFB;
+                attention_info.flags &= ~fopAc_AttnFlag_BATTLE_e;
                 shape_angle.x = 0;
                 field_0x6f4.set(0.0f, 0.0f, 0.0f);
                 setActionMode(ACTION_WAIT, MODE_0);

--- a/src/d/actor/d_a_e_zs.cpp
+++ b/src/d/actor/d_a_e_zs.cpp
@@ -548,7 +548,7 @@ int daE_ZS_c::create() {
 
         shape_angle.z = 0;
         shape_angle.x = 0;
-        attention_info.distances[2] = 0;
+        attention_info.distances[fopAc_attn_BATTLE_e] = 0;
         daE_ZS_Execute(this);
         mCyl.OffTgSetBit();
         mCyl.OffCoSetBit();

--- a/src/d/actor/d_a_ep.cpp
+++ b/src/d/actor/d_a_ep.cpp
@@ -937,7 +937,7 @@ static int daEp_Create(fopAc_ac_c* a_this) {
     }
 
     i_this->field_0xa5c = -1;
-    i_this->attention_info.distances[4] = 7;
+    i_this->attention_info.distances[fopAc_attn_CARRY_e] = 7;
     fopAcM_OnCarryType(i_this, fopAcM_CARRY_UNK_30);
 
     i_this->mSph2.Set(at_sph_src);

--- a/src/d/actor/d_a_npc_ashB.cpp
+++ b/src/d/actor/d_a_npc_ashB.cpp
@@ -1089,10 +1089,10 @@ static bool daNpcAshB_IsDelete(void* param_0) {
 void daNpcAshB_c::setParam() {
     attention_info.flags =
         daPy_py_c::checkNowWolf() ? 0 : (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-    attention_info.distances[0] =
+    attention_info.distances[fopAc_attn_LOCK_e] =
         getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] =
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] =
         getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
 }
 

--- a/src/d/actor/d_a_npc_besu.cpp
+++ b/src/d/actor/d_a_npc_besu.cpp
@@ -1049,9 +1049,9 @@ void daNpc_Besu_c::setParam() {
         }
     }
 
-    attention_info.distances[0] = daNpcT_getDistTableIdx(att_dist, att_ang);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(talk_dist, talk_ang);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(att_dist, att_ang);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_dist, talk_ang);
     attention_info.flags = att_flags;
 
     scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,

--- a/src/d/actor/d_a_npc_bou.cpp
+++ b/src/d/actor/d_a_npc_bou.cpp
@@ -449,14 +449,14 @@ void daNpc_Bou_c::setParam() {
         }
     }
 
-    attention_info.distances[0] = daNpcT_getDistTableIdx(sVar8, sVar7);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar10, sVar9);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(sVar8, sVar7);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar10, sVar9);
     if (mType == TYPE_1) {
         uVar7 |= fopAc_AttnFlag_UNK_0x800000;
         field_0xfdc = getActorDistance(daPy_getPlayerActorClass(), 
                     daNpcT_getDistTableIdx(field_0xfe0, field_0xfe4), 
-                    attention_info.distances[1]);
+                    attention_info.distances[fopAc_attn_TALK_e]);
         if (field_0xfdc < 4) {
             g_meter2_info.mBlinkButton |= 1;
         }

--- a/src/d/actor/d_a_npc_chat.cpp
+++ b/src/d/actor/d_a_npc_chat.cpp
@@ -3072,9 +3072,12 @@ void daNpcChat_c::setParam() {
         attention_info.flags = 0;
     } else {
         if (mTalkIconType == 0) {
-            attention_info.flags = 0xC0000A;
+            attention_info.flags =
+                fopAc_AttnFlag_TALK_e | fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_UNK_0x400000 |
+                fopAc_AttnFlag_UNK_0x800000;
         } else {
-            attention_info.flags = fopAc_AttnFlag_UNK_0x400000 | fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
+            attention_info.flags =
+                fopAc_AttnFlag_TALK_e | fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_UNK_0x400000;
         }
     }
 

--- a/src/d/actor/d_a_npc_grs.cpp
+++ b/src/d/actor/d_a_npc_grs.cpp
@@ -360,7 +360,7 @@ void daNpc_grS_c::setParam() {
     unkInt1 = 5;
     unkInt2 = 6;
     attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(unkInt1, unkInt2);
-    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(unkInt3, unkInt4);
     attention_info.flags = flags;
 

--- a/src/d/actor/d_a_npc_hanjo.cpp
+++ b/src/d/actor/d_a_npc_hanjo.cpp
@@ -463,9 +463,9 @@ void daNpc_Hanjo_c::setParam() {
             sVar4 = 9;
         }
     }
-    attention_info.distances[0] = daNpcT_getDistTableIdx(sVar4, sVar1);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar6, sVar5);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(sVar4, sVar1);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar6, sVar5);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
     scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,
               mpHIO->m.common.scale);

--- a/src/d/actor/d_a_npc_henna.cpp
+++ b/src/d/actor/d_a_npc_henna.cpp
@@ -271,8 +271,8 @@ static void message_shop(npc_henna_class* i_this) {
     } else {
         fopAcM_OnStatus(&i_this->actor, 0);
         cLib_onBit<u32>(i_this->actor.attention_info.flags, fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e);
-        i_this->actor.attention_info.distances[1] = 4;
-        i_this->actor.attention_info.distances[3] = 4;
+        i_this->actor.attention_info.distances[fopAc_attn_TALK_e] = 4;
+        i_this->actor.attention_info.distances[fopAc_attn_SPEAK_e] = 4;
         i_this->actor.eventInfo.onCondition(1);
         if (dComIfGp_event_runCheck() && i_this->cam_mode == 0 &&
             i_this->actor.eventInfo.checkCommandTalk() != 0)
@@ -2188,7 +2188,7 @@ static void message_guide(npc_henna_class* i_this) {
         fopAcM_OnStatus(actor, 0);
 
         cLib_onBit<u32>(actor->attention_info.flags, (fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e));
-        actor->attention_info.distances[1] = 2;
+        actor->attention_info.distances[fopAc_attn_TALK_e] = 2;
         actor->attention_info.distances[fopAc_attn_SPEAK_e] = 2;
 
         actor->eventInfo.onCondition(dEvtCnd_CANTALK_e);

--- a/src/d/actor/d_a_npc_impal.cpp
+++ b/src/d/actor/d_a_npc_impal.cpp
@@ -1130,10 +1130,10 @@ static int daNpcImpal_IsDelete(void* i_this) {
 }
 
 void daNpcImpal_c::setParam() {
-    attention_info.distances[0] =
+    attention_info.distances[fopAc_attn_LOCK_e] =
         getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] =
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] =
         getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
 
     if (field_0xde9) {

--- a/src/d/actor/d_a_npc_jagar.cpp
+++ b/src/d/actor/d_a_npc_jagar.cpp
@@ -576,7 +576,7 @@ void daNpc_Jagar_c::setParam() {
         uVar7 |= fopAc_AttnFlag_UNK_0x800000;
         field_0xfec = getActorDistance(daPy_getPlayerActorClass(), 
                     daNpcT_getDistTableIdx(field_0xff0, field_0xff4), 
-                    attention_info.distances[1]);
+                    attention_info.distances[fopAc_attn_TALK_e]);
         if (field_0xfec < 4) {
             g_meter2_info.mBlinkButton |= 1;
         }

--- a/src/d/actor/d_a_npc_kkri.cpp
+++ b/src/d/actor/d_a_npc_kkri.cpp
@@ -568,7 +568,7 @@ void daNpc_Kkri_c::setParam() {
         attention_info.distances[fopAc_attn_SPEAK_e] = 57;
     } else {
         attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(attn_dist, attn_angle);
-        attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
+        attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
         attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_dist, talk_angle);
     }
 

--- a/src/d/actor/d_a_npc_maro.cpp
+++ b/src/d/actor/d_a_npc_maro.cpp
@@ -669,9 +669,9 @@ void daNpc_Maro_c::setParam() {
         }
     }
 
-    attention_info.distances[0] = daNpcT_getDistTableIdx(sVar8, sVar7);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar10, sVar9);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(sVar8, sVar7);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar10, sVar9);
 
     attention_info.flags = uVar7;
     scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale,

--- a/src/d/actor/d_a_npc_midp.cpp
+++ b/src/d/actor/d_a_npc_midp.cpp
@@ -358,9 +358,9 @@ void daNpc_midP_c::setParam() {
     s16 sVar3 = mpHIO->m.common.attention_distance;
     s16 sVar4 = mpHIO->m.common.attention_angle;
 
-    attention_info.distances[0] = daNpcT_getDistTableIdx(sVar3, sVar4);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar1, sVar2);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(sVar3, sVar4);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar1, sVar2);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 
     scale.setall(mpHIO->m.common.scale);

--- a/src/d/actor/d_a_npc_saru.cpp
+++ b/src/d/actor/d_a_npc_saru.cpp
@@ -545,9 +545,9 @@ void daNpc_Saru_c::setParam() {
     s16 sVar3 = mpHIO->m.common.attention_distance;
     s16 sVar4 = mpHIO->m.common.attention_angle;
 
-    attention_info.distances[0] = daNpcT_getDistTableIdx(sVar3, sVar4);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar1, sVar2);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(sVar3, sVar4);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar1, sVar2);
 
     if (mType == 2) {
         uVar1 = 0;

--- a/src/d/actor/d_a_npc_seib.cpp
+++ b/src/d/actor/d_a_npc_seib.cpp
@@ -266,9 +266,9 @@ void daNpc_seiB_c::setParam() {
     dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.mDist;
     dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.mDist;
 
-    attention_info.distances[0] = 39;
-    attention_info.distances[1] = 39;
-    attention_info.distances[3] = 39;
+    attention_info.distances[fopAc_attn_LOCK_e] = 39;
+    attention_info.distances[fopAc_attn_TALK_e] = 39;
+    attention_info.distances[fopAc_attn_SPEAK_e] = 39;
     attention_info.flags = 0;
 
     scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);

--- a/src/d/actor/d_a_npc_seic.cpp
+++ b/src/d/actor/d_a_npc_seic.cpp
@@ -273,9 +273,9 @@ void daNpc_seiC_c::setParam() {
     dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.field_0x90;
     dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.field_0x90;
 
-    attention_info.distances[0] = 39;
-    attention_info.distances[1] = 39;
-    attention_info.distances[3] = 39;
+    attention_info.distances[fopAc_attn_LOCK_e] = 39;
+    attention_info.distances[fopAc_attn_TALK_e] = 39;
+    attention_info.distances[fopAc_attn_SPEAK_e] = 39;
     attention_info.flags = 0;
 
     scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);

--- a/src/d/actor/d_a_npc_seid.cpp
+++ b/src/d/actor/d_a_npc_seid.cpp
@@ -272,9 +272,9 @@ void daNpc_seiD_c::setParam() {
     dComIfGp_getAttention()->getDistTable(0x27).mDistMax = mpHIO->m.field_0x90;
     dComIfGp_getAttention()->getDistTable(0x27).mDistMaxRelease = mpHIO->m.field_0x90;
 
-    attention_info.distances[0] = 39;
-    attention_info.distances[1] = 39;
-    attention_info.distances[3] = 39;
+    attention_info.distances[fopAc_attn_LOCK_e] = 39;
+    attention_info.distances[fopAc_attn_TALK_e] = 39;
+    attention_info.distances[fopAc_attn_SPEAK_e] = 39;
     attention_info.flags = 0;
 
     scale.set(mpHIO->m.common.scale, mpHIO->m.common.scale, mpHIO->m.common.scale);

--- a/src/d/actor/d_a_npc_shoe.cpp
+++ b/src/d/actor/d_a_npc_shoe.cpp
@@ -655,10 +655,10 @@ static bool daNpcShoe_IsDelete(void* param_0) {
 }
 
 void daNpcShoe_c::setParam() {
-    attention_info.distances[0] =
+    attention_info.distances[fopAc_attn_LOCK_e] =
         getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] =
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] =
         getDistTableIdx(mpHIO->m.common.talk_distance, mpHIO->m.common.talk_angle);
 
     attention_info.flags =

--- a/src/d/actor/d_a_npc_tkj.cpp
+++ b/src/d/actor/d_a_npc_tkj.cpp
@@ -651,7 +651,7 @@ void daNpcTkj_c::setParam() {
     s16 attn_angle = mpHIO->m.common.attention_angle;
 
     attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(attn_dist, attn_angle);
-    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(talk_dist, talk_angle);
     attention_info.flags = attn_flags;
 

--- a/src/d/actor/d_a_npc_tkj2.cpp
+++ b/src/d/actor/d_a_npc_tkj2.cpp
@@ -950,9 +950,9 @@ static void action(npc_tkj2_class* i_this) {
     }
 
     if (bVar1) {
-        cLib_onBit<u32>(a_this->attention_info.flags, 0x10);
+        cLib_onBit<u32>(a_this->attention_info.flags, fopAc_AttnFlag_CARRY_e);
     } else {
-        cLib_offBit<u32>(a_this->attention_info.flags, 0x10);
+        cLib_offBit<u32>(a_this->attention_info.flags, fopAc_AttnFlag_CARRY_e);
     }
 }
 

--- a/src/d/actor/d_a_npc_uri.cpp
+++ b/src/d/actor/d_a_npc_uri.cpp
@@ -1511,7 +1511,7 @@ int daNpc_Uri_c::wait(void* param_0) {
                     && !daNpcT_chkEvtBit(0x92))
                 {
                     cXyz acStack_70 = getAttnPos(daPy_getPlayerActorClass());
-                    int dist_index = attention_info.distances[1];
+                    int dist_index = attention_info.distances[fopAc_attn_TALK_e];
                     f32 fVar2 = dComIfGp_getAttention()->getDistTable(dist_index).mLowerY * -1.0f;
                     f32 fVar3 = dComIfGp_getAttention()->getDistTable(dist_index).mUpperY * -1.0f;
                     if (chkPointInArea(acStack_70, attention_info.position, 200.0f, fVar2, fVar3,

--- a/src/d/actor/d_a_npc_ykm.cpp
+++ b/src/d/actor/d_a_npc_ykm.cpp
@@ -1577,8 +1577,8 @@ void daNpc_ykM_c::setCollision() {
 int daNpc_ykM_c::drawDbgInfo() {
 #if DEBUG
     if (mpHIO->m.common.debug_info_ON != 0) {
-        f32 fVar1 = dComIfGp_getAttention()->getDistTable(attention_info.distances[6]).mDistMax;
-        f32 fVar2 = dComIfGp_getAttention()->getDistTable(attention_info.distances[1]).mDistMax;
+        f32 fVar1 = dComIfGp_getAttention()->getDistTable(attention_info.distances[fopAc_attn_SPEAK_e]).mDistMax;
+        f32 fVar2 = dComIfGp_getAttention()->getDistTable(attention_info.distances[fopAc_attn_TALK_e]).mDistMax;
         dDbVw_drawCircleOpa(attention_info.position, fVar1, (GXColor){0x0, 0xc8, 0x0, 0xff}, 1, 12);
         dDbVw_drawCircleOpa(attention_info.position, fVar2, (GXColor){0xc8, 0x0, 0x0, 0xff}, 1, 12);
         dDbVw_drawSphereXlu(eyePos, 18.0f, (GXColor){0x80, 0x80, 0x80, 0xa0}, 1);

--- a/src/d/actor/d_a_npc_zant.cpp
+++ b/src/d/actor/d_a_npc_zant.cpp
@@ -261,9 +261,9 @@ void daNpc_Zant_c::setParam() {
 
     s16 sVar1 = mpHIO->m.common.talk_distance;
     s16 sVar2 = mpHIO->m.common.talk_angle;
-    attention_info.distances[0] = daNpcT_getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar1, sVar2);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.common.attention_distance, mpHIO->m.common.attention_angle);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar1, sVar2);
 
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
 

--- a/src/d/actor/d_a_npc_zelR.cpp
+++ b/src/d/actor/d_a_npc_zelR.cpp
@@ -371,9 +371,9 @@ void daNpc_ZelR_c::setParam() {
     s16 sVar2 = l_HIO.m.common.talk_angle;
     s16 sVar3 = l_HIO.m.common.attention_distance;
     s16 sVar4 = l_HIO.m.common.attention_angle;
-    attention_info.distances[0] = daNpcT_getDistTableIdx(sVar3, sVar4);
-    attention_info.distances[1] = attention_info.distances[0];
-    attention_info.distances[3] = daNpcT_getDistTableIdx(sVar1, sVar2);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(sVar3, sVar4);
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+    attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(sVar1, sVar2);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
     scale.setall(l_HIO.m.common.scale);
     mCcStts.SetWeight(l_HIO.m.common.weight);

--- a/src/d/actor/d_a_npc_zrc.cpp
+++ b/src/d/actor/d_a_npc_zrc.cpp
@@ -415,7 +415,7 @@ int daNpc_zrC_c::ctrlJointCallBack(J3DJoint* i_joint, int param_1) {
 
 void daNpc_zrC_c::setParam() {
     ActionFn action = mpNextActionFn;
-    u32 attn_flags = 10;
+    u32 attn_flags = fopAc_AttnFlag_TALK_e | fopAc_AttnFlag_SPEAK_e;
     selectAction();
 
     if (!mTwilight && daPy_py_c::checkNowWolf()) {

--- a/src/d/actor/d_a_npc_zrz.cpp
+++ b/src/d/actor/d_a_npc_zrz.cpp
@@ -511,7 +511,7 @@ static void* s_subRock(void* i_proc, void* i_this) {
 
 void daNpc_zrZ_c::setParam() {
     ActionFn action = mpNextActionFn;
-    u32 attn_flags = 10;
+    u32 attn_flags = fopAc_AttnFlag_TALK_e | fopAc_AttnFlag_SPEAK_e;
     selectAction();
 
     if (!mTwilight && daPy_py_c::checkNowWolf()) {

--- a/src/d/actor/d_a_obj_digsnow.cpp
+++ b/src/d/actor/d_a_obj_digsnow.cpp
@@ -27,7 +27,7 @@ int daObjDigSnow_c::Create() {
     fopAcM_SetMtx(this, mpModel->getBaseTRMtx());
     fopAcM_setCullSizeBox2(this, mpModel->getModelData());
 
-    attention_info.distances[0x07] = 31;
+    attention_info.distances[fopAc_attn_ETC_e] = 31;
 
     mode_init_wait();
 

--- a/src/d/actor/d_a_obj_gra2.cpp
+++ b/src/d/actor/d_a_obj_gra2.cpp
@@ -953,9 +953,9 @@ void daObj_GrA_c::setParam() {
     } else if (mMode == 1) {
         if (checkProcess(&daObj_GrA_c::standWaitJump)) {
             attnSttsOn(1, 1);
-            attention_info.distances[0] = getDistTableIdx(6, 6);
-            attention_info.distances[1] = attention_info.distances[0];
-            attention_info.distances[3] = getDistTableIdx(4, 6);
+            attention_info.distances[fopAc_attn_LOCK_e] = getDistTableIdx(6, 6);
+            attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
+            attention_info.distances[fopAc_attn_SPEAK_e] = getDistTableIdx(4, 6);
         } else {
             attention_info.flags = 0;
         }

--- a/src/d/actor/d_a_obj_gra_rock.cpp
+++ b/src/d/actor/d_a_obj_gra_rock.cpp
@@ -37,7 +37,7 @@ void daObjGraRock_c::setAttnPos() {
     mDoMtx_stack_c::ZXYrotS(current.angle.x, current.angle.y, current.angle.z);
     mDoMtx_stack_c::multVec(&cStack_50, &attention_info.position);
     attention_info.position += current.pos;
-    attention_info.distances[0] = daNpcF_getDistTableIdx(8, 5);
+    attention_info.distances[fopAc_attn_LOCK_e] = daNpcF_getDistTableIdx(8, 5);
     attention_info.flags = fopAc_AttnFlag_LOCK_e;
     dAttention_c* attention = dComIfGp_getAttention();
     if (attention->LockonTruth()) {

--- a/src/d/actor/d_a_obj_kago.cpp
+++ b/src/d/actor/d_a_obj_kago.cpp
@@ -191,7 +191,7 @@ int daObj_Kago_c::Execute() {
     scale.set(mpHIO->m.field_0x08 * field_0xb0c, mpHIO->m.field_0x08 * field_0xb0c, mpHIO->m.field_0x08 * field_0xb0c);
     attention_info.flags = 0;
     fopAcM_OffCarryType(this, fopAcM_CARRY_CHICKEN);
-    attention_info.distances[4] = 13;
+    attention_info.distances[fopAc_attn_CARRY_e] = 13;
 
     if (mType == 0) {
         mStts.SetWeight(mpHIO->m.mWeight);

--- a/src/d/actor/d_a_obj_katatsumuri.cpp
+++ b/src/d/actor/d_a_obj_katatsumuri.cpp
@@ -708,7 +708,7 @@ int daObjKAT_c::create() {
             mDraw = true;
         }
 
-        attention_info.distances[4] = 93;
+        attention_info.distances[fopAc_attn_CARRY_e] = 93;
         mSex = (u8)((fopAcM_GetParam(this) & 0x10) >> 4);
         setItemNo(l_kat_itemno[mSex]);
         setSaveBitNo(l_musiya_num[mSex]);

--- a/src/d/actor/d_a_obj_kbacket.cpp
+++ b/src/d/actor/d_a_obj_kbacket.cpp
@@ -156,7 +156,7 @@ int daObj_KBacket_c::Execute() {
 
     attention_info.flags = 0;
 
-    attention_info.distances[4] = 6;
+    attention_info.distances[fopAc_attn_CARRY_e] = 6;
 
     mAcchCir.SetWallR(mpHIO->m.field_0x1c);
     mAcchCir.SetWallH(mpHIO->m.field_0x18);

--- a/src/d/actor/d_a_obj_kshutter.cpp
+++ b/src/d/actor/d_a_obj_kshutter.cpp
@@ -173,7 +173,7 @@ int daObjKshtr_c::Create() {
         field_0x5fc = 0.0f;
         attention_info.position.y += 150.0f;
         eyePos.y += 150.0f;
-        attention_info.flags = 0x20;
+        attention_info.flags = fopAc_AttnFlag_DOOR_e;
 
         if (mIsCheckKey) {
             mAction = 0;

--- a/src/d/actor/d_a_obj_scannon_crs.cpp
+++ b/src/d/actor/d_a_obj_scannon_crs.cpp
@@ -87,8 +87,8 @@ int daSCannonCrs_c::create() {
                               -500.0f, -100.0f, -500.0f,
                               500.0f, 2500.0f, 500.0f);
 
-        attention_info.distances[1] = 54;
-        attention_info.distances[3] = 54;
+        attention_info.distances[fopAc_attn_TALK_e] = 54;
+        attention_info.distances[fopAc_attn_SPEAK_e] = 54;
 
         eventInfo.setArchiveName(l_arcName);
         mEvtIdx = dComIfGp_getEventManager().getEventIdx(this, l_eventName, 0xFF);

--- a/src/d/actor/d_a_obj_sw.cpp
+++ b/src/d/actor/d_a_obj_sw.cpp
@@ -732,7 +732,7 @@ static int daObj_Sw_Create(fopAc_ac_c* a_this) {
 
         OS_REPORT("//////////////OBJ_SW SET 2 !!\n");
         if (i_this->field_0x570 == 8) {
-            a_this->attention_info.distances[2] = 22;
+            a_this->attention_info.distances[fopAc_attn_BATTLE_e] = 22;
             a_this->home.pos.y += -70.0f;
             a_this->current.pos.y = a_this->home.pos.y;
 

--- a/src/d/actor/d_a_obj_ten.cpp
+++ b/src/d/actor/d_a_obj_ten.cpp
@@ -706,7 +706,7 @@ int daObjTEN_c::create() {
         } else {
             mDraw = true;
         }
-        attention_info.distances[4] = 0x5d;
+        attention_info.distances[fopAc_attn_CARRY_e] = 0x5d;
         mSex = (fopAcM_GetParam(this) & 0x10) >> 4;
         setItemNo(l_ten_itemno[mSex]);
         setSaveBitNo(l_musiya_num[mSex]);

--- a/src/d/actor/d_a_obj_wdStick.cpp
+++ b/src/d/actor/d_a_obj_wdStick.cpp
@@ -73,7 +73,7 @@ int daWdStick_c::create() {
         mSph2.SetStts(&mStts);
         fopAcM_OnCarryType(this, fopAcM_CARRY_UNK_30);
         cLib_onBit<u32>(attention_info.flags, fopAc_AttnFlag_CARRY_e);
-        attention_info.distances[4] = 59;
+        attention_info.distances[fopAc_attn_CARRY_e] = 59;
         misCarrying = fopAcM_checkCarryNow(this);
         mode_init_wait();
     }

--- a/src/d/actor/d_a_obj_yel_bag.cpp
+++ b/src/d/actor/d_a_obj_yel_bag.cpp
@@ -152,7 +152,7 @@ int daObj_YBag_c::Execute() {
     int local_8c = fopAcM_checkCarryNow(this) != 0;
     scale.set(mpHIO->m.field_0x08, mpHIO->m.field_0x08, mpHIO->m.field_0x08);
     attention_info.flags = 0;
-    attention_info.distances[4] = 6;
+    attention_info.distances[fopAc_attn_CARRY_e] = 6;
     mAcchCir.SetWallR(mpHIO->m.field_0x1c);
     mAcchCir.SetWallH(mpHIO->m.field_0x18);
     gravity = mpHIO->m.field_0x04;

--- a/src/d/actor/d_a_peru.cpp
+++ b/src/d/actor/d_a_peru.cpp
@@ -341,7 +341,7 @@ int daPeru_c::isDelete() {
 void daPeru_c::reset() {
     initialize();
     attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x4C, mpHIO->m.inner.field_0x4E);
-    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x48, mpHIO->m.inner.field_0x4A);
     attention_info.flags = fopAc_AttnFlag_SPEAK_e | fopAc_AttnFlag_TALK_e;
     scale.setall(mpHIO->m.inner.field_0x08);
@@ -376,7 +376,7 @@ void daPeru_c::setParam() {
         attention_info.flags = 0;
     }
     attention_info.distances[fopAc_attn_LOCK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x4C, mpHIO->m.inner.field_0x4E);
-    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[0];
+    attention_info.distances[fopAc_attn_TALK_e] = attention_info.distances[fopAc_attn_LOCK_e];
     attention_info.distances[fopAc_attn_SPEAK_e] = daNpcT_getDistTableIdx(mpHIO->m.inner.field_0x48, mpHIO->m.inner.field_0x4A);
     scale.setall(mpHIO->m.inner.field_0x08);
     mCcStts.SetWeight(mpHIO->m.inner.field_0x10);

--- a/src/d/actor/d_a_sq.cpp
+++ b/src/d/actor/d_a_sq.cpp
@@ -401,11 +401,13 @@ static int message(sq_class* i_this) {
 
     if (i_this->mMessageState == 2 && i_this->mFlowID != -1 && daPy_py_c::checkNowWolf()) {
         fopAcM_OnStatus(i_this, 0);
-        cLib_onBit<u32>(i_this->attention_info.flags, 0xa);
+        cLib_onBit<u32>(i_this->attention_info.flags,
+                        fopAc_AttnFlag_TALK_e | fopAc_AttnFlag_SPEAK_e);
         i_this->eventInfo.onCondition(1);
     } else {
         fopAcM_OffStatus(i_this, 0);
-        cLib_offBit<u32>(i_this->attention_info.flags, 0xa);
+        cLib_offBit<u32>(i_this->attention_info.flags,
+                         fopAc_AttnFlag_TALK_e | fopAc_AttnFlag_SPEAK_e);
     }
 
     return 0;


### PR DESCRIPTION
This PR fixes a bunch of instances of integer literals being used for attention types/flags instead of the corresponding enum values. This helps a bit with non-GCN versions where the enum values are different. I tried to find as many occurrences of this as I could, although it's likely that there are still some I missed.