### PR TITLE
Fix misspelled dSv_config_language enum values

### DIFF
--- a/include/d/d_save.h
+++ b/include/d/d_save.h
@@ -523,11 +523,11 @@ public:
     void setPointer(bool i_mPointer) { mPointer = i_mPointer; }
 
     enum dSv_config_language {
-        LANGAUGE_ENGLISH,
-        LANGAUGE_GERMAN,
-        LANGAUGE_FRENCH,
-        LANGAUGE_SPANISH,
-        LANGAUGE_ITALIAN,
+        LANGUAGE_ENGLISH,
+        LANGUAGE_GERMAN,
+        LANGUAGE_FRENCH,
+        LANGUAGE_SPANISH,
+        LANGUAGE_ITALIAN,
     };
 
 private:

--- a/src/d/actor/d_a_mg_fish.cpp
+++ b/src/d/actor/d_a_mg_fish.cpp
@@ -3232,7 +3232,7 @@ static int daMg_Fish_Execute(mg_fish_class* i_this) {
 #if VERSION == VERSION_GCN_JPN
     lit_1008 = 0;
 #elif VERSION == VERSION_GCN_PAL
-    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ENGLISH) {
+    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ENGLISH) {
         lit_1008 = 2;
     } else {
         lit_1008 = 0;
@@ -3845,7 +3845,7 @@ static int daMg_Fish_Create(fopAc_ac_c* i_this) {
 #if VERSION == VERSION_GCN_JPN
     lit_1008 = 0;
 #elif VERSION == VERSION_GCN_PAL
-    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ENGLISH) {
+    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ENGLISH) {
         lit_1008 = 2;
     } else {
         lit_1008 = 0;

--- a/src/d/actor/d_a_mg_fshop.cpp
+++ b/src/d/actor/d_a_mg_fshop.cpp
@@ -1614,13 +1614,13 @@ static int daFshop_Create(fopAc_ac_c* actor) {
 
         u8 sp10 = 1;
         #if VERSION == VERSION_GCN_PAL || VERSION == VERSION_WII_PAL
-        if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ENGLISH) {
+        if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ENGLISH) {
             sp10 = 2;
         } else {
             sp10 = 0;
         }
         #elif PLATFORM_SHIELD
-        if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+        if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
             sp10 = 2;
         } else {
             sp10 = 0;

--- a/src/d/d_error_msg.cpp
+++ b/src/d/d_error_msg.cpp
@@ -53,13 +53,13 @@ static void messageSet(u32 status, bool i_drawBg) {
     const char* msg_p;
 
     #if VERSION == VERSION_GCN_PAL
-    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
         inf1 = (BMG_INF1*)&msg_data_ge[0x20];
-    } else if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_FRENCH) {
+    } else if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_FRENCH) {
         inf1 = (BMG_INF1*)&msg_data_fr[0x20];
-    } else if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_SPANISH) {
+    } else if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_SPANISH) {
         inf1 = (BMG_INF1*)&msg_data_sp[0x20];
-    } else if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ITALIAN) {
+    } else if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ITALIAN) {
         inf1 = (BMG_INF1*)&msg_data_it[0x20];
     } else {
         inf1 = (BMG_INF1*)&msg_data[0x20];
@@ -165,7 +165,7 @@ static void messageSet(u32 status, bool i_drawBg) {
     }
 
     #if VERSION == VERSION_GCN_PAL
-    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ENGLISH) {
+    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ENGLISH) {
         spane.draw(x + 2.0f, y + 10.0f + 2.0f, FB_WIDTH, HBIND_LEFT);
         tpane.draw(x, y + 10.0f, FB_WIDTH, HBIND_LEFT);
     } else {

--- a/src/d/d_file_sel_info.cpp
+++ b/src/d/d_file_sel_info.cpp
@@ -170,7 +170,7 @@ void dFile_info_c::setSaveDate(dSv_save_c* i_savedata) {
     sprintf(mSaveDate, "%d.%02d.%02d %02d:%02d", time.year, time.mon + 1, time.mday,
             time.hour, time.min);
     #elif VERSION == VERSION_GCN_PAL
-    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ENGLISH) {
+    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ENGLISH) {
         sprintf(mSaveDate, "%02d/%02d/%d %02d:%02d", time.mon + 1, time.mday, time.year, time.hour,
                 time.min);
     } else {

--- a/src/d/d_menu_fishing.cpp
+++ b/src/d/d_menu_fishing.cpp
@@ -129,7 +129,7 @@ bool dMenu_Fishing_c::isSync() {
 void dMenu_Fishing_c::init() {
     #if VERSION == VERSION_GCN_PAL
     BOOL isEnglish = FALSE;
-    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_ENGLISH) {
+    if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_ENGLISH) {
         isEnglish = TRUE;
     }
     #endif

--- a/src/d/d_msg_class.cpp
+++ b/src/d/d_msg_class.cpp
@@ -1481,7 +1481,7 @@ bool jmessage_tMeasureProcessor::do_tag(u32 i_tag, void const* i_data, u32 i_siz
         switch (i_tag & 0xFF00FFFF) {
         case MSGTAG_PLAYER_GENITIV:
             #if VERSION == VERSION_GCN_PAL
-            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
                 setPlayerName(buffer, 1);
             } else {
                 setPlayerName(buffer, 0);
@@ -1491,7 +1491,7 @@ bool jmessage_tMeasureProcessor::do_tag(u32 i_tag, void const* i_data, u32 i_siz
             return true;
         case MSGTAG_HORSE_GENITIV:
             #if VERSION == VERSION_GCN_PAL
-            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
                 setHorseName(buffer, 1);
             } else {
                 setHorseName(buffer, 0);
@@ -4242,7 +4242,7 @@ bool jmessage_string_tMeasureProcessor::do_tag(u32 i_tag, void const* i_data, u3
         switch (i_tag & 0xFF00FFFF) {
         case MSGTAG_PLAYER_GENITIV:
             #if VERSION == VERSION_GCN_PAL
-            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
                 setPlayerName(buffer, 1);
             } else {
                 setPlayerName(buffer, 0);
@@ -4253,7 +4253,7 @@ bool jmessage_string_tMeasureProcessor::do_tag(u32 i_tag, void const* i_data, u3
             break;
         case MSGTAG_HORSE_GENITIV:
             #if VERSION == VERSION_GCN_PAL
-            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
                 setHorseName(buffer, 1);
             } else {
                 setHorseName(buffer, 0);
@@ -4850,7 +4850,7 @@ bool jmessage_string_tRenderingProcessor::do_tag(u32 i_tag, void const* i_data, 
         switch (i_tag & 0xFF00FFFF) {
         case MSGTAG_PLAYER_GENITIV:
             #if VERSION == VERSION_GCN_PAL
-            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
                 setPlayerName(buffer, 1);
             } else {
                 setPlayerName(buffer, 0);
@@ -4861,7 +4861,7 @@ bool jmessage_string_tRenderingProcessor::do_tag(u32 i_tag, void const* i_data, 
             break;
         case MSGTAG_HORSE_GENITIV:
             #if VERSION == VERSION_GCN_PAL
-            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_GERMAN) {
+            if (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_GERMAN) {
                 setHorseName(buffer, 1);
             } else {
                 setHorseName(buffer, 0);

--- a/src/d/d_msg_object.cpp
+++ b/src/d/d_msg_object.cpp
@@ -1606,16 +1606,16 @@ void dMsgObject_c::readMessageGroupLocal(mDoDvdThd_mountXArchive_c** p_arcMount)
     int msgGroup = dStage_stagInfo_GetMsgGroup(dComIfGp_getStage()->getStagInfo());
     #if REGION_PAL
     switch (dComIfGs_getPalLanguage()) {
-    case dSv_player_config_c::LANGAUGE_GERMAN:
+    case dSv_player_config_c::LANGUAGE_GERMAN:
         sprintf(arcName, "/res/Msgde/bmgres%d.arc", msgGroup);
         break;
-    case dSv_player_config_c::LANGAUGE_FRENCH:
+    case dSv_player_config_c::LANGUAGE_FRENCH:
         sprintf(arcName, "/res/Msgfr/bmgres%d.arc", msgGroup);
         break;
-    case dSv_player_config_c::LANGAUGE_SPANISH:
+    case dSv_player_config_c::LANGUAGE_SPANISH:
         sprintf(arcName, "/res/Msgsp/bmgres%d.arc", msgGroup);
         break;
-    case dSv_player_config_c::LANGAUGE_ITALIAN:
+    case dSv_player_config_c::LANGUAGE_ITALIAN:
         sprintf(arcName, "/res/Msgit/bmgres%d.arc", msgGroup);
         break;
     default:

--- a/src/d/d_msg_unit.cpp
+++ b/src/d/d_msg_unit.cpp
@@ -310,11 +310,11 @@ void dMsgUnit_c::setTag(int i_type, int i_value, char* o_buffer, bool param_4) {
 
 #if REGION_PAL
             if (i_value == 1 ||
-                (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_FRENCH &&
+                (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_FRENCH &&
                     i_value == 0)) {
 #elif !REGION_USA
             if (i_value == 1 ||
-                (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGAUGE_SPANISH &&
+                (dComIfGs_getPalLanguage() == dSv_player_config_c::LANGUAGE_SPANISH &&
                     i_value == 0)) {
 #else
             if (i_value == 1) {

--- a/src/d/d_save.cpp
+++ b/src/d/d_save.cpp
@@ -1035,15 +1035,15 @@ u8 dSv_player_config_c::getPalLanguage() const {
 #if VERSION == VERSION_GCN_PAL
     switch (OSGetLanguage()) {
     case 0:
-        return LANGAUGE_ENGLISH;
+        return LANGUAGE_ENGLISH;
     case 1:
-        return LANGAUGE_GERMAN;
+        return LANGUAGE_GERMAN;
     case 2:
-        return LANGAUGE_FRENCH;
+        return LANGUAGE_FRENCH;
     case 3:
-        return LANGAUGE_SPANISH;
+        return LANGUAGE_SPANISH;
     case 4:
-        return LANGAUGE_ITALIAN;
+        return LANGUAGE_ITALIAN;
     }
 #elif VERSION >= VERSION_WII_USA_R0
     switch (SCGetLanguage()) {

--- a/src/m_Do/m_Do_MemCardRWmng.cpp
+++ b/src/m_Do/m_Do_MemCardRWmng.cpp
@@ -319,19 +319,19 @@ static void mDoMemCdRWm_BuildHeader(mDoMemCdRWm_HeaderData* header) {
 
 #if VERSION == VERSION_GCN_PAL
     switch (dComIfGs_getPalLanguage()) {
-    case dSv_player_config_c::LANGAUGE_ENGLISH:
+    case dSv_player_config_c::LANGUAGE_ENGLISH:
         snprintf(header->mComment, sizeof(header->mComment), "%d/%d Save Data", time.mon + 1, time.mday);
         break;
-    case dSv_player_config_c::LANGAUGE_GERMAN:
+    case dSv_player_config_c::LANGUAGE_GERMAN:
         snprintf(header->mComment, sizeof(header->mComment), "%d/%d Spielstand", time.mday, time.mon + 1);
         break;
-    case dSv_player_config_c::LANGAUGE_FRENCH:
+    case dSv_player_config_c::LANGUAGE_FRENCH:
         snprintf(header->mComment, sizeof(header->mComment), "Donn%ces de jeu %d/%d", 0xE9, time.mday, time.mon + 1);
         break;
-    case dSv_player_config_c::LANGAUGE_SPANISH:
+    case dSv_player_config_c::LANGUAGE_SPANISH:
         snprintf(header->mComment, sizeof(header->mComment), "Datos guardados el %d/%d", time.mday, time.mon + 1);
         break;
-    case dSv_player_config_c::LANGAUGE_ITALIAN:
+    case dSv_player_config_c::LANGUAGE_ITALIAN:
         snprintf(header->mComment, sizeof(header->mComment), "Dati salvati: %d/%d", time.mday, time.mon + 1);
         break;
     }


### PR DESCRIPTION
This fixes the enum names in `dSv_config_language` being typoed (`LANGAUGE`). As far as I can tell this isn't backed up by any assert messages so I think we introduced it by mistake.