### PR TITLE
Name mSideStepLandComboTimer

### DIFF
--- a/include/d/actor/d_a_alink.h
+++ b/include/d/actor/d_a_alink.h
@@ -4158,7 +4158,7 @@ public:
     /* 0x02FAD */ u8 mPeepExitID;
     /* 0x02FAE */ u8 mUseButtonFlags;
     /* 0x02FAF */ u8 field_0x2faf;
-    /* 0x02FB0 */ u8 field_0x2fb0;
+    /* 0x02FB0 */ u8 mSideStepLandComboTimer;
     /* 0x02FB1 */ u8 mWolfLockNum;
     /* 0x02FB2 */ u8 mMidnaTalkDelayTimer;
     /* 0x02FB3 */ u8 field_0x2fb3;

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -11836,7 +11836,7 @@ BOOL daAlink_c::checkMoveDoAction() {
             }
 
             int direction = getDirectionFromShapeAngle();
-            if (field_0x2fb0 != 0 && direction != DIR_BACKWARD && checkSideRollAction(direction)) {
+            if (mSideStepLandComboTimer != 0 && direction != DIR_BACKWARD && checkSideRollAction(direction)) {
                 return true;
             }
 
@@ -15827,7 +15827,7 @@ int daAlink_c::procSideStepLandInit() {
         field_0x3478 = mpHIO->mSideStep.m.mBackLandAnm.mCancelFrame;
         field_0x2f98 = 2;
         mProcVar1.field_0x300a = 0;
-        field_0x2fb0 = 0;
+        mSideStepLandComboTimer = 0;
         field_0x2fcc = 10;
     } else {
         daAlink_ANM anm_id;
@@ -15843,7 +15843,7 @@ int daAlink_c::procSideStepLandInit() {
         setSingleAnimeParam(anm_id, &mpHIO->mSideStep.m.mSideLandAnm);
         field_0x3478 = mpHIO->mSideStep.m.mSideLandAnm.mCancelFrame;
         mProcVar1.field_0x300a = 1;
-        field_0x2fb0 = 8;
+        mSideStepLandComboTimer = 8;
         field_0x2fcc = 0;
 
         if (checkEnemyGroup(mTargetedActor) && mEquipItem == 0x103 && checkNoUpperAnime()) {
@@ -18384,8 +18384,8 @@ int daAlink_c::execute() {
             if (!checkWolf()) {
                 setHatAngle();
 
-                if (field_0x2fb0 != 0) {
-                    field_0x2fb0--;
+                if (mSideStepLandComboTimer != 0) {
+                    mSideStepLandComboTimer--;
                 }
 
                 footBgCheck();

--- a/src/d/actor/d_a_alink_wolf.inc
+++ b/src/d/actor/d_a_alink_wolf.inc
@@ -490,7 +490,7 @@ void daAlink_c::changeLink(int param_0) {
         resetWolfAtCollision();
         resetWolfBallGrab();
         deleteEquipItem(FALSE, FALSE);
-        field_0x2fb0 = 0;
+        mSideStepLandComboTimer = 0;
 
         for (int i = 0; i < 10; i++) {
             mWolfLockAcKeep[i].clearData();


### PR DESCRIPTION
This is the field used to count the frames to convert a second jump press into a side roll combo

Found this when making https://github.com/TwilitRealm/dusklight/pull/1512 to ensure jump prompts worked as part of the roll override and figured it needed a better name than the (I assume) auto-gen'd decomp value. Let me know if it needs any work